### PR TITLE
add geothermal as baseload

### DIFF
--- a/web/src/helpers/constants.js
+++ b/web/src/helpers/constants.js
@@ -17,12 +17,12 @@ const modeColor = {
 const modeOrder = [
   'nuclear',
   'coal',
+  'geothermal',
   'wind',
   'solar',
   'hydro',
   'hydro storage',
   'battery storage',
-  'geothermal',
   'biomass',
   'gas',
   'oil',


### PR DESCRIPTION
This mirrors de4064461615cfe as was done for nuclear and coal.

Geothermal is almost always used as baseload not varying its output greatly. The specific use case that can be seen is improving the intuitiveness of NZ-NZN origin of electricity chart.

Discussion item:

It looks like changing the order of the "origin of electricity" chart also changes the order of the bar-charts mode list. Thus this change might crowd the top of the sidebar for a value that's 0 for vast majority of regions, and pushing wind/solar/hydro down. Is it worth it?

![screenshot - 300718 - 20 25 13](https://user-images.githubusercontent.com/47415/43415792-ce0c8dba-9436-11e8-8dc5-8823e431d012.png)