### PR TITLE
Add missing zone names for India

### DIFF
--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -606,6 +606,10 @@
             "countryName": "Indien",
             "zoneName": "Delhi"
         },
+        "IN-DN": {
+            "countryName": "Indien",
+            "zoneName": "Dadra und Nagar Haveli"
+        },
         "IN-GA": {
             "countryName": "Indien",
             "zoneName": "Goa"
@@ -682,7 +686,7 @@
             "countryName": "Indien",
             "zoneName": "Sikkim"
         },
-        "IN-TL": {
+        "IN-TN": {
             "countryName": "Indien",
             "zoneName": "Tamil Nadu"
         },

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -610,6 +610,10 @@
             "countryName": "India",
             "zoneName": "Delhi"
           },
+          "IN-DN": {
+            "countryName": "India",
+            "zoneName": "Dadra and Nagar Haveli"
+          },
           "IN-GA": {
             "countryName": "India",
             "zoneName": "Goa"
@@ -686,7 +690,7 @@
             "countryName": "India",
             "zoneName": "Sikkim"
           },
-          "IN-TL": {
+          "IN-TN": {
             "countryName": "India",
             "zoneName": "Tamil Nadu"
           },


### PR DESCRIPTION
The state of Tamil-Nadu was abbreviated as IN-TL in en.json, but on the map it is IN-TN.
Dadra and Nagar Haveli (IN-DN) is the small state between Gujarat and Maharashtra and was missing in en.json.