### PR TITLE
Update German numbers of netto installation

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -886,17 +886,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 9501,
-      "coal": 46336,
-      "gas": 29731,
+      "biomass": 7400,
+      "coal": 46250,
+      "gas": 29550,
       "geothermal": 39,
       "hydro": 5490,
       "hydro storage": 9440,
       "nuclear": 9516,
       "oil": 4437,
-      "solar": 40716,
+      "solar": 44320,
       "unknown": 3137,
-      "wind": 49592
+      "wind": 58190
     },
     "contributors": [
       "https://github.com/corradio"


### PR DESCRIPTION
Updated the numbers of netto installed electricity in Germany.
My source came from "Frauenhofer ISE" the  data is from July 2018

Source link: https://www.energy-charts.de/power_inst.htm?year=2018&period=annual&type=power_inst