### PR TITLE
Add price parsers to JP zones

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1966,10 +1966,12 @@
   },
   "JP-CB": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -1985,10 +1987,12 @@
   },
   "JP-CG": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2004,10 +2008,12 @@
   },
   "JP-HKD": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2023,10 +2029,12 @@
   },
   "JP-HR": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2042,10 +2050,12 @@
   },
   "JP-KN": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2061,10 +2071,12 @@
   },
   "JP-KY": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP-KY.fetch_production"
+      "production": "JP-KY.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2080,10 +2092,12 @@
   },
   "JP-SK": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2099,10 +2113,12 @@
   },
   "JP-TH": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [
@@ -2118,10 +2134,12 @@
   },
   "JP-TK": {
     "contributors": [
-      "https://github.com/tmslaine"
+      "https://github.com/tmslaine",
+      "https://github.com/lorrieq"
     ],
     "parsers": {
-      "production": "JP.fetch_production"
+      "production": "JP.fetch_production",
+      "price": "JP.fetch_price"
     },
     "timezone": "Asia/Tokyo",
     "bounding_box": [


### PR DESCRIPTION
Forgot to include this in PR #1577 so that the price parsers actually run! Might be worth including some sort of checklist in the `example.py` file or in the `README` file like write parser, update `config` files, update `README` sources if necessary, create PR with sample output etc etc. Or not and it's just me with this problem of forgetting things ;-)

Oh, anybody else noticed that Japan now appears as one big zone rather than broken up into it's 10 zones and know why that's happening? (Chubu, Chugoku etc..)