### PR TITLE
Validate GB-NIR total load

### DIFF
--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -277,7 +277,7 @@ def fetch_production(zone_key='GB-NIR', session=None, target_datetime=None,
             'source': 'soni.ltd.uk'
         }
         production_mix_by_quarter_hour.append(
-            validate(production_mix, logger=logger, required=['gas', 'coal']))
+            validate(production_mix, logger=logger, required=['gas', 'coal'], floor=1.0))
 
     return production_mix_by_quarter_hour
 


### PR DESCRIPTION
This will stop all zero generation being accepted into the database. @corradio if you have a better idea of the average minimum (less some for error) let me know and I'll alter the floor.

fixes #1507 