### PR TITLE
Disable SSL verification for NA

### DIFF
--- a/parsers/NA.py
+++ b/parsers/NA.py
@@ -37,7 +37,7 @@ def get_text_from_image(link, expected_size, new_size, logger, session=None):
     """
 
     s = session or requests.Session()
-    img = Image.open(s.get(link, stream=True).raw)
+    img = Image.open(s.get(link, stream=True, verify=False).raw)
 
     if img.size != expected_size:
         logger.warning("Check Namibia Scada dashboard for {} changes.".format(link),


### PR DESCRIPTION
Not great practice but this gets Namibia working again.

```shell
(EM-env) chris@ThinkPad:~/electricitymap$ python -m parsers.NA
fetch_production() ->
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'storage': {}, 'source': 'nampower.com.na', 'datetime': datetime.datetime(2018, 9, 18, 11, 26, 59, 923282, tzinfo=tzfile('/usr/share/zoneinfo/Africa/Windhoek')), 'zoneKey': 'NA', 'production': {'solar': 34.04, 'coal': 12.08, 'oil': 0.0, 'hydro': 90.05, 'wind': 0.54}}
fetch_exchange(NA, ZA)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'sortedZoneKeys': 'NA->ZA', 'datetime': datetime.datetime(2018, 9, 18, 11, 27, 4, 126393, tzinfo=tzfile('/usr/share/zoneinfo/Africa/Windhoek')), 'source': 'nampower.com.na', 'netFlow': -312.67}
fetch_exchange(NA, ZM)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'sortedZoneKeys': 'NA->ZM', 'datetime': datetime.datetime(2018, 9, 18, 11, 27, 7, 834397, tzinfo=tzfile('/usr/share/zoneinfo/Africa/Windhoek')), 'source': 'nampower.com.na', 'netFlow': -7.95}
```

ref #1593 