### PR TITLE
Disable SSL verification for MX

### DIFF
--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -30,7 +30,7 @@ def fetch_MX_exchange(sorted_zone_keys, s):
     Returns a float.
     """
 
-    req = s.get(MX_EXCHANGE_URL)
+    req = s.get(MX_EXCHANGE_URL, verify=False)
     soup = BeautifulSoup(req.text, 'html.parser')
     exchange_div = soup.find("div", attrs={'id': EXCHANGES[sorted_zone_keys]})
     val = exchange_div.text


### PR DESCRIPTION
Same problem as NA, it's been broken for at least a month.

ref #1242 

```shell
(EM-env) chris@ThinkPad:~/electricitymap$ python parsers/MX.py 
fetch_exchange(MX-NO, MX-NW)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 34, 742394, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 229.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NO->MX-NW'}
fetch_exchange(MX-OR, MX-PN)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 35, 964037, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 857.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-OR->MX-PN'}
fetch_exchange(MX-NE, MX-OC)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 37, 163823, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 2748.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NE->MX-OC'}
fetch_exchange(MX-NE, MX-NO)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 38, 354295, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 163.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NE->MX-NO'}
fetch_exchange(MX-OC, MX-OR)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 39, 576793, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 88.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-OC->MX-OR'}
fetch_exchange(MX-NE, US)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 40, 789628, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -109.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NE->US'}
fetch_exchange(MX-CE, MX-OC)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 41, 979423, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -893.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-CE->MX-OC'}
fetch_exchange(MX-PN, BZ)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 43, 171101, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -48.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'BZ->MX-PN'}
fetch_exchange(MX-NO, MX-OC)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 44, 372321, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 91.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NO->MX-OC'}
fetch_exchange(MX-NO, US)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 45, 562203, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 0.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NO->US'}
fetch_exchange(MX-NE, MX-OR)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 46, 753237, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 771.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-NE->MX-OR'}
fetch_exchange(MX-CE, MX-OR)
/home/chris/EM-env/lib/python3.5/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
{'datetime': datetime.datetime(2018, 9, 18, 3, 7, 47, 981872, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -1552.0, 'source': 'cenace.gob.mx', 'sortedZoneKeys': 'MX-CE->MX-OR'}
```