### PR TITLE
`test_parser.py`: better wrong parser output handling

### DIFF
--- a/test_parser.py
+++ b/test_parser.py
@@ -62,7 +62,7 @@ def test_parser(zone, data_type, target_datetime):
         dts = [e['datetime'] for e in res_list]
     except:
         print('Parser output lacks `datetime` key for at least some of the '
-              f'ouput. Full ouput: \n\n{res}\n')
+              'ouput. Full ouput: \n\n{}\n'.format(res))
         return
 
     last_dt = arrow.get(max(dts)).to('UTC')

--- a/test_parser.py
+++ b/test_parser.py
@@ -47,17 +47,24 @@ def test_parser(zone, data_type, target_datetime):
     else:
         args = [zone]
     res = parser(*args, target_datetime=target_datetime)
+
+    if not res:
+        print(f'Error: parser returned nothing ({res})')
+        return
+
     elapsed_time = time.time() - start
     if isinstance(res, (list, tuple)):
         res_list = iter(res)
     else:
         res_list = [res]
+
     try:
         dts = [e['datetime'] for e in res_list]
     except:
         print('Parser output lacks `datetime` key for at least some of the '
               f'ouput. Full ouput: \n\n{res}\n')
         return
+
     last_dt = arrow.get(max(dts)).to('UTC')
     max_dt_warning = (
         ' :( >2h from now !!!'
@@ -70,7 +77,6 @@ def test_parser(zone, data_type, target_datetime):
                      'min returned datetime: {}'.format(min(dts)),
                      'max returned datetime: {} UTC {}'.format(
                          last_dt, max_dt_warning), ]))
-
 
 
 if __name__ == '__main__':

--- a/test_parser.py
+++ b/test_parser.py
@@ -52,7 +52,12 @@ def test_parser(zone, data_type, target_datetime):
         res_list = iter(res)
     else:
         res_list = [res]
-    dts = [e['datetime'] for e in res_list]
+    try:
+        dts = [e['datetime'] for e in res_list]
+    except:
+        print('Parser output lacks `datetime` key for at least some of the '
+              f'ouput. Full ouput: \n\n{res}\n')
+        return
     last_dt = arrow.get(max(dts)).to('UTC')
     max_dt_warning = (
         ' :( >2h from now !!!'

--- a/test_parser.py
+++ b/test_parser.py
@@ -49,7 +49,7 @@ def test_parser(zone, data_type, target_datetime):
     res = parser(*args, target_datetime=target_datetime)
 
     if not res:
-        print(f'Error: parser returned nothing ({res})')
+        print('Error: parser returned nothing ({})'.format(res))
         return
 
     elapsed_time = time.time() - start


### PR DESCRIPTION
before this, `python test_parser.py` lead to a difficult to understand output.