### PR TITLE
Using NODE_ENV in all possible places

### DIFF
--- a/web/src/services/dataservice.js
+++ b/web/src/services/dataservice.js
@@ -11,19 +11,14 @@ var moment = require('moment');
 
 // API
 function protectedJsonRequest(endpoint, path, callback) {
-  let t = new Date().getTime();
-  let md = forge.md.sha256.create();
-  let s
-  if (endpoint.indexOf('localhost') != -1) {
-    s = md.update('development' + path + t).digest().toHex();
-  }
-  else {
-    s = md.update(ELECTRICITYMAP_PUBLIC_TOKEN + path + t).digest().toHex();
-  }
-  let req = d3.json(endpoint + path)
+  const now = new Date().getTime();
+  const md = forge.md.sha256.create();
+  const signature = md.update(ELECTRICITYMAP_PUBLIC_TOKEN + path + now).digest().toHex();
+  const req = d3.json(endpoint + path)
     .header('electricitymap-token', Cookies.get('electricitymap-token'))
-    .header('x-request-timestamp', t)
-    .header('x-signature', s)
+    .header('x-request-timestamp', now)
+    .header('x-signature', signature)
+
   return req.get(null, callback);
 }
 

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -1,20 +1,21 @@
-const redux = require('redux');
-const reduxLogger = require('redux-logger').logger;
-const reducer = require('./reducers');
+import { compose, createStore, applyMiddleware } from 'redux';
+import { logger } from 'redux-logger';
+import reducer from './reducers';
 
-const isProduction = window.location.href.indexOf('electricitymap') !== -1;
 
-const store = isProduction ?
-  redux.createStore(
-    reducer,
+const middlewares = [];
+
+if (process.env.NODE_ENV === 'development') {
+  middlewares.push(logger);
+}
+
+const store = createStore(
+  reducer,
+  compose(
+    applyMiddleware(...middlewares),
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
   )
-  :
-  redux.createStore(
-    reducer,
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
-    redux.applyMiddleware(reduxLogger),
-  );
+);
 
 // Utility to react to store changes
 const observe = (select, onChange) => {

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -1,12 +1,11 @@
 import { compose, createStore, applyMiddleware } from 'redux';
-import { logger } from 'redux-logger';
 import reducer from './reducers';
 
 
 const middlewares = [];
 
 if (process.env.NODE_ENV === 'development') {
-  middlewares.push(logger);
+  middlewares.push(require('redux-logger').logger);
 }
 
 const store = createStore(


### PR DESCRIPTION
- Remove client environment dependency on url in browser
- Same environment for client and server
- Using injected by webpack `ELECTRICITYMAP_PUBLIC_TOKEN` instead of hardcoded for `development` env
- const instead of let's for identifiers which won't be reassigned