### PR TITLE
quality: derivative filter

### DIFF
--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -10,6 +10,8 @@ import pandas as pd
 import requests
 import xml.etree.ElementTree as ET
 
+from contrib.parsers.lib.validation import validate_diffs
+
 API_ENDPOINT = 'https://opendata.reseaux-energies.fr/api/records/1.0/search/'
 
 MAP_GENERATION = {
@@ -100,6 +102,16 @@ def fetch_production(zone_key='FR', session=None, target_datetime=None,
             'storage': storage,
             'source': 'opendata.reseaux-energies.fr'
         })
+
+    max_diffs = {
+        'hydro': 1600,
+        'solar': 500,
+        'coal': 500,
+        'wind': 1000,
+        'nuclear': 1300,
+    }
+
+    datapoints = validate_diffs(datapoints, max_diffs, logger)
 
     return datapoints
 

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 import xml.etree.ElementTree as ET
 
-from contrib.parsers.lib.validation import validate_production_diffs
+from .lib.validation import validate_production_diffs
 
 API_ENDPOINT = 'https://opendata.reseaux-energies.fr/api/records/1.0/search/'
 

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 import xml.etree.ElementTree as ET
 
-from contrib.parsers.lib.validation import validate_diffs
+from contrib.parsers.lib.validation import validate_production_diffs
 
 API_ENDPOINT = 'https://opendata.reseaux-energies.fr/api/records/1.0/search/'
 
@@ -111,7 +111,7 @@ def fetch_production(zone_key='FR', session=None, target_datetime=None,
         'nuclear': 1300,
     }
 
-    datapoints = validate_diffs(datapoints, max_diffs, logger)
+    datapoints = validate_production_diffs(datapoints, max_diffs, logger)
 
     return datapoints
 

--- a/parsers/lib/utils.py
+++ b/parsers/lib/utils.py
@@ -1,5 +1,6 @@
 import math
 
+
 def sum_production_dicts(prod1: dict, prod2: dict()):
     """
     Sum two productions dictionnaries. For a production mode key, if both

--- a/parsers/lib/utils.py
+++ b/parsers/lib/utils.py
@@ -10,3 +10,9 @@ def sum_production_dicts(prod1: dict, prod2: dict()):
             continue
         to_return[prod_name] = (value1 or 0) + (value2 or 0)
     return to_return
+
+
+def nan_to_zero(v):
+    if math.isnan(v):
+        return 0
+    return v

--- a/parsers/lib/utils.py
+++ b/parsers/lib/utils.py
@@ -1,3 +1,5 @@
+import math
+
 def sum_production_dicts(prod1: dict, prod2: dict()):
     """
     Sum two productions dictionnaries. For a production mode key, if both

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -53,8 +53,7 @@ def validate_production_diffs(
     for energy, max_diff in max_diff.items():
         if 'energy' == 'total':
             series = pd.Series(
-                [sum([nan_to_zero(v)
-                     for en, v in datapoint['production'].items()])
+                [np.nansum([v for v in datapoint['production'].values()])
                  for datapoint in datapoints])
         else:
             series = pd.Series(

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -70,8 +70,8 @@ def validate_production_diffs(
                 (datapoints[i]['datetime'], datapoints[i]['production'][energy])
                 for i in wrongs_ixs_and_previous if i > 0]
             logger.warning(
-                f'some datapoints have a too high production value difference '
-                f'for {energy}: {to_display}')
+                'some datapoints have a too high production value difference '
+                'for {}: {}'.format(energy, to_display))
         ok_diff &= new_diffs
     # first datapoint is always OK
     ok_diff.iloc[0] = True

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -52,7 +52,8 @@ def validate_diffs(datapoints: list, max_diff: dict, logger: logging.Logger):
         series = pd.Series(
             [datapoint['production'].get(energy, np.nan)
              for datapoint in datapoints])
-        new_diffs = np.abs(series.diff()) < max_diff
+        # nan is always allowed (can be disallowed using `validate` function)
+        new_diffs = (np.abs(series.diff()) < max_diff) | series.isna()
         if not new_diffs[1:].all():
             wrongs_ixs = new_diffs[~new_diffs].index
             wrongs_ixs_and_previous = sorted(

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -3,6 +3,10 @@
 """Centralised validation function for all parsers."""
 
 from logging import getLogger
+import logging
+
+import numpy as np
+import pandas as pd
 
 
 def has_value_for_key(datapoint, key, logger):
@@ -25,6 +29,45 @@ def check_expected_range(datapoint, value, expected_range, logger, key=None):
                        extra={'key': datapoint['zoneKey']})
         return
     return True
+
+
+def validate_diffs(datapoints: list, max_diff: dict, logger: logging.Logger):
+    """
+
+    Parameters
+    ----------
+    datapoints: a list of datapoints having a 'production' field
+    max_diff: dict representing the max allowed diff per energy type
+    logger
+
+    Returns
+    -------
+    the same list of datapoints, with the ones having a too big diff removed
+    """
+    # sort datapoins by datetime
+    datapoints = sorted(datapoints, key=lambda x: x['datetime'])
+
+    ok_diff = np.ones_like(datapoints, dtype=bool)
+    for energy, max_diff in max_diff.items():
+        series = pd.Series(
+            [datapoint['production'].get(energy, np.nan)
+             for datapoint in datapoints])
+        new_diffs = np.abs(series.diff()) < max_diff
+        if not new_diffs[1:].all():
+            wrongs_ixs = new_diffs[~new_diffs].index
+            wrongs_ixs_and_previous = sorted(
+                {ix - 1 for ix in wrongs_ixs} | set(wrongs_ixs))
+            to_display = [
+                (datapoints[i]['datetime'], datapoints[i]['production'][energy])
+                for i in wrongs_ixs_and_previous if i > 0]
+            logger.warning(
+                f'some datapoints have a too high diff for {energy}: '
+                f'{to_display}')
+        ok_diff &= new_diffs
+    # first datapoint is always OK
+    ok_diff.iloc[0] = True
+
+    return [datapoints[i] for i in ok_diff[ok_diff].index]
 
 
 def validate(datapoint, logger=getLogger(__name__), **kwargs):

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -31,7 +31,7 @@ def check_expected_range(datapoint, value, expected_range, logger, key=None):
     return True
 
 
-def validate_diffs(datapoints: list, max_diff: dict, logger: logging.Logger):
+def validate_production_diffs(datapoints: list, max_diff: dict, logger: logging.Logger):
     """
 
     Parameters
@@ -62,8 +62,8 @@ def validate_diffs(datapoints: list, max_diff: dict, logger: logging.Logger):
                 (datapoints[i]['datetime'], datapoints[i]['production'][energy])
                 for i in wrongs_ixs_and_previous if i > 0]
             logger.warning(
-                f'some datapoints have a too high diff for {energy}: '
-                f'{to_display}')
+                f'some datapoints have a too high production value difference '
+                f'for {energy}: {to_display}')
         ok_diff &= new_diffs
     # first datapoint is always OK
     ok_diff.iloc[0] = True

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -49,7 +49,7 @@ def validate_production_diffs(
     # sort datapoins by datetime
     datapoints = sorted(datapoints, key=lambda x: x['datetime'])
 
-    ok_diff = np.ones_like(datapoints, dtype=bool)
+    ok_diff = pd.Series(np.ones_like(datapoints, dtype=bool))
     for energy, max_diff in max_diff.items():
         if 'energy' == 'total':
             series = pd.Series(


### PR DESCRIPTION
Introducing a simple quality filter that checks that the difference between consecutive production values for a specific energy is not too big. Warns about and removes datapoints that are too different from the previous one.

It solves the problem of some production being wrong for a single datapoint, but it will remove the wrong datapoint AND the next one. Shoud we compare to rolling median instead of only previous point?