### PR TITLE
mandatory logger in validate function

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -240,8 +240,7 @@ def fetch_production(zone_key='GB', session=None, target_datetime=None,
     }
     data = [x for x in data
             if validate(
-                x, required=required, expected_range=expected_range,
-                logger=logger)]
+                x, logger, required=required, expected_range=expected_range)]
 
     return data
 

--- a/parsers/NA.py
+++ b/parsers/NA.py
@@ -146,7 +146,7 @@ def fetch_production(zone_key = 'NA', session=None, target_datetime=None, logger
           'source': 'nampower.com.na'
           }
 
-    data = validate(data, required=['hydro'])
+    data = validate(data, logger, required=['hydro'])
 
     return data
 

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -66,7 +66,7 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=N
             data[i]['production'][MAP_GENERATION[k]] = \
                 data[i]['production'].get(MAP_GENERATION[k], 0) + v['Valor'] / interval_hours
 
-    return list(filter(lambda x: validate(x, required=['gas'], floor=0.0, ) is not None, data))
+    return list(filter(lambda x: validate(x, logger, required=['gas'], floor=0.0, ) is not None, data))
 
 
 if __name__ == '__main__':

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -27,7 +27,7 @@ def check_expected_range(datapoint, value, expected_range, logger, key=None):
     return True
 
 
-def validate(datapoint, logger=getLogger(__name__), **kwargs):
+def validate(datapoint, logger, **kwargs):
     """
     Validates a production datapoint based on given constraints.
     If the datapoint is found to be invalid then None is returned.
@@ -84,14 +84,16 @@ def validate(datapoint, logger=getLogger(__name__), **kwargs):
     >>>       'source': 'mysource.com'
     >>> }
 
-    >>> validate(datapoint, required=['gas'], expected_range=(100, 2000))
+    >>> validate(datapoint, None, required=['gas'], expected_range=(100, 2000))
     datapoint
-    >>> validate(datapoint, required=['not_a_production_type'])
+    >>> validate(datapoint, None, required=['not_a_production_type'])
     None
-    >>> validate(datapoint, required=['gas'],
+    >>> validate(datapoint, None, required=['gas'],
     >>>          expected_range={'solar': (0, 1000), 'wind': (100, 2000)})
     datapoint
     """
+    if logger is None:
+        logger = getLogger(__name__)
 
     remove_negative = kwargs.pop('remove_negative', False)
     required = kwargs.pop('required', [])
@@ -166,5 +168,5 @@ test_datapoint = {
 }
 
 if __name__ == '__main__':
-    print(validate(test_datapoint, required=['gas'],
+    print(validate(test_datapoint, None, required=['gas'],
                    expected_range=(100, 2000), remove_negative=True))


### PR DESCRIPTION
in order to make sure the logger is always passed in `validate`, so that warnings are available on Kibana