### PR TITLE
Prepare production mix toggle

### DIFF
--- a/web/src/components/zonelist.js
+++ b/web/src/components/zonelist.js
@@ -36,6 +36,10 @@ export default class ZoneList {
     this.clickHandler = clickHandler;
   }
 
+  setElectricityMixMode(arg) {
+    this.electricityMixMode = arg;
+  }
+
   filterZonesByQuery(query) {
     this._deHighlightSelectedItem();
     d3.select(this.selectorId).selectAll('a').each((zone, i, nodes) => {
@@ -130,9 +134,16 @@ export default class ZoneList {
         .indexOf(query.toLowerCase()) !== -1);
   }
 
+  _getCo2IntensityAccessor() {
+    return d => (this.electricityMixMode === 'consumption'
+      ? d.co2intensity
+      : d.co2intensityProduction);
+  }
+
   _sortAndValidateZones(zones) {
+    const accessor = this._getCo2IntensityAccessor();
     return zones
-      .filter(d => d.co2intensity)
+      .filter(accessor)
       .sort((x, y) => {
         if (!x.co2intensity && !x.countryCode) {
           return d3.ascending(
@@ -141,8 +152,8 @@ export default class ZoneList {
           );
         }
         return d3.ascending(
-          x.co2intensity || Infinity,
-          y.co2intensity || Infinity,
+          accessor(x) || Infinity,
+          accessor(y) || Infinity,
         );
       });
   }
@@ -202,8 +213,9 @@ export default class ZoneList {
   }
 
   _setItemCO2IntensityTag() {
+    const accessor = this._getCo2IntensityAccessor();
     this.selector.select('.co2-intensity-tag')
-      .style('background-color', zone => (zone.co2intensity && this.co2ColorScale ? this.co2ColorScale(zone.co2intensity) : 'gray'));
+      .style('background-color', zone => (accessor(zone) && this.co2ColorScale ? this.co2ColorScale(accessor(zone)) : 'gray'));
   }
 
   _setItemClickHandlers() {

--- a/web/src/helpers/tooltip.js
+++ b/web/src/helpers/tooltip.js
@@ -7,11 +7,12 @@ const formatting = require('./formatting');
 
 // Production
 const FLAG_SIZE = 16;
-module.exports.showProduction = function showProduction(tooltipInstance, mode, country, displayByEmissions, co2color, co2Colorbars) {
+module.exports.showProduction = function showProduction(
+  tooltipInstance, mode, country, displayByEmissions, co2color, co2Colorbars, electricityMixMode)
+{
   const selector = tooltipInstance._selector;
 
   if (!country.productionCo2Intensities) { return; }
-  if (co2Colorbars) co2Colorbars.forEach((d) => { d.currentMarker(co2intensity); });
   const tooltip = d3.select(selector);
   tooltip.selectAll('#mode').text(translation.translate(mode) || mode);
 
@@ -21,7 +22,7 @@ module.exports.showProduction = function showProduction(tooltipInstance, mode, c
 
   const isStorage = value < 0;
 
-  var co2intensity = value < 0 ?
+  const co2intensity = value < 0 ?
     undefined :
     mode.indexOf('storage') !== -1 ?
       country.dischargeCo2Intensities[mode.replace(' storage', '')] :
@@ -31,6 +32,8 @@ module.exports.showProduction = function showProduction(tooltipInstance, mode, c
     mode.indexOf('storage') !== -1 ?
       country.dischargeCo2IntensitySources[mode.replace(' storage', '')] :
       country.productionCo2IntensitySources[mode];
+
+  if (co2Colorbars) co2Colorbars.forEach((d) => { d.currentMarker(co2intensity); });
 
   tooltip.select('.emission-rect')
     .style('background-color', co2intensity ? co2color(co2intensity) : 'gray');
@@ -169,9 +172,13 @@ module.exports.showExchange = function showExchange(tooltipInstance, key, countr
   tooltipInstance.show();
 };
 
-module.exports.showMapCountry = function showMapCountry(tooltipInstance, countryData, co2color, co2Colorbars, lowCarbonGauge, renewableGauge) {
-  if (countryData.co2intensity && co2Colorbars) {
-    co2Colorbars.forEach((c) => { c.currentMarker(countryData.co2intensity); });
+module.exports.showMapCountry = function showMapCountry(tooltipInstance, countryData, co2color, co2Colorbars, lowCarbonGauge, renewableGauge, electricityMixMode) {
+  const co2intensity = electricityMixMode === 'consumption'
+    ? countryData.co2intensity
+    : countryData.co2intensityProduction;
+
+  if (co2intensity && co2Colorbars) {
+    co2Colorbars.forEach((c) => { c.currentMarker(co2intensity); });
   }
   const tooltip = d3.select(tooltipInstance._selector);
   tooltip.select('#country-flag')
@@ -182,39 +189,48 @@ module.exports.showMapCountry = function showMapCountry(tooltipInstance, country
 
   if (countryData.hasParser && lowCarbonGauge && renewableGauge) {
     tooltip.select('.emission-rect')
-      .style('background-color', countryData.co2intensity ? co2color(countryData.co2intensity) : 'gray');
+      .style('background-color', co2intensity ? co2color(co2intensity) : 'gray');
     tooltip.select('.country-emission-intensity')
-      .text(Math.round(countryData.co2intensity) || '?');
+      .text(Math.round(co2intensity) || '?');
 
-    const hasFossilFuelData = countryData.fossilFuelRatio !== undefined || countryData.fossilFuelRatio !== null;
+    const fossilFuelRatio = electricityMixMode === 'consumption'
+      ? countryData.fossilFuelRatio
+      : countryData.fossilFuelRatioProduction;
+    const hasFossilFuelData = fossilFuelRatio != null;
     if (hasFossilFuelData) {
-      const fossilFuelPercent = countryData.fossilFuelRatio * 100;
+      const fossilFuelPercent = fossilFuelRatio * 100;
       lowCarbonGauge.setPercentage(Math.round(100 - fossilFuelPercent));
       tooltip.select('.lowcarbon-percentage').text(Math.round(100 - fossilFuelPercent));
     } else {
       tooltip.select('.lowcarbon-percentage').text('?');
     }
-    const hasRenewableData = countryData.renewableRatio !== undefined || countryData.renewableRatio !== null;
+
+    const renewableRatio = electricityMixMode === 'consumption'
+      ? countryData.renewableRatio
+      : countryData.renewableRatioProduction;
+    const hasRenewableData = renewableRatio != null;
     if (hasRenewableData) {
-      const renewablePercent = countryData.renewableRatio * 100;
+      const renewablePercent = renewableRatio * 100;
       renewableGauge.setPercentage(Math.round(renewablePercent));
       tooltip.select('.renewable-percentage').text(Math.round(renewablePercent));
     } else {
       tooltip.select('.renewable-percentage').text('?');
     }
   }
-  tooltip.select('.zone-details').style('display', countryData.hasParser && countryData.co2intensity ? 'block' : 'none');
-  tooltip.select('.temporary-outage-text').style('display', countryData.hasParser && !countryData.co2intensity ? 'block' : 'none');
+  tooltip.select('.zone-details').style('display', countryData.hasParser && co2intensity ? 'block' : 'none');
+  tooltip.select('.temporary-outage-text').style('display', countryData.hasParser && !co2intensity ? 'block' : 'none');
   tooltip.select('.no-parser-text').style('display', !countryData.hasParser ? 'block' : 'none');
 
   tooltipInstance.show();
 };
 
 module.exports.showMapExchange = function showMapExchange(tooltipInstance, exchangeData, co2color, co2Colorbars) {
+  const { co2intensity } = exchangeData;
+
   const tooltip = d3.select(tooltipInstance._selector);
-  if (exchangeData.co2intensity && co2Colorbars) { co2Colorbars.forEach((c) => { c.currentMarker(exchangeData.co2intensity); }); }
+  if (co2intensity && co2Colorbars) { co2Colorbars.forEach((c) => { c.currentMarker(co2intensity); }); }
   tooltip.select('.emission-rect')
-    .style('background-color', exchangeData.co2intensity ? co2color(exchangeData.co2intensity) : 'gray');
+    .style('background-color', co2intensity ? co2color(co2intensity) : 'gray');
   const i = exchangeData.netFlow > 0 ? 0 : 1;
   const ctrFrom = exchangeData.countryCodes[i];
   tooltip.selectAll('span#from')
@@ -229,7 +245,7 @@ module.exports.showMapExchange = function showMapExchange(tooltipInstance, excha
   tooltip.select('img.flag.to')
     .attr('src', flags.flagUri(exchangeData.countryCodes[(i + 1) % 2], 16));
   tooltip.select('.country-emission-intensity')
-    .text(Math.round(exchangeData.co2intensity) || '?');
+    .text(Math.round(co2intensity) || '?');
 
   tooltipInstance.show();
 };

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -117,8 +117,12 @@ const countryTable = new CountryTable('.country-table-container', modeColor, mod
 const countryHistoryCarbonGraph = new LineGraph(
   '#country-history-carbon',
   d => moment(d.stateDatetime).toDate(),
-  d => d.co2intensity,
-  d => d.co2intensity != null,
+  d => (getState().application.electricityMixMode === 'consumption'
+    ? d.co2intensity
+    : d.co2intensityProduction),
+  d => (getState().application.electricityMixMode === 'consumption'
+    ? d.co2intensity
+    : d.co2intensityProduction),
 );
 const countryHistoryPricesGraph = new LineGraph(
   '#country-history-prices',
@@ -324,7 +328,9 @@ try {
         .onExchangeClick((d) => {
           console.log(d);
         })
-        .setData(Object.values(getState().data.grid.exchanges))
+        .setData(getState().application.electricityMixMode === 'consumption'
+          ? Object.values(getState().data.grid.exchanges)
+          : [])
         .render();
       LoadingService.stopLoading('#loading');
       LoadingService.stopLoading('#small-loading');
@@ -597,11 +603,19 @@ function dataLoaded(err, clientVersion, callerLocation, state, argSolar, argWind
     // Assign country map data
     zoneMap
       .onCountryMouseOver((d) => {
-        tooltipHelper.showMapCountry(countryTooltip, d, co2color, co2Colorbars, tooltipLowCarbonGauge, tooltipRenewableGauge);
+        tooltipHelper.showMapCountry(
+          countryTooltip, d, co2color, co2Colorbars,
+          tooltipLowCarbonGauge, tooltipRenewableGauge,
+          getState().application.electricityMixMode,
+        );
       })
       .onZoneMouseMove((d, i, clientX, clientY) => {
         // TODO: Check that i changed before calling showMapCountry
-        tooltipHelper.showMapCountry(countryTooltip, d, co2color, co2Colorbars, tooltipLowCarbonGauge, tooltipRenewableGauge);
+        tooltipHelper.showMapCountry(
+          countryTooltip, d, co2color, co2Colorbars,
+          tooltipLowCarbonGauge, tooltipRenewableGauge,
+          getState().application.electricityMixMode,
+        );
         const rect = node.getBoundingClientRect();
         countryTooltip.update(clientX + rect.left, clientY + rect.top);
       })
@@ -909,10 +923,18 @@ function renderGauges(state) {
     countryLowCarbonGauge.setPercentage(null);
     countryRenewableGauge.setPercentage(null);
   } else {
-    const countryLowCarbonPercentage = d.fossilFuelRatio != null ?
-      100 - (d.fossilFuelRatio * 100) : null;
+    const fossilFuelRatio = state.application.electricityMixMode === 'consumption'
+      ? d.fossilFuelRatio
+      : d.fossilFuelRatioProduction;
+    const countryLowCarbonPercentage = fossilFuelRatio != null ?
+      100 - (fossilFuelRatio * 100) : null;
     countryLowCarbonGauge.setPercentage(countryLowCarbonPercentage);
-    const countryRenewablePercentage = d.renewableRatio != null ? d.renewableRatio * 100 : null;
+
+    const renewableRatio = state.application.electricityMixMode === 'consumption'
+      ? d.renewableRatio
+      : d.renewableRatioProduction;
+    const countryRenewablePercentage = renewableRatio != null ?
+      renewableRatio * 100 : null;
     countryRenewableGauge.setPercentage(countryRenewablePercentage);
   }
 }
@@ -930,7 +952,10 @@ function renderCountryTable(state) {
     // In this case there's nothing to do,
     // as the countryTable doesn't support receiving null data
   } else {
-    countryTable.data(d).render(true);
+    countryTable
+      .electricityMixMode(state.application.electricityMixMode)
+      .data(d)
+      .render(true);
 
     const zoneIsMissingParser = d.hasParser === undefined || !d.hasParser;
     countryTable.showNoParserMessageIf(zoneIsMissingParser);
@@ -957,7 +982,10 @@ function renderOpenTooltips(state) {
   }
 
   if (countryTooltip.isVisible) {
-    tooltipHelper.showMapCountry(countryTooltip, zoneData, co2color, co2Colorbars);
+    tooltipHelper.showMapCountry(
+      countryTooltip, zoneData, co2color, co2Colorbars,
+      state.application.electricityMixMode,
+    );
   }
 
   if (priceTooltip.isVisible) {
@@ -1034,7 +1062,12 @@ function renderHistory(state) {
   );
 
   // Figure out the highest CO2 emissions
-  const hi_co2 = d3.max(history, d => d.co2intensity);
+  const hi_co2 = d3.max(
+    history,
+    d => (getState().application.electricityMixMode === 'consumption'
+      ? d.co2intensity
+      : d.co2intensityProduction)
+  );
   countryHistoryCarbonGraph.y.domain([0, 1.1 * hi_co2]);
 
   // Create price color scale
@@ -1083,7 +1116,11 @@ function renderHistory(state) {
           .co2ScaleDomain([lo_emission, hi_emission]);
 
         if (g === countryHistoryCarbonGraph) {
-          tooltipHelper.showMapCountry(countryTooltip, d, co2color, co2Colorbars, tooltipLowCarbonGauge, tooltipRenewableGauge);
+          tooltipHelper.showMapCountry(
+            countryTooltip, d, co2color, co2Colorbars,
+            tooltipLowCarbonGauge, tooltipRenewableGauge,
+            state.application.electricityMixMode,
+          );
           countryTooltip.update(
             currentEvent.clientX - 7,
             g.rootElement.node().getBoundingClientRect().top - 7);
@@ -1124,7 +1161,7 @@ function renderLeftPanelCollapseButton(state) {
   d3.select('.left-panel')
     .classed('collapsed', isLeftPanelCollapsed);
   d3.select('#left-panel-collapse-button')
-    .classed('collapsed', isLeftPanelCollapsed)
+    .classed('collapsed', isLeftPanelCollapsed);
   if (typeof zoneMap !== 'undefined') {
     zoneMap.map.resize();
   }
@@ -1219,22 +1256,47 @@ function centerOnZoneName(state, zoneName, zoomLevel) {
     zoneMap.map.easeTo({ center: [lon, lat], zoom: zoomLevel });
   }
 }
-
-// Observe for grid zones change
-observe(state => state.data.grid.zones, (zones, state) => {
-  if (typeof zoneMap !== 'undefined') {
-    zoneMap.setData(Object.values(zones));
-  }
-  zoneList.setZones(zones);
-  zoneList.render();
-});
-// Observe for grid exchanges change
-observe(state => state.data.grid.exchanges, (exchanges) => {
+function renderExchanges(state) {
+  const { exchanges } = state.data.grid;
+  const { electricityMixMode } = state.application;
   if (exchangeLayer) {
     exchangeLayer
-      .setData(Object.values(exchanges))
+      .setData(electricityMixMode === 'consumption'
+        ? Object.values(exchanges)
+        : [])
       .render();
   }
+}
+function renderZones(state) {
+  const { zones } = state.data.grid;
+  const { electricityMixMode } = state.application;
+  if (typeof zoneMap !== 'undefined') {
+    zoneMap.setData(electricityMixMode === 'consumption'
+      ? Object.values(zones)
+      : Object.values(zones)
+        .map(d => Object.assign({}, d, { co2intensity: d.co2intensityProduction })));
+  }
+  zoneList.setElectricityMixMode(electricityMixMode);
+  zoneList.setZones(zones);
+  zoneList.render();
+}
+
+// Observe for electricityMixMode change
+observe(state => state.application.electricityMixMode, (electricityMixMode, state) => {
+  renderExchanges(state);
+  renderZones(state);
+  renderMap(state);
+  renderCountryTable(state);
+  renderGauges(state);
+  countryHistoryCarbonGraph.render();
+});
+// Observe for grid zones change
+observe(state => state.data.grid.zones, (zones, state) => {
+  renderZones(state);
+});
+// Observe for grid exchanges change
+observe(state => state.data.grid.exchanges, (exchanges, state) => {
+  renderExchanges(state);
 });
 // Observe for grid change
 observe(state => state.data.grid, (grid, state) => {
@@ -1404,3 +1466,9 @@ fetch(true, () => {
     setInterval(fetch, REFRESH_TIME_MINUTES * 60 * 1000);
   }
 });
+
+window.toggleElectricityMixMode = () => {
+  dispatchApplication('electricityMixMode', getState().application.electricityMixMode === 'consumption'
+      ? 'production'
+      : 'consumption');
+}

--- a/web/src/reducers/dataReducer.js
+++ b/web/src/reducers/dataReducer.js
@@ -123,8 +123,7 @@ module.exports = (state = initialDataState, action) => {
         });
         if (!zone.exchange || !Object.keys(zone.exchange).length) {
           console.warn(`${key} is missing exchanges`);
-        } 
-
+        }
       });
 
       // Populate exchange pairs for exchange layer

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -22,6 +22,7 @@ const initialApplicationState = {
   colorBlindModeEnabled: cookieGetBool('colorBlindModeEnabled', false),
   brightModeEnabled: cookieGetBool('brightModeEnabled', true),
   customDate: null,
+  electricityMixMode: 'production',
   isCordova: window.isCordova,
   isEmbedded: window.top !== window.self,
   isLeftPanelCollapsed: false,
@@ -60,6 +61,10 @@ const applicationReducer = (state = initialApplicationState, action) => {
       if (key === 'showPageState' &&
           state.showPageState !== 'country') {
         newState.pageToGoBackTo = state.showPageState;
+      }
+
+      if (key === 'electricityMixMode' && ['consumption', 'production'].indexOf(value) === -1) {
+        throw Error(`Unknown electricityMixMode "${value}"`);
       }
 
       return newState;

--- a/web/src/services/dataservice.js
+++ b/web/src/services/dataservice.js
@@ -6,18 +6,21 @@ const d3 = Object.assign(
   {},
   require('d3-queue'),
   require('d3-request'),
-  );
+);
 var moment = require('moment');
 
 // API
 function protectedJsonRequest(endpoint, path, callback) {
   const now = new Date().getTime();
   const md = forge.md.sha256.create();
-  const signature = md.update(ELECTRICITYMAP_PUBLIC_TOKEN + path + now).digest().toHex();
+  const tk = (endpoint.indexOf('localhost') !== -1)
+    ? 'development'
+    : ELECTRICITYMAP_PUBLIC_TOKEN;
+  const signature = md.update(tk + path + now).digest().toHex();
   const req = d3.json(endpoint + path)
     .header('electricitymap-token', Cookies.get('electricitymap-token'))
     .header('x-request-timestamp', now)
-    .header('x-signature', signature)
+    .header('x-signature', signature);
 
   return req.get(null, callback);
 }

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -68,13 +68,23 @@ co2Sub = function(str) {
         <link rel="canonical" href="<%- fullUrl %>" />
         <% } %>
 
+        <!-- Set Global Variables -->
+        <script>
+            var bundleHash = '<%= bundleHash %>';
+            var locale = '<%= locale %>';
+            var FBLocale = '<%= FBLocale %>';
+            var isCordova = <%= (typeof isCordova !== 'undefined' && isCordova) %>;
+        </script>
+
         <!-- Add crash reporting early on so we catch all errors -->
         <script src="https://browser.sentry-cdn.com/4.0.6/bundle.min.js" crossorigin="anonymous"></script>
         <script>
-            Sentry.init({
-                dsn: 'https://bdda83aba5724206bf02a880b14c56d1@sentry.io/1295430',
-                release: '<%= bundleHash %>',
-            });
+            if (bundleHash !== 'dev') {
+                Sentry.init({
+                    dsn: 'https://bdda83aba5724206bf02a880b14c56d1@sentry.io/1295430',
+                    release: '<%= bundleHash %>',
+                });
+            }
         </script>
 
         <!-- Google App Indexing (Android) -->
@@ -97,14 +107,6 @@ co2Sub = function(str) {
 
         <!-- Google Analytics -->
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-79729918-1"></script>
-
-        <!-- Set Global Variables -->
-        <script>
-            var bundleHash = '<%= bundleHash %>';
-            var locale = '<%= locale %>';
-            var FBLocale = '<%= FBLocale %>';
-            var isCordova = <%= (typeof isCordova !== 'undefined' && isCordova) %>;
-        </script>
     </head>
     <body lang="<%= locale %>">
         <div id="main">


### PR DESCRIPTION
Fixes https://github.com/tmrowco/electricitymap-contrib/issues/1554

The goal here is to add a toggle that enables to switch between production view and consumption view.
For now I
- added a new redux key `electricityMixMode`
- added a `toggleElectricityMixMode` global function that you can trigger from the console
- updated the code everywhere

![untitled9](https://user-images.githubusercontent.com/1655848/47287395-677f5480-d5f2-11e8-9b32-e86bf37eb485.gif)

@ovbm are you able to help with designing the toggle? As action you just need to trigger a method similar to https://github.com/tmrowco/electricitymap-contrib/compare/olc/add-production-mix-toggle?expand=1#diff-42c3276bc26032ecad9d7061dd401cd4R1470, and remove that global function.