### PR TITLE
CR query previous day if before 1:30 on current day

### DIFF
--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # coding=utf-8
 
+import datetime as dt
 import logging
 
 import arrow
@@ -160,8 +161,16 @@ def df_to_data(zone_key, day, df, logger):
 
 def fetch_production(zone_key='CR', session=None,
                      target_datetime=None, logger=logging.getLogger(__name__)):
-    # ensure we have an arrow object. if no target_datetime is specified, this defaults to now.
+    # ensure we have an arrow object.
+    # if no target_datetime is specified, this defaults to now.
     target_datetime = arrow.get(target_datetime).to(TIMEZONE)
+
+    # if before 01:30am on the current day then fetch previous day due to
+    # data lag.
+    today = arrow.get().to(TIMEZONE).date()
+    if target_datetime.date() == today:
+        target_datetime = target_datetime if target_datetime.time() >= dt.time(1, 30) \
+            else target_datetime.shift(days=-1)
 
     if target_datetime < arrow.get('2012-07-01'):
         # data availability limit found by manual trial and error


### PR DESCRIPTION
@systemcatch sorry for another review, short one! Closes #1477.

I didn't want to ignore the error (`ValueError: No tables found matching pattern 'Angostura'`) even though the data gets backfilled later in the day in case this error actually means something in the future. e.g. the source changed etc.. 

So right now it fetches the previous date if it's before 1:30am local time and the current date if after 1:30am local time (this behaviour only occurs when `target_datetime` is the current date!)