### PR TITLE
Update constants to reflect API report change

### DIFF
--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -30,7 +30,7 @@ REPORT_META = {
         'skiprows': 5
     },
     'INTERFUELHH': {
-        'expected_fields': 7,
+        'expected_fields': 8,
         'skiprows': 0
     }
 }
@@ -55,7 +55,8 @@ EXCHANGES = {
     'FR->GB': 3,
     'GB-NIR->IE': 4,
     'GB->NL': 5,
-    'GB->IE': 6
+    'GB->IE': 6,
+    'BE->GB': 7
 }
 
 


### PR DESCRIPTION
To get the parser running again for now. `BE->GB` exchange will have to be added to `config/exchanges.json` in the early new year.

related to #1662