### PR TITLE
Create production parser for India as a whole

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Italy
   - Wind & Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=ITA)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- India: [mercomindia](https://mercomindia.com/solar-indias-installed-power-capacity/)
 - India (Andhra Pradesh): [wikipedia.org](https://en.wikipedia.org/wiki/Power_sector_of_Andhra_Pradesh)
 - India (Chhattisgarh, Delhi, Gujarat, Karnataka, Punjab, Uttar Pradesh): [National Power Portal](https://npp.gov.in/dashBoard/cp-map-dashboard)
 - Latvia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - Iceland: [LANDSNET](http://amper.landsnet.is/MapData/api/measurements)
 - Ireland: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - Italy: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
+- India: [meritindia](http://meritindia.in/)
 - India (Andhra Pradesh): [CORE Dashboard](https://core.ap.gov.in/CMDashBoard/UserInterface/Power/PowerReport.aspx)
 - India (Chhattisgarh): [cspc.co.in](http://117.239.199.203/csptcl/GEN.aspx)
 - India (Delhi): [delhisldc](http://www.delhisldc.org/Redirect.aspx?Loc=0804)

--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -80,6 +80,9 @@ var countryCo2eqFootprint = {
     'GB-ORK': function (productionMode) {
         return (productionMode == 'unknown' || productionMode == 'other') ? {value: 13, source: 'assumes 95% wind, 5% solar'} : null;
     }, // Source http://www.oref.co.uk/wp-content/uploads/2015/05/Orkney-wide-energy-audit-2014-Energy-Sources-and-Uses.pdf
+    'IN': function (productionMode) {
+        return (productionMode == 'unknown' || productionMode == 'other') ? {value: 26, source: 'assumes 43% solar PV and 57% wind'} : null;
+    },
     'NL': function (productionMode) {
         return (productionMode == 'unknown' || productionMode == 'other') ? {value: 563, source: 'assumes 57% gas, 33% coal, 5% biomass, 4% nuclear'} : null;
     },  // Source: Derived from 2017 annual average: coal  30.0%, co-generation(gas)  19.0%, gas 28.0%, coke-oven-gas 5.0%, nuclear 4.0%, Wind  7.7%, biomass (waste) 4.90%, solar 1.40%, accoring to http://en-tran-ce.org/newsletter-renewable-energy-in-the-netherlands/

--- a/config/zones.json
+++ b/config/zones.json
@@ -1679,6 +1679,17 @@
     },
     "timezone": "Europe/Dublin"
   },
+  "IN": {
+    "bounding_box": [],
+    "capacity": {},
+    "contributors": [
+      "https://github.com/systemcatch"
+    ],
+    "parsers": {
+      "production": "IN.fetch_production"
+    },
+    "timezone": "Asia/Kolkata"
+  },
   "IN-AP": {
     "bounding_box": [
       [

--- a/config/zones.json
+++ b/config/zones.json
@@ -1681,7 +1681,15 @@
   },
   "IN": {
     "bounding_box": [],
-    "capacity": {},
+    "capacity": {
+      "solar": 26000,
+      "wind": 34000,
+      "coal": 196000,
+      "hydro": 50000,
+      "gas": 25000,
+      "nuclear": 6700,
+      "biomass": 9400
+    },
     "contributors": [
       "https://github.com/systemcatch"
     ],

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -1,0 +1,99 @@
+#!usr/bin/env python3
+
+"""Parser for all of India"""
+
+import arrow
+import logging
+import requests
+from bs4 import BeautifulSoup
+
+GENERATION_MAPPING = {'THERMAL GENERATION': 'coal',
+                      'GAS GENERATION': 'gas',
+                      'HYDRO GENERATION': 'hydro',
+                      'NUCLEAR GENERATION': 'nuclear',
+                      'RENEWABLE GENERATION': 'unknown'}
+
+GENERATION_URL = 'http://meritindia.in/Dashboard/BindAllIndiaMap'
+
+
+def get_data(session):
+    """
+    Requests html then extracts generation data.
+    Returns a dictionary.
+    """
+
+    s = session or requests.Session()
+    req = s.get(GENERATION_URL)
+    soup = BeautifulSoup(req.text, 'lxml')
+    tables = soup.findAll('table')
+
+    gen_info = tables[-1]
+    rows = gen_info.findAll('td')
+
+    generation = {}
+    for row in rows:
+        gen_title = row.find('div', {"class": "gen_title_sec"})
+        gen_val = row.find('div', {"class": "gen_value_sec"})
+        val = gen_val.find('span', {"class": "counter"})
+        generation[gen_title.text] = val.text.strip()
+
+    return generation
+
+
+def fetch_production(zone_key = 'IN', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
+    """
+    Requests the last known production mix (in MW) of a given zone
+    Arguments:
+    zone_key (optional) -- used in case a parser is able to fetch multiple zones
+    session (optional) -- request session passed in order to re-use an existing session
+    Return:
+    A dictionary in the form:
+    {
+      'zoneKey': 'FR',
+      'datetime': '2017-01-01T00:00:00Z',
+      'production': {
+          'biomass': 0.0,
+          'coal': 0.0,
+          'gas': 0.0,
+          'hydro': 0.0,
+          'nuclear': null,
+          'oil': 0.0,
+          'solar': 0.0,
+          'wind': 0.0,
+          'geothermal': 0.0,
+          'unknown': 0.0
+      },
+      'storage': {
+          'hydro': -10.0,
+      },
+      'source': 'mysource.com'
+    }
+    """
+
+    if target_datetime is not None:
+        raise NotImplementedError('This parser is not yet able to parse past dates')
+
+    raw_data = get_data(session)
+    processed_data = {k: float(v.replace(',', '')) for k,v in raw_data.items()}
+    processed_data.pop('DEMANDMET', None)
+
+    for k in processed_data:
+        if k not in GENERATION_MAPPING.keys():
+            processed_data.pop(k)
+            logger.warning('Key \'{}\' in IN is not mapped to type.'.format(k), extra={'key': 'IN'})
+
+    mapped_production = {GENERATION_MAPPING[k]: v for k,v in processed_data.items()}
+
+    data = {
+      'zoneKey': zone_key,
+      'datetime': arrow.now('Asia/Kolkata').datetime,
+      'production': mapped_production,
+      'storage': {},
+      'source': 'meritindia.in'
+    }
+
+    return data
+
+if __name__ == '__main__':
+    print('fetch_production() -> ')
+    print(fetch_production())


### PR DESCRIPTION
Currently we're assigning the combined renewable generation to 'unknown' which is fairly harsh, maybe we can come up with a better fixed intensity?

Let me know if anything needs to be adjusted so it doesn't show up on the map.

ref #1623 

Little slow but it works.
```shell
(EM-env) chris@ThinkPad:~/electricitymap/parsers$ python IN.py 
fetch_production() -> 
{'datetime': datetime.datetime(2018, 11, 3, 17, 54, 43, 501302, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Kolkata')), 'source': 'meritindia.in', 'storage': {}, 'production': {'unknown': 2470.0, 'gas': 7897.0, 'hydro': 23462.0, 'coal': 120586.0, 'nuclear': 4037.0}, 'zoneKey': 'IN'}
```
