### PR TITLE
Update Finland's capacities to those currently on ENTSO-E

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
   - Biomass & Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=EST)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Faroe Islands: [Johan Pauli Magnussen's Thesis, p44](https://setur.fo/uploads/tx_userpubrep/BScThesis_JohanPauliMagnussen.pdf)
-- Finland
-  - Solar & Wind: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=FIN)
-  - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- Finland: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - France: [RTE](http://bilan-electrique-2017.rte-france.com/production/le-parc-de-production-national/)
 - Germany: [Frauenhofer ISE](https://www.energy-charts.de/power_inst.htm?year=2018&period=annual&type=power_inst)
 - Georgia: [GSE](http://www.gse.com.ge/for-customers/data-from-the-power-system)

--- a/config/zones.json
+++ b/config/zones.json
@@ -1323,16 +1323,16 @@
       ]
     ],
     "capacity": {
-      "biomass": 2866,
-      "coal": 2854,
-      "gas": 1795,
+      "biomass": 1970,
+      "coal": 3413,
+      "gas": 1865,
       "geothermal": 0,
-      "hydro": 3207,
+      "hydro": 3149,
       "nuclear": 2782,
-      "oil": 1427,
+      "oil": 1386,
       "solar": 0,
-      "unknown": 648,
-      "wind": 1598
+      "unknown": 619,
+      "wind": 1908
     },
     "contributors": [
       "https://github.com/corradio"


### PR DESCRIPTION
The capacity numbers for Finland are both old and wrong. Seems #1378 / #393 moved peat from biomass to coal in the parser, but did not adjust Finland's capacities correspondingly.

These are the current 2018 numbers from ENTSO-E. I dropped the IRENA numbers, because they are almost the same, but would change the total unless you fudge "unknown" to compensate.