### PR TITLE
Reduce test noise & handle US-MISO timezone correctly

### DIFF
--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -32,15 +32,6 @@ def get_json_data(logger, session=None):
     return json_data
 
 
-def add_default_tz(timestamp):
-    """Adds EST timezone to datetime object if tz = None."""
-
-    EST = tz.gettz('America/New_York')
-    modified_timestamp = timestamp.replace(tzinfo=timestamp.tzinfo or EST)
-
-    return modified_timestamp
-
-
 def data_processer(json_data, logger):
     """
     Identifies any unknown fuel types and logs a warning.
@@ -70,8 +61,8 @@ def data_processer(json_data, logger):
         raise ValueError('Timezone reported for US-MISO has changed.')
 
     time_data = " ".join(useful_time_parts)
-    dt_naive = parser.parse(time_data)
-    dt = add_default_tz(dt_naive)
+    tzinfos = {"EST": tz.gettz('America/New_York')}
+    dt = parser.parse(time_data, tzinfos=tzinfos)
 
     return dt, production
 

--- a/parsers/test/test_entsoe_quality.py
+++ b/parsers/test/test_entsoe_quality.py
@@ -10,6 +10,7 @@ from parsers.test.mocks.quality_check import *
 class ProductionTestCase(unittest.TestCase):
     """Tests for ENTSOE's validate_production."""
     test_logger = logging.getLogger()
+    test_logger.setLevel(logging.ERROR)
 
     def test_missing_required_biomass_in_DE(self):
         validated = validate_production(p10, self.test_logger)


### PR DESCRIPTION
Prevents this output in the tests.

```shell
(EM-env) chris@ThinkPad:~/electricitymap$ python -m unittest discover parsers/test/
.................................................Required generation type biomass is missing from DE
.Required generation type solar is missing from DK-DK1
.SI reported total of 5672.00MW falls outside range of (1000, 5000) 
.PL reported total of 1010.60MW falls outside range of (5000, 35000) 
...................
----------------------------------------------------------------------
Ran 71 tests in 1.676s

OK

```

Fixes this before it breaks in the future.

```shell
(EM-env) chris@ThinkPad:~/electricitymap$ python parsers/US_MISO.py 
fetch_production() ->
/home/chris/EM-env/lib/python3.5/site-packages/dateutil/parser/_parser.py:1204: UnknownTimezoneWarning: tzname EST identified but not understood.  Pass `tzinfos` argument in order to correctly return a timezone-aware datetime.  In a future version, this will raise an exception.
  category=UnknownTimezoneWarning)
{'source': 'misoenergy.org', 'production': {'coal': 43595.0, 'wind': 7087.0, 'gas': 18061.0, 'unknown': 1131.0, 'nuclear': 10886.0}, 'zoneKey': 'US-MISO', 'storage': {}, 'datetime': datetime.datetime(2018, 11, 15, 11, 40, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York'))}

```