### PR TITLE
Add solar generation to Russia

### DIFF
--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -18,14 +18,16 @@ MAP_GENERATION_1 = {
     'P_GES': 'hydro',
     'P_GRES': 'unknown',
     'P_TES': 'unknown',
-    'P_BS': 'unknown'
+    'P_BS': 'unknown',
+    'P_REN': 'solar'
 }
 
 MAP_GENERATION_2 = {
     'P_GES': 'hydro',
     'P_GRES': 'unknown',
     'P_TES': 'unknown',
-    'P_BS': 'unknown'
+    'P_BS': 'unknown',
+    'P_REN': 'solar'
 }
 
 exchange_ids = {'CN->RU-AS': "764",
@@ -144,7 +146,6 @@ def fetch_production(zone_key='RU', session=None, target_datetime=None, logger=N
             continue
 
         # Default values
-        row['production']['solar'] = None
         row['production']['biomass'] = None
         row['production']['geothermal'] = None
 


### PR DESCRIPTION
Adds the new renewable category "P_REN" as "solar".

Some of the sample output:
datetime.datetime(2018, 11, 15, 9, 0, tzinfo=tzfile('W-SU'))}, {'zoneKey': 'RU-1', 'production': {'nuclear': 26374.69140625, 'hydro': 7859.890625, 'unknown': 76245.1748046875, 'solar': 148.809997558594, 'biomass': None, 'geothermal': None}, 'storage': {}, 'source': 'so-ups.ru'