### PR TITLE
ignore CA-NS SSL problems

### DIFF
--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -35,11 +35,14 @@ def _get_ns_info(requests_obj, logger):
         'wind': 700
     }
 
-    mix_url = 'http://www.nspower.ca/system_report/today/currentmix.json'
-    mix_data = requests_obj.get(mix_url).json()
+    # As of November 2018, NSPower redirects their web traffic to HTTPS. However we've been
+    # getting SSL errors in Python, even though loading these URLs in Firefox 63 gives no errors.
+    # This isn't confidential or security-sensitive data, so ignore the SSL errors.
+    mix_url = 'https://www.nspower.ca/system_report/today/currentmix.json'
+    mix_data = requests_obj.get(mix_url, verify=False).json()
 
-    load_url = 'http://www.nspower.ca/system_report/today/currentload.json'
-    load_data = requests_obj.get(load_url).json()
+    load_url = 'https://www.nspower.ca/system_report/today/currentload.json'
+    load_data = requests_obj.get(load_url, verify=False).json()
 
     production = []
     imports = []


### PR DESCRIPTION
In our Kibana and on my local Python I get:

`ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:847)`

In Kibana this started on Friday. I noticed that NSPower.ca now redirects web traffic to HTTPS. In a browser (Firefox 63.0.3 on Linux) https://www.nspower.ca/system_report/today/currentmix.json loads just fine, but Python struggles with it. I think it's something to do with certificate stores? We could probably upgrade Python to the latest, but having SSL verification on this domain isn't important, so just ignore the SSL errors for now.