### PR TITLE
Get Taiwan's hydro storage capacity inside parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - Spain (Balearic Islands): [REE](https://demanda.ree.es/movil)
 - Sweden: [SVK](https://www.svk.se/en/national-grid/the-control-room/)
 - Switzerland: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
-- Taiwan: [TAIPOWER](http://www.taipower.com.tw/content/new_info/new_info_in.aspx?LinkID=27)
+- Taiwan: [TAIPOWER](http://www.taipower.com.tw/d006/loadGraph/loadGraph/genshx_.html)
 - Turkey: [ytbs](https://ytbs.teias.gov.tr/ytbs/frm_login.jsf)
 - Ukraine: [UKRENERGO](https://ua.energy/activity/dispatch-information/ues-operation/)
 - United States of America
@@ -270,6 +270,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
   - Renewables: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=SWE)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Switzerland: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- Taiwan: [TAIPOWER](http://www.taipower.com.tw/d006/loadGraph/loadGraph/genshx_.html)
 - Turkey: [TEİAŞ](https://www.teias.gov.tr/)
 - Ukraine: [wikipedia.org](https://uk.wikipedia.org/wiki/%D0%95%D0%BB%D0%B5%D0%BA%D1%82%D1%80%D0%BE%D0%B5%D0%BD%D0%B5%D1%80%D0%B3%D0%B5%D1%82%D0%B8%D0%BA%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8)
 - United States of America

--- a/config/zones.json
+++ b/config/zones.json
@@ -3367,9 +3367,6 @@
         25.2954588893
       ]
     ],
-    "capacity": {
-      "hydro storage": 2602
-    },
     "contributors": [
       "https://github.com/corradio",
       "https://github.com/MariusKroon"

--- a/parsers/TW.py
+++ b/parsers/TW.py
@@ -62,6 +62,7 @@ def fetch_production(zone_key='TW', session=None, target_datetime=None, logger=N
             'gas': gas_capacity,
             'oil': oil_capacity,
             'hydro': production.ix['Hydro'].capacity,
+            'hydro storage':production.ix['Pumping Gen'].capacity,
             'nuclear': production.ix['Nuclear'].capacity,
             'solar': production.ix['Solar'].capacity,
             'wind': production.ix['Wind'].capacity,


### PR DESCRIPTION
We had a fixed value for Taiwanese hydro storage in zones.json, which was overwritten by the automatically gained capacity data of the parser, so "hydro storage" capacity was always shown as "?".

I hope I fixed this now and added the "Pumping Gen" capacity to the parser.

Snippet of the sample output:
'capacity': {'coal': 13097.2, 'gas': 15973.8, 'oil': 2572.1, 'hydro': 2091.4999999999995, **'hydro storage': 2602.0**, 'nuclear': 5144.0, 'solar': 2180.7, 'wind': 694.9, 'unknown': 623.2}, '

Updated source in README.md as well