### PR TITLE
Add solar to DO.py

### DIFF
--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -51,6 +51,7 @@ thermal_plants = {
                  u'ESTRELLA DEL MAR 2 CGN': 'gas',
                  u'ESTRELLA DEL MAR 2 SFO': 'oil',
                  u'ESTRELLA DEL MAR 2 SGN': 'gas',
+                 u'GENERACI\xD3N DE EMERGENCIA AES ANDR\xC9S': 'gas',
                  u'HAINA TG': 'oil',
                  u'INCA KM22': 'oil',
                  u'ITABO 1': 'coal',
@@ -332,7 +333,7 @@ def fetch_production(zone_key='DO', session=None, target_datetime=None, logger=l
               'hydro': hour.get('hydro', 0.0),
               'nuclear': 0.0,
               'oil': hour.get('oil', 0.0),
-              'solar': None,
+              'solar': hour.get('solar', 0.0),
               'wind': hour.get('wind', 0.0),
               'geothermal': 0.0,
               'unknown': hour.get('unknown', 0.0)


### PR DESCRIPTION
resolves #1716 
- include fetched solar data for two large-scale PV plants
   - set solar from 'solar': None to hour.get(...) ... The two plants were already incuded in the "thermal" mapping. I hope this is how it should be done.
   - For the past, it seems that solar experienced similar issues as wind and hydro with data gaps (often for every 2nd hour)... maybe a similar processing as for wind and hydro should be used at some point to set solar to None instead of 0 when data is missing:
```
if isnan(solar):
            solar = None
```
... one of you Pros should to implement this ;)

Sample output for hour 8 of today:

Solar in source 0.72 MW and 1.43 MW:
![image](https://user-images.githubusercontent.com/25743609/50447168-ac3caa00-0919-11e9-9221-bd1b6f6bb7f9.png)

Total solar output 2.15 MW:

`{'zoneKey': 'DO', 'datetime': datetime.datetime(2018, 12, 26, 7, 0, tzinfo=tzfile('America/Virgin')), 'production': {'biomass': 29.66, 'coal': 306.78999999999996, 'gas': 791.6300000000001, 'hydro': 48.24, 'nuclear': 0.0, 'oil': 357.61, 'solar': 2.15, 'wind': 106.69, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}`
_____

Extra:

- add missing power plant "GENERACIÓN DE EMERGENCIA AES ANDRÉS" to mapping (auxiliary gas turbines commisioned on 1st December, see [this source](https://www.diariolibre.com/economia/aes-dominicana-alcanza-meta-de-aportar-120-megavatios-mas-con-gas-natural-KB11544934))

Before:
`GENERACIÓN DE EMERGENCIA AES ANDRÉS is missing from the DO plant mapping!`
`[{'zoneKey': 'DO', 'datetime': datetime.datetime(2018, 12, 26, 0, 0, tzinfo=tzfile('America/Virgin')), 'production': {'biomass': 30.0, 'coal': 304.0, 'gas': 736.72, 'hydro': 200.75, 'nuclear': 0.0, 'oil': 505.92999999999995, 'solar': 0.0, 'wind': None, 'geothermal': 0.0, 'unknown': 112.0},`

After:
`[{'zoneKey': 'DO', 'datetime': datetime.datetime(2018, 12, 26, 0, 0, tzinfo=tzfile('America/Virgin')), 'production': {'biomass': 30.0, 'coal': 304.0, 'gas': 848.72, 'hydro': 200.75, 'nuclear': 0.0, 'oil': 505.92999999999995, 'solar': 0.0, 'wind': None, 'geothermal': 0.0, 'unknown': 0.0},`