### PR TITLE
Namibia capacity update

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Malaysia: [GSO](https://www.gso.org.my/SystemData/PowerStation.aspx)
 - Moldova: [FAS](http://en.fas.gov.ru/upload/other/National%20Agency%20for%20Energy%20Regulation%20(G.%20Pyrzy).pdf)
 - Montenegro: [EPCG](http://www.epcg.com/en/about-us/production-facilities)
-- Namibia: [NamPower](http://www.nampower.com.na/Page.aspx?p=182)
+- Namibia
+  - Coal & Oil: [NamPower](http://www.nampower.com.na/Page.aspx?p=182)
+  - Hydro, solar & wind: [African Energy](https://www.africa-energy.com/database)
 - Netherlands: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Nicaragua: [Climatescope](http://global-climatescope.org/en/country/nicaragua/)
 - Norway

--- a/config/zones.json
+++ b/config/zones.json
@@ -2609,8 +2609,10 @@
   "NA": {
     "capacity": {
       "coal": 120,
-      "hydro": 330,
-      "oil": 38
+      "hydro": 347,
+      "oil": 38,
+      "solar": 116,
+      "wind": 5
     },
     "contributors": [
       "https://github.com/systemcatch",


### PR DESCRIPTION
Just a short update for the installed capacities.

Added missing solar & wind capacity.
Another 35 MW of solar power are under construction and 60 MW planned.
Updated hydro to correct value.