### PR TITLE
El Salvador update

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Denmark (Bornholm)
   - Wind: [stateofgreen.com](https://stateofgreen.com/en/profiles/regional-municipality-of-bornholm/solutions/kalby-wind-turbines)
 - Dominican Republic: [Climatescope](http://global-climatescope.org/en/country/dominican-republic/#/details)
+- El Salvador:
+  - Thermal: [CNE](http://estadisticas.cne.gob.sv/wp-content/uploads/2016/09/Plan_indicativo_2016_2026-1.pdf) 
+  - Biomass, Geothermal, Hydro & Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=SLV)
 - Estonia:
   - Biomass & Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=EST)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3369,9 +3369,11 @@
       ]
     ],
     "capacity": {
+      "biomass": 253,
       "geothermal": 204,
-      "hydro": 472,
-      "unknown": 756
+      "hydro": 575,
+      "oil": 756,
+      "solar": 140
     },
     "contributors": [
       "https://github.com/systemcatch"

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -10,7 +10,10 @@ from operator import itemgetter
 
 # This parser gets hourly electricity generation data from ut.com.sv for El Salvador.
 # El Salvador does have wind generation but there is no data available.
-# Fossil fuel generation is grouped under 'thermal' with no further breakdown given.
+# The 'Termico' category only consists of generation from oil/diesel according to historical data.
+# See: https://www.iea.org/statistics/?country=ELSALVADOR&year=2016&category=Key%20indicators&indicator=ElecGenByFuel
+# A new Liquid Natural Gas power plant may come online in 2020/2021.
+# See: https://gastechinsights.com/article/what-energa-del-pacficos-lng-to-power-project-means-for-el-salvador
 
 # Thanks to jarek for figuring out how to make the correct POST request to the data url.
 

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -173,15 +173,15 @@ def fetch_production(zone_key='SV', session=None, target_datetime=None, logger=N
             'datetime': hour['datetime'],
             'production': {
                 'biomass': hour.get('biomass', 0.0),
-                'coal': hour.get('coal', 0.0),
-                'gas': hour.get('gas', 0.0),
+                'coal': 0.0,
+                'gas': 0.0,
                 'hydro': hour.get('hydro', 0.0),
                 'nuclear': 0.0,
-                'oil': hour.get('oil', 0.0),
+                'oil': hour.get('thermal', 0.0),
                 'solar': hour.get('solar', 0.0),
                 'wind': None,
                 'geothermal': hour.get('geothermal', 0.0),
-                'unknown': hour.get('thermal', 0.0)
+                'unknown': 0.0
             },
             'storage': {
                 'hydro': None,


### PR DESCRIPTION
- Updated & added renewable capacity
- Updated capacity sources in README.md
- Changed parser to fetch "termico" as generation from oil
  - sample output: 
`{'zoneKey': 'SV', 'datetime': datetime.datetime(2018, 12, 30, 5, 0, tzinfo=tzstr('UTC-6')), 'production': {'biomass': 149.89, 'coal': 0.0, 'gas': 0.0, 'hydro': 23.04, 'nuclear': 0.0, 'oil': 50.72, 'solar': 0.0, 'wind': None, 'geothermal': 168.02, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'ut.com.sv'}]`
  - based on generation figures [of IEA from the past](https://www.iea.org/statistics/?country=ELSALVADOR&year=2016&category=Key%20indicators&indicator=ElecGenByFuel&mode=chart&categoryBrowse=false&dataTable=ELECTRICITYANDHEAT&showDataTable=true), there is no other fossil source but oil/diesel
  - a new liquid gas power plant will start operating in 2020/2021 in El Salvador, then we'd have to look out for changes
  - see https://gastechinsights.com/article/what-energa-del-pacficos-lng-to-power-project-means-for-el-salvador
