### PR TITLE
switch oil-shale category from 'oil' to 'coal'

### DIFF
--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -244,7 +244,7 @@
           "source": "2017 average by Tomorrow",
           "value": 1124.6394396486162
         },
-        "oil": {
+        "coal": {
           "source": "EASAC 2007",
           "value": 1515
         }

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -51,13 +51,13 @@ ENTSOE_PARAMETER_DESC = {
 ENTSOE_PARAMETER_BY_DESC = {v: k for k, v in ENTSOE_PARAMETER_DESC.items()}
 ENTSOE_PARAMETER_GROUPS = {
     'biomass': ['B01', 'B17'],
-    'coal': ['B02', 'B05', 'B08'],
+    'coal': ['B02', 'B05', 'B07', 'B08'],
     'gas': ['B03', 'B04'],
     'geothermal': ['B09'],
     'hydro': ['B11', 'B12'],
     'hydro storage': ['B10'],
     'nuclear': ['B14'],
-    'oil': ['B06', 'B07'],
+    'oil': ['B06'],
     'solar': ['B16'],
     'wind': ['B18', 'B19'],
     'other': ['B20', 'B13', 'B15']


### PR DESCRIPTION
fix #1737
We'll need to re-scrap historical Estonia dataset to maintain consistency