### PR TITLE
switch DK2->SE exchange parser from Stattnet to ENTSOE

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -884,7 +884,7 @@
       55.952282
     ],
     "parsers": {
-      "exchange": "statnett.fetch_exchange"
+      "exchange": "ENTSOE.fetch_exchange"
     },
     "rotation": 70
   },


### PR DESCRIPTION
fix #1707, but revert from 15-min granularity to hourly granularity only.
Could be good to revert this commit once [ENTSOE](https://transparency.entsoe.eu/transmission-domain/physicalFlow/show?name=&defaultValue=false&viewType=TABLE&areaType=BORDER_BZN&atch=false&dateTime.dateTime=11.01.2019+00:00|CET|DAY&border.values=CTY|10Y1001A1001A65H!BZN_BZN|10YDK-1--------W_BZN_BZN|10YDK-2--------M&dateTime.timezone=CET_CEST&dateTime.timezone_input=CET+(UTC+1)+/+CEST+(UTC+2))/[Energinet](https://energinet.dk/energisystem_fullscreen) agree again with [Stattnett](https://www.statnett.no/en/for-stakeholders-in-the-power-industry/data-from-the-power-system/)