### PR TITLE
Adjustment of capacity for Poland (PL)

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -2970,7 +2970,7 @@
     "capacity": {
       "biomass": 597,
       "coal": 30289,
-      "gas": 2129,
+      "gas": 2401,
       "hydro": 593,
       "hydro storage": 1780,
       "nuclear": 0,


### PR DESCRIPTION
Capacity volume has been adjusted according to https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show
Production Type	2019 [MW]
Fossil Peat	n/e
Nuclear	n/e
Fossil Hard coal	22444
Wind Onshore	5825
Fossil Brown coal/Lignite	7845
Geothermal	n/e
Hydro Run-of-river and poundage	436
Hydro Water Reservoir	157
Wind Offshore	n/e
Hydro Pumped Storage	1780
Other renewable	n/e
Solar	424
Fossil Oil shale	n/e
Waste	n/e
Fossil Gas	2129
Fossil Coal-derived gas	272
Fossil Oil	415
Marine	n/e
Other	n/e
Biomass	597
Total Grand capacity	42324


Those values has been added together as Hydro Storage
Hydro Run-of-river and poundage	436
Hydro Water Reservoir	157

Those values has been added together as coal:
Fossil Brown coal/Lignite	7845
Fossil Hard coal	22444

There is a question how to classify the following:
Fossil Coal-derived gas	272 
cause this is not a gas nor coal. Currently not included.