### PR TITLE
Singapore solar capacity update

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Russia: [Minenergo](https://minenergo.gov.ru/node/532)
 - Serbia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Singapore
-  - Solar (AC): [Solar Irradiance map](https://www.ema.gov.sg/solarmap.aspx)
-  - Other [Energy Market Authority](https://www.ema.gov.sg/cmsmedia/Publications_and_Statistics/Publications/SES/2016/Singapore%20Energy%20Statistics%202016.pdf)
+  - Solar: [Energy Market Authority Statistics](https://www.ema.gov.sg/statistic.aspx?sta_sid=20170711hc85chOLVvWp)
+  - Other: [Energy Market Authority](https://www.ema.gov.sg/cmsmedia/Publications_and_Statistics/Publications/SES/2016/Singapore%20Energy%20Statistics%202016.pdf)
 - Slovakia: [SEPS](https://www.sepsas.sk/Dokumenty/RocenkySed/ROCENKA_SED_2015.pdf)
 - Slovenia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Spain:

--- a/config/zones.json
+++ b/config/zones.json
@@ -3334,7 +3334,7 @@
     "capacity": {
       "biomass": 257,
       "gas": 10344,
-      "solar": 110
+      "solar": 183.4
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
- Update Singapore's solar capacity to the latest figure for Q3/2018 of 183.4MWp.
- adjust source in readme.md