### PR TITLE
Update capacities for Romania

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Portugal
   - Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=PTA)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
-- Romania: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- Romania:
+  - Nuclear: [Nuclearelectrica](http://www.nuclearelectrica.ro/cne/)
+  - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Russia: [Minenergo](https://minenergo.gov.ru/node/532)
 - Serbia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Singapore

--- a/config/zones.json
+++ b/config/zones.json
@@ -3089,15 +3089,15 @@
       ]
     ],
     "capacity": {
-      "biomass": 95,
-      "coal": 5894,
-      "gas": 4879,
+      "biomass": 115,
+      "coal": 4128,
+      "gas": 3033,
       "geothermal": 0,
-      "hydro": 6703,
+      "hydro": 6143,
       "hydro storage": 0,
-      "nuclear": 1298,
-      "solar": 1152,
-      "wind": 2938
+      "nuclear": 1400,
+      "solar": 1150,
+      "wind": 2968
     },
     "contributors": [
       "https://github.com/corradio"


### PR DESCRIPTION
Updated capacities for Romania according to data:

- from  [transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?name=&defaultValue=true&viewType=TABLE&areaType=BZN&atch=false&dateTime.dateTime=01.01.2016+00:00|UTC|YEAR&dateTime.endDateTime=01.01.2020+00:00|UTC|YEAR&area.values=CTY|10YRO-TEL------P!BZN|10YRO-TEL------P&productionType.values=B01&productionType.values=B02&productionType.values=B03&productionType.values=B04&productionType.values=B05&productionType.values=B06&productionType.values=B07&productionType.values=B08&productionType.values=B09&productionType.values=B10&productionType.values=B11&productionType.values=B12&productionType.values=B13&productionType.values=B14&productionType.values=B20&productionType.values=B15&productionType.values=B16&productionType.values=B17&productionType.values=B18&productionType.values=B19)
- for 2019 (the old capacities were from 2016)

I've only made an exception on the **nuclear capacity** value because on electricitymap.org the nuclear capacity is always more than 1300 MW. The new value is from their site http://www.nuclearelectrica.ro/cne/  (700x2). 
![romania_exceeds_capacity](https://user-images.githubusercontent.com/5528724/52902397-cd828e00-3218-11e9-82f3-39cc17e7285e.png)
 