### PR TITLE
Add wind forecast for MISO

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -3718,7 +3718,8 @@
     "flag_file_name": "us.png",
     "parsers": {
       "consumptionForecast": "EIA.fetch_consumption_forecast",
-      "production": "US_MISO.fetch_production"
+      "production": "US_MISO.fetch_production",
+      "productionPerModeForecast": "US_MISO.fetch_wind_forecast"
     },
     "timezone": null
   },

--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -130,11 +130,14 @@ def fetch_wind_forecast(zone_key='US-MISO', session=None, target_datetime=None, 
     A list of dictionaries in the form:
     {
     'source': 'misoenergy.org',
-    'value': 12932.0,
+    'production': {'wind': 12932.0},
     'datetime': '2019-01-01T00:00:00Z',
     'zoneKey': 'US-MISO'
     }
     """
+
+    if target_datetime:
+        raise NotImplementedError('This parser is not yet able to parse past dates')
 
     s = session or requests.Session()
     req = s.get(wind_forecast_url)
@@ -147,7 +150,7 @@ def fetch_wind_forecast(zone_key='US-MISO', session=None, target_datetime=None, 
         value = float(item['Value'])
 
         datapoint = {'datetime': dt,
-                     'value': value,
+                     'production': {'wind': value},
                      'source': 'misoenergy.org',
                      'zoneKey': zone_key}
         data.append(datapoint)

--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -2,6 +2,7 @@
 
 """Parser for the MISO area of the United States."""
 
+import logging
 import requests
 from dateutil import parser, tz
 
@@ -68,12 +69,14 @@ def data_processer(json_data, logger):
     return dt, production
 
 
-def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, logger=None):
+def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
     Arguments:
     zone_key (optional) -- used in case a parser is able to fetch multiple countries
     session (optional)      -- request session passed in order to re-use an existing session
+    target_datetime (optional) -- used if parser can fetch data for a specific day
+    logger (optional) -- handles logging when parser is run as main
     Return:
     A dictionary in the form:
     {
@@ -97,6 +100,7 @@ def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, log
       'source': 'mysource.com'
     }
     """
+
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
 
@@ -115,7 +119,25 @@ def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, log
 
 
 def fetch_wind_forecast(zone_key='US-MISO', session=None, target_datetime=None, logger=None):
-    req = requests.get(wind_forecast_url)
+    """
+    Requests the day ahead wind forecast (in MW) of a given zone
+    Arguments:
+    zone_key (optional) -- used in case a parser is able to fetch multiple countries
+    session (optional)  -- request session passed in order to re-use an existing session
+    target_datetime (optional) -- used if parser can fetch data for a specific day
+    logger (optional) -- handles logging when parser is run as main
+    Return:
+    A list of dictionaries in the form:
+    {
+    'source': 'misoenergy.org',
+    'value': 12932.0,
+    'datetime': '2019-01-01T00:00:00Z',
+    'zoneKey': 'US-MISO'
+    }
+    """
+
+    s = session or requests.Session()
+    req = s.get(wind_forecast_url)
     raw_json = req.json()
     raw_data = raw_json['Forecast']
 
@@ -137,4 +159,4 @@ if __name__ == '__main__':
     print('fetch_production() ->')
     print(fetch_production())
     print('fetch_wind_forecast() ->')
-    #print(fetch_wind_forecast())
+    print(fetch_wind_forecast())

--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -14,6 +14,7 @@ mapping = {'Coal': 'coal',
            'Wind': 'wind',
            'Other': 'unknown'}
 
+wind_forecast_url = 'https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getWindForecast&returnType=json'
 
 # To quote the MISO data source;
 # "The category listed as “Other” is the combination of Hydro, Pumped Storage Hydro, Diesel, Demand Response Resources,
@@ -113,6 +114,27 @@ def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, log
     return data
 
 
+def fetch_wind_forecast(zone_key='US-MISO', session=None, target_datetime=None, logger=None):
+    req = requests.get(wind_forecast_url)
+    raw_json = req.json()
+    raw_data = raw_json['Forecast']
+
+    data = []
+    for item in raw_data:
+        dt = parser.parse(item['DateTimeEST']).replace(tzinfo=tz.gettz('America/New_York'))
+        value = float(item['Value'])
+
+        datapoint = {'datetime': dt,
+                     'value': value,
+                     'source': 'misoenergy.org',
+                     'zoneKey': zone_key}
+        data.append(datapoint)
+
+    return data
+
+
 if __name__ == '__main__':
     print('fetch_production() ->')
     print(fetch_production())
+    print('fetch_wind_forecast() ->')
+    #print(fetch_wind_forecast())


### PR DESCRIPTION
Let me know how you want this configuring in zones.json 

fixes #1788 

output;

```shell
fetch_wind_forecast() ->
[{'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 0, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11351.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 1, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11304.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11254.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 3, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11222.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 4, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11210.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 5, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11245.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 6, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11301.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 7, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11365.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 8, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11369.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 9, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11246.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 10, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11102.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 11, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11177.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 12, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11444.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 13, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11915.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 14, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12507.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 15, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13070.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 16, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13505.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 17, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13717.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 18, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13795.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 19, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13874.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 20, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13865.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 21, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13803.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 22, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13644.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 4, 23, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13435.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 0, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13258.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 1, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13103.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12926.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 3, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12865.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 4, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12925.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 5, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13045.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 6, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13199.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 7, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13429.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 8, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13457.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 9, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13320.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 10, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 13086.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 11, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12847.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 12, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12671.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 13, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12560.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 14, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12559.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 15, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12571.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 16, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12554.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 17, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12462.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 18, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 12187.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 19, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11734.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 20, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 11252.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 21, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 10810.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 22, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 10490.0}, {'zoneKey': 'US-MISO', 'source': 'misoenergy.org', 'datetime': datetime.datetime(2019, 3, 5, 23, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'value': 10261.0}]
```