### PR TITLE
update Prince Edward Island to new endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - Canada (New Brunswick): [NB Power](https://tso.nbpower.com/Public/en/op/market/data.aspx)
 - Canada (Nova Scotia): [Nova Scotia Power](http://www.nspower.ca/en/home/about-us/todayspower.aspx)
 - Canada (Ontario): [IESO](http://www.ieso.ca/power-data)
-- Canada (Prince Edward Island): [Government of PEI](http://www.gov.pe.ca/windenergy/chart.php)
+- Canada (Prince Edward Island): [Government of PEI](https://www.princeedwardisland.ca/en/feature/pei-wind-energy/)
 - Canada (Yukon): [Yukon Energy](http://www.yukonenergy.ca/energy-in-yukon/electricity-101/current-energy-consumption)
 - Chile (SIC): [SIC](https://sic.coordinador.cl/informes-y-documentos/fichas/operacion-real/)
 - Chile (SING): [SGER](https://sger.coordinadorelectrico.cl/Charts/AmChartCurvaCompuesta?showinfo=True)

--- a/config/zones.json
+++ b/config/zones.json
@@ -697,6 +697,7 @@
       "wind": 203.6
     },
     "contributors": [
+      "https://github.com/reinvented",
       "https://github.com/jarek"
     ],
     "flag_file_name": "ca.png",

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import json
+
 # The arrow library is used to handle datetimes consistently with other parsers
 import arrow
 
@@ -10,21 +12,46 @@ import requests
 timezone = 'Canada/Atlantic'
 
 
+def _find_pei_key(pei_list, sought_key):
+    matching_item = [item for item in pei_list
+                     if 'header' in item['data']
+                     and item['data']['header'].startswith(sought_key)]
+
+    if not matching_item:
+        return None
+
+    return matching_item[0]['data']['actualValue']
+
+
 def _get_pei_info(requests_obj):
-    url = 'http://www.gov.pe.ca/energy/js/chart-values.php'
-    response = requests_obj.get(url)
+    url = 'https://wdf.princeedwardisland.ca/workflow'
+    request = {'featureName': 'WindEnergy'}
+    headers = {'Content-Type': 'application/json'}
+    response = requests_obj.post(url, data=json.dumps(request), headers=headers)
 
-    raw_data = response.json()[0]
+    raw_data = response.json().get('data', [])
 
-    # meaning of keys per https://ruk.ca/content/open-data-pei-electricity
+    datetime_item = [item['data']['text'] for item in raw_data
+                     if 'text' in item['data']]
+    if not datetime_item:
+        # unable to get a timestamp, return empty
+        return None
+    datetime_text = datetime_item[0][len('Last updated '):]
+    data_timestamp = arrow.get(datetime_text, 'MMMM D, YYYY HH:mm A').replace(tzinfo='Canada/Atlantic')
+
+    # see https://ruk.ca/content/new-api-endpoint-pei-wind for more info
     data = {
-        'pei_load': raw_data['data1'],
-        'pei_wind_gen': raw_data['data2'],
-        'pei_fossil_gen': raw_data['data3'],  # "Fossil Fueled Generation"
-        'pei_wind_used': raw_data['data4'],
-        'pei_wind_exported': raw_data['data5'],
-        'utc_datetime': arrow.get(raw_data['updateDate']).datetime
+        'pei_load': _find_pei_key(raw_data, 'Total On-Island Load'),
+        'pei_wind_gen': _find_pei_key(raw_data, 'Total On-Island Wind Generation'),
+        'pei_fossil_gen': _find_pei_key(raw_data, 'Total On-Island Fossil Fuel Generation'),
+        'pei_wind_used': _find_pei_key(raw_data, 'Wind Power Used On Island'),
+        'pei_wind_exported': _find_pei_key(raw_data, 'Wind Power Exported Off Island'),
+        'datetime': data_timestamp.datetime
     }
+
+    # the following keys are always required downstream, if we don't have them, no sense returning
+    if data['pei_wind_gen'] is None or data['pei_fossil_gen'] is None:
+        return None
 
     return data
 
@@ -63,17 +90,20 @@ def fetch_production(zone_key='CA-PE', session=None, target_datetime=None, logge
         raise NotImplementedError('This parser is not yet able to parse past dates')
 
     requests_obj = session or requests.session()
-    raw_info = _get_pei_info(requests_obj)
+    pei_info = _get_pei_info(requests_obj)
+
+    if pei_info is None:
+        return None
 
     data = {
-        'datetime': raw_info['utc_datetime'],
+        'datetime': pei_info['datetime'],
         'zoneKey': zone_key,
         'production': {
-            'wind': raw_info['pei_wind_gen'],
+            'wind': pei_info['pei_wind_gen'],
 
             # These are oil-fueled ("heavy fuel oil" and "diesel") generators
             # used as peakers and back-up
-            'oil': raw_info['pei_fossil_gen'],
+            'oil': pei_info['pei_fossil_gen'],
 
             # specify some sources that definitely aren't present on PEI as zero,
             # this allows the analyzer to better estimate CO2eq
@@ -83,7 +113,7 @@ def fetch_production(zone_key='CA-PE', session=None, target_datetime=None, logge
             'geothermal': 0
         },
         'storage': {},
-        'source': 'www.gov.pe.ca/windenergy'
+        'source': 'princeedwardisland.ca'
     }
 
     return data
@@ -115,7 +145,10 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
         raise NotImplementedError('This exchange pair is not implemented')
 
     requests_obj = session or requests.session()
-    raw_data = _get_pei_info(requests_obj)
+    pei_info = _get_pei_info(requests_obj)
+
+    if pei_info is None or pei_info['pei_load'] is None:
+        return None
 
     # PEI imports most of its electricity. Everything not generated on island
     # is imported from New Brunswick.
@@ -130,16 +163,16 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
     # that doesn't actually reflect what happens on the wires.
     # (New Brunswick being the only interconnection with PEI, "exporting" wind power to NB
     # then "importing" a balance of NB electricity likely doesn't actually happen.)
-    imported_from_nb = (raw_data['pei_load'] - raw_data['pei_fossil_gen'] - raw_data['pei_wind_gen'])
+    imported_from_nb = (pei_info['pei_load'] - pei_info['pei_fossil_gen'] - pei_info['pei_wind_gen'])
 
     # In expected result, "net" represents an export.
     # We have sorted_zone_keys 'CA-NB->CA-PE', so it's export *from* NB,
     # and import *to* PEI.
     data = {
-        'datetime': raw_data['utc_datetime'],
+        'datetime': pei_info['datetime'],
         'sortedZoneKeys': sorted_zone_keys,
         'netFlow': imported_from_nb,
-        'source': 'www.gov.pe.ca/windenergy'
+        'source': 'princeedwardisland.ca'
     }
 
     return data


### PR DESCRIPTION
PEI data is currently stuck at source: https://www.princeedwardisland.ca/en/feature/pei-wind-energy/ says "Last updated March 10, 2019 08:45 AM" where current time there is 14:50.

The "old" API endpoint we were using returns the stuck data, but with updating timestamp, resulting in the following graph:

![pei_not_updating](https://user-images.githubusercontent.com/47415/54089101-a7de3580-433b-11e9-8a51-65413e51efb3.png)

As we've known about a "new" endpoint from #166, and it (seemingly correctly) reports time of last update, switch to that one.