### PR TITLE
Change position of biomass and geothermal

### DIFF
--- a/web/src/helpers/constants.js
+++ b/web/src/helpers/constants.js
@@ -16,14 +16,14 @@ const modeColor = {
 };
 const modeOrder = [
   'nuclear',
-  'coal',
   'geothermal',
+  'biomass',
+  'coal',
   'wind',
   'solar',
   'hydro',
   'hydro storage',
   'battery storage',
-  'biomass',
   'gas',
   'oil',
   'unknown',


### PR DESCRIPTION
This will change the position of biomass and geothermal to a "baseload" position in the lower part of the area plots for the 24 hour production mix.
The almost constant production of these sources will be better comprehensible for the eye.