### PR TITLE
Update US-IPC recent api-adress

### DIFF
--- a/parsers/US_IPC.py
+++ b/parsers/US_IPC.py
@@ -23,7 +23,7 @@ GENERATION_MAPPING = {'Non-Utility Geothermal': 'geothermal',
                       'PURPA/Non-Utility Wind': 'wind',
                       'Natural Gas': 'gas',
                       'PURPA/Non-Utility Solar': 'solar'
-                      #'PURPA Other': 'biomass'
+                      'PURPA Other': 'biomass'
                       }
 
 TIMEZONE = tz.gettz("America/Boise")

--- a/parsers/US_IPC.py
+++ b/parsers/US_IPC.py
@@ -22,7 +22,7 @@ GENERATION_MAPPING = {'Non-Utility Geothermal': 'geothermal',
                       'Diesel': 'oil',
                       'PURPA/Non-Utility Wind': 'wind',
                       'Natural Gas': 'gas',
-                      'PURPA/Non-Utility Solar': 'solar'
+                      'PURPA/Non-Utility Solar': 'solar',
                       'PURPA Other': 'biomass'
                       }
 

--- a/parsers/US_IPC.py
+++ b/parsers/US_IPC.py
@@ -14,7 +14,7 @@ import requests
 # Renewable energy (PURPA) is likely bought with credits from outside the Utility
 # area and not supplied to customers. For that reason those types are commented out.
 
-PRODUCTION_URL = 'https://api.idahopower.com/Energy/Api/V1/GenerationAndDemand/Subset'
+PRODUCTION_URL = 'https://api.idahopower.com/IdaStream/Api/V1/GenerationAndDemand/Subset'
 
 GENERATION_MAPPING = {'Non-Utility Geothermal': 'geothermal',
                       'Hydro': 'hydro',

--- a/parsers/US_IPC.py
+++ b/parsers/US_IPC.py
@@ -60,7 +60,7 @@ def data_processer(raw_data, logger):
     dt_key = lambda x: x['datetime']
     grouped = groupby(raw_data, dt_key)
 
-    keys_to_ignore = {'Load', 'Net Purchases', 'Inadvertent', 'PURPA Other'}
+    keys_to_ignore = {'Load', 'Net Purchases', 'Inadvertent'}
     known_keys = GENERATION_MAPPING.keys() | keys_to_ignore
 
     unmapped = set()


### PR DESCRIPTION
The production data of Idaho Power went missing on the map a while ago.

The api-URL has changed to https://api.idahopower.com/IdaStream/Api/V1/GenerationAndDemand/Subset
I also activated the "PURPA Other" category in biomass according to the description on idahopower's website (https://www.idahopower.com/energy/delivering-power/generation-and-demand/)

Sample output with new URL:

fetch_production() ->
[{'zoneKey': 'US-IPC', 'datetime': datetime.datetime(2019, 3, 19, 0, 0, tzinfo=tzfile('America/Boise')), 'production': {'geothermal': 39.0, 'biomass': 45.0, 'wind': 46.0, 'solar': 0.0, 'oil': 0.0, 'gas': 0.0, 'coal': 215.0, 'hydro': 1529.0}, 'storage': {}, 'source': 'idahopower.com'}, {'zoneKey': 'US-IPC', 'datetime': datetime.datetime(2019, 3, 19, 1, 0, tzinfo=tzfile('America/Boise')), 'production': {'geothermal': 30.0, 'biomass': 43.0, 'wind': 61.0, 'solar': 0.0, 'oil': 0.0, 'gas': 0.0, 'coal': 216.0, 'hydro': 1514.0}, 'storage': {}, 'source': 'idahopower.com'},
