### PR TITLE
US-CAISO capacity update

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,9 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
   - Federal: [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
   - BPA: [BPA](https://transmission.bpa.gov/business/operations/Wind/baltwg.aspx)
-  - CAISO: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
+  - CAISO
+    - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
+    - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
   - MISO: [MISO](https://www.misoenergy.org/about/media-center/corporate-fact-sheet/)
   - NYISO: [NYISO Gold Book](https://home.nyiso.com/wp-content/uploads/2017/12/2017_Gold-Book.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2017.ashx?la=en)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3616,10 +3616,11 @@
     ],
     "capacity": {
       "battery storage": 136,
-      "biomass": 997,
-      "geothermal": 1799,
-      "solar": 11172,
-      "wind": 6269
+      "biomass": 955,
+      "geothermal": 1785,
+      "nuclear": 2256,
+      "solar": 11799,
+      "wind": 6505
     },
     "contributors": [
       "https://github.com/7hibault",


### PR DESCRIPTION
- updated installed renewable capacity for CAISO as of 4th March 2019 according to http://www.caiso.com/informed/Pages/CleanGrid/default.aspx
- added installed nuclear capacity and source