### PR TITLE
Update URL for UY data source

### DIFF
--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -47,7 +47,7 @@ def get_salto_grande(session):
 
 def parse_page(session):
     r = session or requests.session()
-    url = 'http://www.ute.com.uy/SgePublico/ConsPotenciaGeneracionArbolXFuente.aspx'
+    url = 'https://apps.ute.com.uy/SgePublico/ConsPotenciaGeneracionArbolXFuente.aspx'
     response = requests.get(url)
     soup = BeautifulSoup(response.text, 'html.parser')
 


### PR DESCRIPTION
Another provider changed the URL of their transparency data.
Uruguay was offline for a while, and the data has moved to 
https://apps.ute.com.uy/SgePublico/ConsPotenciaGeneracionArbolXFuente.aspx

Sample output with new code: ✔️ 
fetch_production() ->
{'zoneKey': 'UY', 'datetime': datetime.datetime(2019, 3, 29, 13, 0, tzinfo=tzfile('America/Montevideo')), 'production': {'hydro': 1261.8, 'wind': 450.9, 'solar': 182.1, 'biomass': 91.7, 'oil': 0.0}, 'source': 'ute.com.uy'}
fetch_exchange(UY, BR) ->
{'sortedZoneKeys': 'BR->UY', 'datetime': datetime.datetime(2019, 3, 29, 13, 0, tzinfo=tzfile('America/Montevideo')), 'netFlow': -0.0, 'source': 'ute.com.uy'}
