### PR TITLE
Update README with clarification on how to run locally commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The frontend will need compiling. In order to do this, open a terminal in the ro
 ```
 docker-compose run --rm web npm run watch
 ```
-This will watch over source file changes, and recompile if needed.
+This will watch over source file changes, running nonstop and watching changes you make in the code to recompile the frontend if needed. For the next steps you will need to open a new terminal while this command keeps running.
 
 If you encounter any errors in the build process try the following command first:
 ```


### PR DESCRIPTION
Running locally instructions with docker now specify that `docker-compose run --rm web npm run watch` will run nonstop and you will need to open a new terminal for next commands.

I ask for review from @consideRatio 