### PR TITLE
Update BE's installed capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
   - Wind: [IGWindKraft](https://www.igwindkraft.at)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Belarus: [belstat.gov.by](http://www.belstat.gov.by/upload/iblock/7f7/7f70938f51eb9e49abc4a6e62f831a2c.rar), [RenEn](http://director.by/zhurnal/arkhiv-zhurnala/arkhiv-nomerov-2017/375-7-2017-iyul-2017/5456-zelenaya-energetika-nabiraet-oboroty)
-- Belgium: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- Belgium
+  - Hydro, Oil: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+  - Other: [ELIA](https://www.eliagroup.eu/-/media/project/elia/shared/documents/elia-group/publications-pdfs/20190411_gri18_elia_en.pdf)
 - Bolivia: [CNDC](http://www.cndc.bo/agentes/generacion.php)
 - Brazil: [ONS](http://www.ons.org.br/Paginas/resultados-da-operacao/historico-da-operacao/capacidade_instalada.aspx)
 - Bulgaria: [wikipedia.org](https://en.wikipedia.org/wiki/Energy_in_Bulgaria)

--- a/config/zones.json
+++ b/config/zones.json
@@ -309,7 +309,6 @@
     "timezone": "Asia/Dhaka"
   },
   "BE": {
-    "_comment": "entsoe coal figure outdated",
     "bounding_box": [
       [
         2.51357303225,
@@ -321,16 +320,16 @@
       ]
     ],
     "capacity": {
-      "biomass": 1076,
+      "biomass": 1113,
       "coal": 0,
-      "gas": 5811,
+      "gas": 6974,
       "geothermal": 0,
-      "hydro": 178,
+      "hydro": 181,
       "hydro storage": 1308,
       "nuclear": 5919,
-      "oil": 260,
-      "solar": 2953,
-      "wind": 2622
+      "oil": 334,
+      "solar": 3581,
+      "wind": 3247
     },
     "contributors": [
       "https://github.com/corradio"


### PR DESCRIPTION
Closes #1824 
Updated capacity in zones.json and source in README.md.
I used the most recent ENTSO-E figures for oil+hydro, but everything else comes from the new Elia source mentioned in #1824. :)