### PR TITLE
Add BY default carbon intensity

### DIFF
--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -788,6 +788,13 @@
       "fossilFuelRatio": 0.1336282447898255,
       "renewableRatio": 0.8563119118269659
     },
+    "BY": {
+      "_source": "IEA yearly data for 2016",
+      "_url": "https://www.iea.org/statistics/?country=BELARUS&year=2016&category=Electricity&indicator=ElecGenByFuel",
+      "carbonIntensity": 488,
+      "fossilFuelRatio": 0.99,
+      "renewableRatio": 0.01
+    },
     "CA-AB": {
       "_source": "Tomorrow",
       "carbonIntensity": 562.3496877300418,


### PR DESCRIPTION
Belarus (BY) is often exporting to Lithuania, and we haven't set a default carbon intensity for BY yet.
This will set the carbon intensity to 488 g/kWh, based on the latest available electricity mix values [by the IEA for 2016](https://www.iea.org/statistics/?country=BELARUS&year=2016&category=Electricity&indicator=ElecGenByFuel&mode=chart&dataTable=ELECTRICITYANDHEAT).