### PR TITLE
Fix direction of Moyle-interconnector

### DIFF
--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -152,7 +152,7 @@ def moyle_processor(df):
         snapshot = {}
         snapshot['datetime'] = add_default_tz(parser.parse(row['TimeStamp'],
                                                            dayfirst=True))
-        snapshot['netFlow'] = -1 * row['Total_Moyle_Load_MW']
+        snapshot['netFlow'] = row['Total_Moyle_Load_MW']
         snapshot['source'] = 'soni.ltd.uk'
         snapshot['sortedZoneKeys'] = 'GB->GB-NIR'
         datapoints.append(snapshot)


### PR DESCRIPTION
The exchange direction was accidentally flipped by me in PR #1823  due to the SortedZoneKeys pointing from GB->GB-NIR.