### PR TITLE
Add Armenia [work in progress]

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 &nbsp;<details><summary>Click to see the full list of sources</summary>
 - Åland: [Kraftnät Åland](http://www.kraftnat.ax/text2.con?iPage=28&iLan=1)
 - Argentina: [Cammesa](http://portalweb.cammesa.com/Memnet1/default.aspx)
+- Armenia: [Armenian Energy Power System Operator](http://epso.am/poweren.htm)  
 - Aruba: [WEB Aruba](https://www.webaruba.com/renewable-energy-dashboard/aruba) ([JSON](https://www.webaruba.com/renewable-energy-dashboard/app/rest/results.json))
 - Australia: [AREMI National Map](http://nationalmap.gov.au/renewables/)
   ([CSV](http://services.aremi.nationalmap.gov.au/aemo/v3/csv/all))
@@ -185,6 +186,9 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 Production capacities are centralized in the [zones.json](https://github.com/tmrowco/electricitymap-contrib/blob/master/config/zones.json) file.
 &nbsp;<details><summary>Click to see the full list of sources</summary>
 - Argentina: [Cammesa](http://portalweb.cammesa.com/Documentos%20compartidos/Noticias/Informe%20Anual%202016.pdf)
+- Armenia
+   - Biomass, Hydro, Solar, Wind: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=ARM)
+   - Nuclear, Gas: [wikipedia.org](https://en.wikipedia.org/wiki/List_of_power_stations_in_Armenia)
 - Aruba: [WEB Aruba](https://www.webaruba.com/energy-production/power-production-figures)
 - Australia [wikipedia.org](https://en.wikipedia.org/wiki/Wind_power_in_Australia#Wind_power_by_state)
 - Austria

--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -39,6 +39,26 @@
     },
     "rotation": 0
   },
+  "AM->AZ":{
+    "lonlat": [
+      46.0,
+      39.75
+     ],
+    "parsers": {
+      "exchange": "AM.fetch_exchange"
+    },
+    "rotation": 90
+  },
+  "AM->IR":{
+    "lonlat": [
+      46.3,
+      38.9
+      ],
+    "parsers": {
+      "exchange": "AM.fetch_exchange"
+    },
+    "rotation": 180
+  },
   "AR->BR-S": {
     "lonlat": [
       -56.407453,

--- a/config/zones.json
+++ b/config/zones.json
@@ -37,6 +37,16 @@
     "timezone": null
   },
   "AM": {
+     "bounding_box": [
+      [
+        43.0,
+        38.6
+      ],
+      [
+        46.3,
+        41.6
+      ]
+    ],
     "capacity": {
       "biomass": 1.3,
       "gas": 1832,
@@ -46,6 +56,8 @@
       "wind": 2.9
       },
     "contributors": [
+      "https://github.com/tmslaine",
+      "https://github.com/systemcatch",
       "https://github.com/alixunderplatz"
     ],
     "parsers": {

--- a/config/zones.json
+++ b/config/zones.json
@@ -36,6 +36,23 @@
     },
     "timezone": null
   },
+  "AM": {
+    "capacity": {
+      "biomass": 1.3,
+      "gas": 1832,
+      "hydro": 1326.8,
+      "nuclear": 440,
+      "solar": 2.4,
+      "wind": 2.9
+      },
+    "contributors": [
+      "https://github.com/alixunderplatz"
+    ],
+    "parsers": {
+      "production": "AM.fetch_production"
+    },
+    "timezone": "Asia/Yerevan"
+  },      
   "AR": {
     "capacity": {
       "gas": 18930,

--- a/parsers/AM.py
+++ b/parsers/AM.py
@@ -8,12 +8,15 @@ from dateutil import parser as dparser
 from dateutil import tz
 from bs4 import BeautifulSoup
 
+#URL of the power system summary: http://epso.am/poweren.htm
+#URL of the detailled SCADA-page: http://epso.am/scada.htm
+
 power_plant_mapping = {
     'var atom': 'nuclear', # atom = 'atomnaya elektro stantsiya'
     'var tes': 'gas',      # tes = 'termalnaya elektro stantsiya' - only gas in AM
     'var ges': 'hydro',    # ges = 'gidro elektro stantsiya'
-    'var altern': 'gas'    # alternative station = 'Այլընտրանքային կայանների' on the Armenian version of the website
-    }                      # "alternative" could translate to "renewable", but it's more likely that it's for a new gas unit (CCGT)
+    'var altern': 'hydro'  # altern = two hydro power plants according to SCADA data (middle row, right box)
+    }
 
 tie_line_mapping = {
     'var Lalvar': 'GE',
@@ -65,11 +68,11 @@ def fetch_production(zone_key='AM', session=None, target_datetime=None, logger=N
     data_split = data_string.split('\r\n')
 
     gas_tes = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[10])
-    gas_altern = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[8])
-    gas_total = float(gas_tes[0]) + float(gas_altern[0])
+    gas_total = float(gas_tes[0])
 
     hydro_ges = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[11])
-    hydro_total = float(hydro_ges[0])
+    hydro_altern = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[8])
+    hydro_total = float(hydro_ges[0])+float(hydro_altern[0])
 
     nuclear_atom = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[9])
     nuclear_total = float(nuclear_atom[0])

--- a/parsers/AM.py
+++ b/parsers/AM.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+import arrow
+import re
+import requests
+from dateutil import parser as dparser
+from dateutil import tz
+from bs4 import BeautifulSoup
+
+power_plant_mapping = {
+    'var atom': 'nuclear', # atom = 'atomnaya elektro stantsiya'
+    'var tes': 'gas',      # tes = 'termalnaya elektro stantsiya' - only gas in AM
+    'var ges': 'hydro',    # ges = 'gidro elektro stantsiya'
+    'var altern': 'gas'    # alternative station = 'Այլընտրանքային կայանների' on the Armenian version of the website
+    }                      # "alternative" could translate to "renewable", but it's more likely that it's for a new gas unit (CCGT)
+
+tie_line_mapping = {
+    'var Lalvar': 'GE',
+    'var ninoc': 'GE',
+    'var alaver': 'GE',
+    'var shin': 'AZ(AM)',
+    'var arcakh': 'AZ(AM)',
+    'var ahar': 'IR'
+    }
+
+other_variables_mapping = {
+    'var cons': 'total production', #please note, this is an error of the variable name ('cons' is actually used for total production)
+    'var peretok': 'total import/export', #positive = import, negative = export
+    'var herc2': 'frequency',       #"hertz" ;)
+    'var time2': 'timestamp',       #date is missing
+    'sparum2': 'total consumption', #please note, this is an error of the variable name (probably means "production", but is used for consumption)
+    }
+
+soup_content_variables_mapping = {
+    '[0]' : 'empty',
+    '[1]' : 'Lalvar (GE)',
+    '[2]' : 'ninoc (GE)',
+    '[3]' : 'alaver (GE)',
+    '[4]' : 'shin (AZ)',
+    '[5]' : 'arcakh (AZ)',
+    '[6]' : 'ahar (IR)',
+    '[7]' : 'cons [total production]',
+    '[8]' : ' altern',
+    '[9]' : 'atom',
+    '[10]' : 'tes',
+    '[11]' : 'ges',
+    '[12]' : 'peretok',
+    '[13]' : 'herc2',
+    '[14]' : 'time2',
+    '[15]' : 'sparum2 []',
+    '[16]' : 'empty',
+    '[17]' : 'empty',
+    }
+
+def fetch_production(zone_key='AM', session=None, target_datetime=None, logger=None):
+    r = session or requests.session()
+    url = 'http://epso.am/poweren.htm'
+    response = r.get(url)
+    response.encoding = 'utf-8'
+    html_doc = response.text
+    soup = BeautifulSoup(html_doc, 'html.parser')
+
+    data_string = soup.find(text=re.compile('var'))
+    data_split = data_string.split('\r\n')
+
+    gas_tes = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[10])
+    gas_altern = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[8])
+    gas_total = float(gas_tes[0]) + float(gas_altern[0])
+
+    hydro_ges = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[11])
+    hydro_total = float(hydro_ges[0])
+
+    nuclear_atom = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[9])
+    nuclear_total = float(nuclear_atom[0])
+
+    time_string = dparser.parse(data_split[14].split()[3],fuzzy=True)
+    date_time = time_string.replace(tzinfo=tz.gettz('Asia/Yerevan'))
+
+    #Operating solar, wind and biomass plants exist in small numbers, but are not reported yet
+    data = {
+        'zoneKey': zone_key,
+        'datetime': date_time,
+        'production': {
+            'gas': gas_total,
+            'hydro': hydro_total,
+            'nuclear': nuclear_total,
+            'coal': 0,
+            'geothermal': 0,
+            'oil': 0
+            },
+        'storage': {
+            'hydro storage': 0,
+            'battery storage': 0
+            },
+        'source': 'http://epso.am/poweren.htm'
+    }
+
+    return data
+
+
+def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
+    """Requests the last known power exchange (in MW) between two countries
+    Arguments:
+    zone_key (optional) -- used in case a parser is able to fetch multiple countries
+    session (optional)      -- request session passed in order to re-use an existing session
+    Return:
+    A dictionary in the form:
+    {
+      'sortedZoneKeys': 'DK->NO',
+      'datetime': '2017-01-01T00:00:00Z',
+      'netFlow': 0.0,
+      'source': 'mysource.com'
+    }
+    """
+
+    r = session or requests.session()
+    url = 'http://epso.am/poweren.htm'
+    response = r.get(url)
+    response.encoding = 'utf-8'
+    html_doc = response.text
+    soup = BeautifulSoup(html_doc, 'html.parser')
+
+    data_string = soup.find(text=re.compile('var'))
+    data_split = data_string.split('\r\n')
+    GE_1 = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[1])
+    GE_2 = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[2])
+    GE_3 = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[3])
+    AZ_1 = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[4])
+    AZ_2 = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[5])
+    IR_1 = re.findall("[-+]?[.]?[\d]+(?:,\d\d\d)*[\.]?\d*(?:[eE][-+]?\d+)?", data_split[6])
+
+    AM_AZ = float(AZ_1[0])+float(AZ_2[0])
+    AM_GE = float(GE_1[0])+float(GE_2[0])+float(GE_3[0])
+    AM_IR = float(IR_1[0])
+
+    time_string = dparser.parse(data_split[14].split()[3],fuzzy=True)
+    date_time = time_string.replace(tzinfo=tz.gettz('Asia/Yerevan'))
+ 
+    if '->'.join(sorted([zone_key1, zone_key2])) == 'AM->AZ':
+        AM_AZ_exchange = {
+            'datetime': date_time,
+            'netFlow': -1* AM_AZ,
+            'source': 'http://epso.am/poweren.htm',
+            'sortedZoneKeys': 'AM->AZ'
+            }
+        return AM_AZ_exchange
+    elif '->'.join(sorted([zone_key1, zone_key2])) == 'AM->GE':
+        AM_GE_exchange = {
+            'datetime': date_time,
+            'netFlow': -1 * AM_GE,
+            'source': 'http://epso.am/poweren.htm',
+            'sortedZoneKeys': 'AM-GE'
+            }
+        return AM_GE_exchange
+    elif '->'.join(sorted([zone_key1, zone_key2])) == 'AM->IR':
+        AM_IR_exchange = {
+            'datetime': date_time,
+            'netFlow': -1 * AM_IR,
+            'source': 'http://epso.am/poweren.htm',
+            'sortedZoneKeys': 'AM->IR'
+            }
+        return AM_IR_exchange
+    else:
+        raise NotImplementedError('This exchange pair is not implemented')
+
+if __name__ == '__main__':
+    print('fetch_production->')
+    print(fetch_production())
+    print('fetch_exchange(AM, AZ) ->')
+    print(fetch_exchange('AM', 'AZ'))
+    print('fetch_exchange(AM, GE) ->')
+    print(fetch_exchange('AM', 'GE'))
+    print('fetch_exchange(AM, IR) ->')
+    print(fetch_exchange('AM', 'IR'))

--- a/parsers/AM.py
+++ b/parsers/AM.py
@@ -88,9 +88,12 @@ def fetch_production(zone_key='AM', session=None, target_datetime=None, logger=N
             'gas': gas_total,
             'hydro': hydro_total,
             'nuclear': nuclear_total,
+            'biomass': None,
             'coal': 0,
             'geothermal': 0,
-            'oil': 0
+            'oil': 0,
+            'solar': None,
+            'wind': None
             },
         'storage': {
             'hydro': 0,


### PR DESCRIPTION
The basic parser for Armenia 🇦🇲 is done :) High data frequency:  updated every minute 👍 👍 👍 
Thanks for the support @corradio! 👍
 
Now I need you guys to **carefully check and to improve** it! 😄 
Feel free to add your tweaks directly or comment the lines with your suggestions.
**Please add a list of what still has to be adjusted in other files to get this thing working ;)**

_______________________________
Sample output:

```
fetch_production ->
{'zoneKey': 'AM', 'datetime': datetime.datetime(2019, 4, 18, 23, 59, tzinfo=tzfile('Asia/Yerevan')), 'production': {'gas': 225.0, 'hydro': 451.0, 'nuclear': 224.0, 'coal': 0, 'geothermal': 0, 'oil': 0}, 'storage': {'hydro storage': 0, 'battery storage': 0}, 'source': 'http://epso.am/poweren.htm'}
fetch_exchange(AM, AZ) ->
{'datetime': datetime.datetime(2019, 4, 18, 23, 59, tzinfo=tzfile('Asia/Yerevan')), 'netFlow': -17.5, 'source': 'http://epso.am/poweren.htm', 'sortedZoneKeys': 'AM->AZ'}
fetch_exchange(AM, GE) ->
{'datetime': datetime.datetime(2019, 4, 18, 23, 59, tzinfo=tzfile('Asia/Yerevan')), 'netFlow': -0.0, 'source': 'http://epso.am/poweren.htm', 'sortedZoneKeys': 'AM-GE'}
fetch_exchange(AM, IR) ->
{'datetime': datetime.datetime(2019, 4, 18, 23, 59, tzinfo=tzfile('Asia/Yerevan')), 'netFlow': 266.5, 'source': 'http://epso.am/poweren.htm', 'sortedZoneKeys': 'AM->IR'}
```
_______________________________
There is one problem with the timestamp I just got aware of:
The html only delivers the time (HH:mm) of the data, but not the date. This time is passed to time_string using dateutil, which automatically sets the timestamp's date.
"00:25" -> 2019-04-18 00:25:00
The point is, my machine's local time is used instead of Armenia's time. That's why it returns the 18th of April, although its the 19th in Armenia already.
Someone needs to fix the merge of time_string with the correct current date in Armenia. Or we simply use arrow.now(tz='Asia/Yerevan'), the difference is like 1 minute...
_______________
I make the request from the same URL, with the same lines of code two seperate times, in fetch_production and fetch_exchange, although one requst should be sufficient ;)
It's probably better to make the request for all the data in one step, because sometimes the connection closes, causing an error (maybe some error handling at this point: retry to reach the data url after 3 seconds or so...). This could lead to data gaps for either exchange or production, I guess?
_______________

Basically I extract the desired info and then the numbers from the html.
Here is what the souped html part of interest looks like (see data_string in my code and see mappings for variable description):

```
var Lalvar = "0"
var ninoc = "0"
var alaver = "0"
var shin = "-4.2"
var arcakh = "21.7"
var ahar = "-266.5"
var cons = "901"
var altern = "0"
var atom = "224"
var tes = "225"
var ges = "451"
var peretok = "-249.00"
var herc2 = "50.01"
var time2 = "23:59"
var sparum2 = "650"
```
__________________________
last but not least: Thanks to all you parser-writers for your code snippets ;) & to all q&a on stackoverflow and similar pages!
_________________________
Closes #1253 
"If it looks stupid, but it works, it ain't stupid" 😆