### PR TITLE
Update to fix US-BPA

### DIFF
--- a/parsers/US_BPA.py
+++ b/parsers/US_BPA.py
@@ -68,7 +68,7 @@ def data_processor(df, logger):
         production = row.to_dict()
 
         dt = production.pop('Date/Time')
-        dt = dt.to_datetime()
+        dt = dt.to_pydatetime()
         mapped_production = {GENERATION_MAPPING[k]:v for k,v in production.items()
                              if k not in keys_to_remove}
 


### PR DESCRIPTION
- pandas to_datetime() is deprecated, use to_pydatetime() instead.

ref #1833 