### PR TITLE
Updated DE capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -967,17 +967,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 7720,
-      "coal": 45380,
-      "gas": 29630,
+      "biomass": 7740,
+      "coal": 44910,
+      "gas": 29390,
       "geothermal": 38,
-      "hydro": 5500,
-      "hydro storage": 9440,
+      "hydro": 4800,
+      "hydro storage": 9600,
       "nuclear": 9516,
       "oil": 4300,
-      "solar": 45550,
+      "solar": 47200,
       "unknown": 3137,
-      "wind": 59240
+      "wind": 59830
     },
     "contributors": [
       "https://github.com/corradio"


### PR DESCRIPTION
Updated installed netto capacity in Germany. 
Source: Frauenhofer ISE (last update: 2.05.19)
https://www.energy-charts.de/power_inst_de.htm