### PR TITLE
Fix CA-AB

### DIFF
--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -64,8 +64,8 @@ def fetch_production(zone_key='CA-AB', session=None, target_datetime=None, logge
     dt = convert_time_str(time_string)
 
     df_generations = pd.read_html(response.text, match='GENERATION', skiprows=1, index_col=0, header=0)
-    total_net_generation = df_generations[1]['TNG']
-    maximum_capability = df_generations[1]['MC']
+    total_net_generation = df_generations[2]['TNG']
+    maximum_capability = df_generations[2]['MC']
 
     return {
         'datetime': dt,


### PR DESCRIPTION
Maybe the tables on the website were rearranged a bit. 
Setting  `total_net_generation = df_generations[1]..`. to     `total_net_generation = df_generations[2]...` has fixed CA-AB :)
ref #1833

Sample output:
```python
{'datetime': datetime.datetime(2019, 5, 5, 2, 33, tzinfo=<DstTzInfo 'Canada/Mountain' MDT-1 day, 18:00:00 DST>), 'zoneKey': 'CA-AB', 'production': {'coal': 3065.0, 'gas': 5269.0, 'hydro': 84.0, 'wind': 24.0, 'unknown': 192.0}, 'capacity': {'coal': 5723.0, 'gas': 7641.0, 'hydro': 894.0, 'wind': 1445.0, 'unknown': 438.0}, 'source': 'ets.aeso.ca'}
```