### PR TITLE
Fix GT mapping

### DIFF
--- a/parsers/GT.py
+++ b/parsers/GT.py
@@ -11,6 +11,7 @@ import pandas as pd
 tz_gt = 'America/Guatemala'
 
 MAP_GENERATION = {
+    'biomass': u'Biogas',
     'coal': 'Turbina de Vapor',
     'gas': 'Turbina de Gas',
     'hydro': u'Hidroeléctrica',
@@ -34,10 +35,7 @@ def fetch_hourly_production(zone_key, obj, hour, date):
     # Fill datetime variable
     data['datetime'] = arrow.get(date, 'DD/MM/YYYY').replace(tzinfo=tz_gt, hour=hour).datetime
 
-    # First add 'Biomasa' and 'Biogas' together to make 'biomass' variable (and avoid negative
-    # values)
-    data['production']['biomass'] = max(obj[obj['tipo'] == 'Biomasa'].potencia.iloc[0], 0) + max(obj[obj['tipo'] == 'Biogas'].potencia.iloc[0], 0)
-    # Then fill the other sources directly with the MAP_GENERATION frame
+    # Fill the sources with the MAP_GENERATION frame
     for i_type in MAP_GENERATION.keys():
         val = obj[obj['tipo'] == MAP_GENERATION[i_type]].potencia.iloc[0]
         if i_type == 'oil' and val > -1:


### PR DESCRIPTION
The "Biomasa" category had disappeared from the data, so adding Biogas+Biomasa wouldn't work.
Fixed the parser and added 'Biogas' to MAP_GENERATION at the beginning.
ref #1833 

Sample output:
`
fetch_production() ->
[{'zoneKey': 'GT', 'production': {'biomass': 3.0, 'coal': 809.5, 'gas': 0.0, 'hydro': 236.5, 'oil': 9.1, 'solar': 0.0, 'wind': 0.7, 'geothermal': 32.8}, 'storage': {}, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 0, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'production': {'biomass': 0.0, 'coal': 840.1278, 'gas': 0.075, 'hydro': 119.3845, 'oil': 10.8034, 'solar': 0.0, 'wind': 2.45, 'geothermal': 32.99}, 'storage': {}, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 1, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'production': {'biomass': 3.214, 'coal': 893.824, 'gas': 0.0, 'hydro': 178.15, 'oil': 21.274, 'solar': 0.0, 'wind': 1.17, 'geothermal': 28.269}, 'storage': {}, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 2, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'production': {'biomass': 0.0, 'coal': 917.1326, 'gas': 0.035, 'hydro': 177.5884, 'oil': 8.895, 'solar': 0.0, 'wind': 0.2325, 'geothermal': 32.27}, 'storage': {}, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 3, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'production': {'biomass': 3.214, 'coal': 890.163, 'gas': 0.0, 'hydro': 164.644, 'oil': 10.15, 'solar': 0.0, 'wind': 1.01, 'geothermal': 28.269}, 'storage': {}, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 4, 0, tzinfo=tzfile('America/Guatemala'))}]
`
and
`
fetch_consumption() ->
[{'zoneKey': 'GT', 'consumption': 1071.7, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 0, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'consumption': 981.5542, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 1, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'consumption': 956.761, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 2, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'consumption': 941.5608, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 3, 0, tzinfo=tzfile('America/Guatemala'))}, {'zoneKey': 'GT', 'consumption': 936.11, 'source': 'amm.org.gt', 'datetime': datetime.datetime(2019, 5, 5, 4, 0, tzinfo=tzfile('America/Guatemala'))}]
`