### PR TITLE
Adjust JP storage format

### DIFF
--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -59,7 +59,10 @@ def fetch_production(zone_key='JP-TK', session=None, target_datetime=None,
                 'geothermal': None,
                 'unknown': df.loc[i, 'unknown']
             },
-            'storage': None,
+            'storage': {
+                'hydro': None,
+                'battery': None
+            },
             'source': 'occtonet.or.jp, {}'.format(sources[zone_key]),
             }
         datalist.append(data)

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -59,10 +59,6 @@ def fetch_production(zone_key='JP-TK', session=None, target_datetime=None,
                 'geothermal': None,
                 'unknown': df.loc[i, 'unknown']
             },
-            'storage': {
-                'hydro': None,
-                'battery': None
-            },
             'source': 'occtonet.or.jp, {}'.format(sources[zone_key]),
             }
         datalist.append(data)


### PR DESCRIPTION
I hope this small adjustment will fix the quality issue mentioned in @systemcatch 's comment in #1833:

> JP parsers failing quality test
> 
> `> invalid point: {'zoneKey': 'JP-HKD', 'datetime': datetime.datetime(2019, 4, 28, 0, 20, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Tokyo')), 'production': {'biomass': None, 'coal': None, 'gas': None, 'hydro': None, 'nuclear': None, 'oil': None, 'solar': None, 'wind': None, 'geothermal': None, 'unknown': 2791.0}, 'storage': None, 'source': 'occtonet.or.jp, denkiyoho.hepco.co.jp', 'schemaVersion': 3}, reason:storage value must be a dict, was None
> `

Now the parser output for storage is:
`'storage': {'hydro': None, 'battery': None}`
