### PR TITLE
Replace exchange values AM->GE with AM parser

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -35,7 +35,7 @@
       41.205
     ],
     "parsers": {
-      "exchange": "GE.fetch_exchange"
+      "exchange": "AM.fetch_exchange"
     },
     "rotation": 0
   },


### PR DESCRIPTION
It seems that the Georgian source ( http://gse.com.ge/home ) does provide only power exchanges for the 220kV electric lines (OHTL Alaverdi), but not for the 110kV lines (OHTL Lalvar and OHTL Ninotsminda), that are shown on the Armenian source ( http://epso.am/poweren.htm ). This amounts to a small difference of up to 2MW depending on the time of the day. This commit proposes to use the latter for computing the exchange values.