### PR TITLE
Fixing french name for Greenland

### DIFF
--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -603,7 +603,7 @@
             "zoneName": "Gibraltar"
         },
         "GL": {
-            "zoneName": "Greonland"
+            "zoneName": "Groenland"
         },
         "GM": {
             "zoneName": "Gambie"


### PR DESCRIPTION
Minor change to fix the name of Greenland in French locale.