### PR TITLE
Automatic ENTSOE capacity updates

### DIFF
--- a/utils/ENTSOE_capacity_update.py
+++ b/utils/ENTSOE_capacity_update.py
@@ -17,7 +17,7 @@ def update_zone(zone, data, zonesfile):
 		zones = json.load(zf)
 
 	if zone not in zones:
-		raise ValueError(f"Zone {zone} does not exist in the zonesfile")
+		raise ValueError("Zone {} does not exist in the zonesfile".format(zone))
 
 	zones[zone]["capacity"].update(data)
 
@@ -62,17 +62,19 @@ def main():
 	data_file = args.data_file
 
 	if not os.path.exists(zonesfile):
-		print(f"ERROR: Zonesfile {zonesfile} does not exist.", file=sys.stderr)
+		print("ERROR: Zonesfile {} does not exist.".format(zonesfile),
+			  file=sys.stderr)
 		sys.exit(1)
 	if not os.path.exists(data_file):
-		print(f"ERROR: Data file {data_file} does not exist.", file=sys.stderr)
+		print("ERROR: Data file {} does not exist.".format(data_file),
+			  file=sys.stderr)
 		sys.exit(1)
 	
 	data = pd.read_csv(data_file).set_index("Production Type").to_dict()
 	aggregated_data = aggregate_data(data)
 
-	print(f"Aggregated capacities: {json.dumps(aggregated_data)}")
-	print(f"Updating zone {zone}")
+	print("Aggregated capacities: {}".format(json.dumps(aggregated_data)))
+	print("Updating zone {}".format(zone))
 
 	update_zone(zone, aggregated_data, zonesfile)
 

--- a/utils/update_capacities_entsoe.py
+++ b/utils/update_capacities_entsoe.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import argparse
+import pandas as pd
+import json
+import pathlib
+
+from parsers.ENTSOE import ENTSOE_PARAMETER_DESC, ENTSOE_PARAMETER_GROUPS
+
+ZONESFILE = pathlib.Path(__file__).parent.parent / "config" / "zones.json"
+
+
+def update_zone(zone, data, zonesfile):
+	with open(zonesfile) as zf:
+		zones = json.load(zf)
+
+	zones[zone]["capacity"].update(data)
+
+	with open(zonesfile, "w") as zf:
+		json.dump(zones, zf, indent=2)
+		zf.write("\n")
+
+
+def aggregate_data(data):
+	"""Aggregates data the way it is stated in
+	   parsers.ENTSOE.ENTSOE_PARAMETER_GROUPS"""
+	if len(data) > 1:
+		# assume keys start with YYYY
+		sorted_keys = list(sorted(data.keys()))
+		data = data[sorted_keys[-1]]
+	else:
+		data = next(iter(data.values()))
+
+	categories = dict(ENTSOE_PARAMETER_GROUPS["production"])
+	categories.update(ENTSOE_PARAMETER_GROUPS["storage"])
+
+	aggregated = {}
+	for group, category_abbreviations in categories.items():
+		category_descriptions = list(map(lambda x: ENTSOE_PARAMETER_DESC[x], category_abbreviations))
+		aggregated[group] = sum(data[c] for c in category_descriptions)
+
+	return aggregated
+
+
+def parse_args():
+	parser = argparse.ArgumentParser()
+	parser.add_argument("zone", help="The zone abbreviation (e.g. AT)")
+	parser.add_argument("data_file", help="The csv file from ENTSOE containing the installed capacities")
+	parser.add_argument("--zonesfile", default=ZONESFILE)
+	return parser.parse_args()
+
+
+def main():
+	args = parse_args()
+	
+	zone = args.zone
+	zonesfile = args.zonesfile
+	data_file = args.data_file
+	data = pd.read_csv(data_file).set_index("Production Type").to_dict()
+
+	aggregated_data = aggregate_data(data)
+	print(json.dumps(aggregated_data))
+
+	update_zone(zone, aggregated_data, zonesfile)
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
As already announced in #1893 I created a script which allows for updating production capacities in the file `zones.json` by using CSV files exported from the [ENTSOE page for installed capacities](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show).

The aggregation of values is done by using the mapping defined in parsers.ENTSOE.ENTSOE_PARAMETER_GROUPS. At the moment that is:

    biomass -> "Biomass" + "Waste"
    coal -> "Fossil Brown coal/Lignite" + "Fossil Hard coal" + "Fossil Oil shale" + "Fossil Peat"
    gas -> "Fossil Coal-derived gas" + "Fossil Gas"
    geothermal -> "Geothermal"
    hydro -> "Hydro Run-of-river and poundage" + "Hydro Water Reservoir"
    nuclear -> "Nuclear"
    oil -> "Fossil Oil"
    solar -> "Solar"
    wind -> "Wind Offshore" + "Wind Onshore"
    unknown -> "Other" + "Marine" + "Other renewable"
    hydro storage -> "Hydro Pumped Storage"

The mapping is not hard coded, though, but loaded directly from the parser file. That means if the names or the assignment change somehow the behaviour of my script will change as well.

For me, the following questions are still open:

- Is there a possibility to download data for multiple countries from ENTSOE simulatneously or is there even an API which I could query to fetch the capacity data? In this case it would be very easy to extend the script to handle multiple zones in the same run.
- Does the location of the file make sense where it is?
- The script depends on pandas for CSV parsing because it's so convenient. If this dependency is a problem for you it can be easily converted to use python's built-in csv parser.

I am happy to hear your feedback! :-)
