### PR TITLE
Fix CA-AB dataframe handling

### DIFF
--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -64,8 +64,13 @@ def fetch_production(zone_key='CA-AB', session=None, target_datetime=None, logge
     dt = convert_time_str(time_string)
 
     df_generations = pd.read_html(response.text, match='GENERATION', skiprows=1, index_col=0, header=0)
-    total_net_generation = df_generations[2]['TNG']
-    maximum_capability = df_generations[2]['MC']
+
+    for idx, df in enumerate(df_generations):
+        try:
+            total_net_generation = df_generations[idx]['TNG']
+            maximum_capability = df_generations[idx]['MC']
+        except KeyError:
+            continue
 
     return {
         'datetime': dt,


### PR DESCRIPTION
This is an another attempt to fix the problem with CA-AB (see #1845 before). The parser will try each df found rather than trying by index. However I'm not that happy with this solution as I still don't get why read_html is matching 2 dfs rather than just one.

ref #1833 