### PR TITLE
Fix electricity sources for IN_DL

### DIFF
--- a/parsers/IN_DL.py
+++ b/parsers/IN_DL.py
@@ -5,6 +5,14 @@ from .lib import web
 from .lib import zonekey
 from .lib import IN
 
+plants = {
+    "CCGT-Bawana": "Gas",
+    "DMSWSL-Dsidc": "G2E",
+    "EDWPL-Gazipur": "G2E",
+    "GT": "Gas",
+    "Pragati": "Gas",
+    "TOWMP-Okhla": "G2E"
+}
 
 def fetch_consumption(zone_key='IN-DL', session=None, target_datetime=None, logger=None):
     """Fetch Delhi consumption"""
@@ -32,7 +40,13 @@ def fetch_production(zone_key='IN-DL', session=None, target_datetime=None, logge
     """Fetch Delhi production"""
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
-    
+
+    energy = {
+        "Gas": 0,
+        "G2E": 0,
+        "Coal": 0
+    }
+
     zonekey.assert_zone_key(zone_key, 'IN-DL')
 
     html = web.get_response_soup(zone_key, 'http://www.delhisldc.org/Redirect.aspx?Loc=0804', session)
@@ -43,53 +57,28 @@ def fetch_production(zone_key='IN-DL', session=None, target_datetime=None, logge
     prod_table = html.find("table", {"id": "ContentPlaceHolder3_dgenco"})
     prod_rows = prod_table.findAll('tr')
 
-    # BTPS https://en.wikipedia.org/wiki/Badarpur_Thermal_Power_Station
-    btps = read_value(prod_rows[1])
-
-    # CCGT https://en.wikipedia.org/wiki/Pragati-III_Combined_Cycle_Power_Plant = Pragati-3
-    ccgt = read_value(prod_rows[2])
-
-    # DMSWSL (Delhi Municipal Solid Waste Solutions Limited): Garbage-to-electricity
-    dmswsl = read_value(prod_rows[3])
-
-    # EDWPL (East Delhi Waste Processing Company Limited): Garbage-to-electricity
-    edwpl = read_value(prod_rows[4])
-
-    # GT (Gas Turbine) https://en.wikipedia.org/wiki/IPGCL_Gas_Turbine_Power_Station
-    gt = read_value(prod_rows[5])
-
-    # Pragati https://en.wikipedia.org/wiki/Pragati-I_Combined_Cycle_Gas_Power_Station = Pragati-1
-    pragati = read_value(prod_rows[6])
-
-    # TOWMP (Timarpur Okhla Waste Management Company Pvt. Ltd.): Garbage-to-electricity
-    towmp = read_value(prod_rows[7])
-
-    # Coal production
-    coal = btps
-
-    # Gas production
-    gas = ccgt + pragati + gt
-
-    # Unknown production
-    garbage = dmswsl + edwpl + towmp
+    for plant in range(1, len(plants) + 1):
+        energy[plants[read_name(prod_rows[plant])]] += read_value(prod_rows[plant])
 
     data = {
         'zoneKey': zone_key,
         'datetime': india_date_time.datetime,
         'production': {
-            'coal': coal,
-            'gas': gas,
-            'biomass': garbage
+            'coal': energy["Coal"],
+            'gas': energy["Gas"],
+            'biomass': energy["G2E"]
         },
         'source': 'delhisldc.org',
     }
 
     return data
 
-def read_value(row):
-    value = float(row.findAll('td')[2].text)
+def read_value(row, index=2):
+    value = float(row.findAll('td')[index].text)
     return value if value >= 0.0 else 0.0
 
+def read_name(row, index=0):
+    return row.findAll('td')[index].text
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The data source for New Delhi in India has changed to reflect the shutting down of the Badarpur Coal Thermal Power Station (https://timesofindia.indiatimes.com/city/delhi/badarpur-thermal-plant-shut-for-good/articleshow/66228551.cms) in October 2018.

The parser had been designed to read the rows of an HTML table and assign data in sequential order. Following the change in the upstream data source, that sequence has changed as well. Therefore, the parser has been incorrectly assigning another plant's electricity generation data to Badarpur's. This means that since the time the dashboard had changed - quite a few months, at least - the parser has been malfunctioning.

This commit resolves this bug by using a library of names of power plants and the fuel source used in each. The electricity generation data is only assigned if the name of the plant from the HTML row matches the one in the library.