### PR TITLE
Force LF line endings on .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
This setting makes sure that all .sh files modified by git get saved with LF line endings.

This should fix the problems that some people are having when running the files in a Windows / WSL environment.