### PR TITLE
Remove coal power in AT

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -96,7 +96,7 @@
     ],
     "capacity": {
       "biomass": 474,
-      "coal": 598,
+      "coal": 0,
       "gas": 4466,
       "hydro": 8590,
       "hydro storage": 3401,


### PR DESCRIPTION
Austria did close the last coal power plant ("Dürnrohr") today, as per 2019-08-02
https://noe.orf.at/stories/3007102/