### PR TITLE
Update Poland's solar capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -3074,7 +3074,7 @@
       "hydro storage": 1780,
       "nuclear": 0,
       "oil": 415,
-      "solar": 424,
+      "solar": 882,
       "wind": 5825
     },
     "contributors": [


### PR DESCRIPTION
Bump Poland's installed solar capacity with data from PSE communique
to 882 kW