### PR TITLE
Correct SSL handling for MX exchanges

### DIFF
--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -5,8 +5,7 @@ import pandas
 import requests
 from bs4 import BeautifulSoup
 from collections import defaultdict
-
-MX_EXCHANGE_URL = 'http://www.cenace.gob.mx/Paginas/Publicas/Info/DemandaRegional.aspx'
+MX_EXCHANGE_URL = 'https://www.cenace.gob.mx/Paginas/Publicas/Info/DemandaRegional.aspx'
 
 EXCHANGES = {"MX-NO->MX-NW": "IntercambioNTE-NOR",
              "MX-NE->MX-NO": "IntercambioNES-NTE",
@@ -30,7 +29,7 @@ def fetch_MX_exchange(sorted_zone_keys, s):
     Returns a float.
     """
 
-    req = s.get(MX_EXCHANGE_URL, verify=False)
+    req = s.get(MX_EXCHANGE_URL)
     soup = BeautifulSoup(req.text, 'html.parser')
     exchange_div = soup.find("div", attrs={'id': EXCHANGES[sorted_zone_keys]})
     val = exchange_div.text


### PR DESCRIPTION
CENACE have updated their SSL certificate for their site (https://www.cenace.gob.mx/Paginas/Publicas/Info/DemandaRegional.aspx). All http requests 404 rather than upgrading, this fix will get all the MX exchanges working again.

```shell
/home/chris/EM/bin/python /home/chris/electricitymap/parsers/MX.py
fetch_exchange(MX-NO, MX-NW)
{'sortedZoneKeys': 'MX-NO->MX-NW', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 9, 765669, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 454.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-OR, MX-PN)
{'sortedZoneKeys': 'MX-OR->MX-PN', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 10, 661615, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 1095.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-NE, MX-OC)
{'sortedZoneKeys': 'MX-NE->MX-OC', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 12, 374944, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 2769.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-NE, MX-NO)
{'sortedZoneKeys': 'MX-NE->MX-NO', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 13, 222500, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 9.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-OC, MX-OR)
{'sortedZoneKeys': 'MX-OC->MX-OR', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 14, 864883, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 227.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-NE, US)
{'sortedZoneKeys': 'MX-NE->US', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 15, 662907, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 2.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-CE, MX-OC)
{'sortedZoneKeys': 'MX-CE->MX-OC', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 16, 584567, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -1297.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-PN, BZ)
{'sortedZoneKeys': 'BZ->MX-PN', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 19, 739839, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -48.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-NO, MX-OC)
{'sortedZoneKeys': 'MX-NO->MX-OC', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 21, 368255, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 126.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-NO, US)
{'sortedZoneKeys': 'MX-NO->US', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 22, 480093, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 0.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-NE, MX-OR)
{'sortedZoneKeys': 'MX-NE->MX-OR', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 23, 850162, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': 959.0, 'source': 'cenace.gob.mx'}
fetch_exchange(MX-CE, MX-OR)
{'sortedZoneKeys': 'MX-CE->MX-OR', 'datetime': datetime.datetime(2019, 8, 11, 7, 31, 26, 654819, tzinfo=tzfile('/usr/share/zoneinfo/America/Tijuana')), 'netFlow': -1532.0, 'source': 'cenace.gob.mx'}
```