### PR TITLE
Add parser for US (South Carolina)

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -4050,6 +4050,14 @@
     "timezone": null
   },
   "US-SC": {
+    "_comment": "Production comes from two sources. 1) South Carolina Electric & Gas Co, a division of SCANA (https://www.scana.com/), acquired by Dominion 2) Santee Cooper (http://www.santeecooper.com/) aka South Carolina Public Service Authority. Capacity from http://www.energy.sc.gov/files/view/Santee%20Cooper_IRP_2018_FINAL.pdf averaged between summer and winter reported capacities.",
+    "capacity": {
+      "hydro": 962,
+      "coal": 5240,
+      "gas": 3416.5,
+      "nuclear": 966,
+      "oil": 143.5
+    },
     "bounding_box": [
       [
         -83.110764,
@@ -4060,8 +4068,14 @@
         35.068720
       ]
     ],
+    "parsers": {
+      "production": "US_SC.fetch_production"
+    },
     "flag_file_name": "us.png",
-    "timezone": null
+    "timezone": "US/Eastern",
+    "contributors": [
+      "https://github.com/snarfed"
+    ]
   },
   "US-SPP": {
     "capacity": {

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -20,7 +20,9 @@ DAY_AHEAD = {
 }
 
 PRODUCTION = {
-    'US-SEC': 'EBA.SEC-ALL.NG.H'
+    'US-SC': 'EBA.SC-ALL.NG.H',
+    'US-SCEG': 'EBA.SCEG-ALL.NG.H',
+    'US-SEC': 'EBA.SEC-ALL.NG.H',
 }
 
 EXCHANGES = {

--- a/parsers/US_SC.py
+++ b/parsers/US_SC.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Parser for South Carolina, USA.
+
+Historical data only right now, via EIA. Generation comes from two sources:
+
+South Carolina Electric & Gas Co, a division of SCANA, acquired by Dominion
+Energy in Jan 2019.
+https://www.scana.com/
+https://en.wikipedia.org/wiki/SCANA
+
+South Carolina Public Service Authority, aka Santee Cooper
+http://www.santeecooper.com/
+https://en.wikipedia.org/wiki/Santee_Cooper
+
+https://github.com/tmrowco/electricitymap-contrib/issues/1674
+"""
+import logging
+
+from . import EIA
+from .ENTSOE import merge_production_outputs
+
+
+def fetch_production(zone_key='US-SC', session=None, target_datetime=None,
+                     logger=logging.getLogger(__name__)):
+    sc = fetch_unknown(zone_key='US-SC', session=session,
+                       target_datetime=target_datetime, logger=logger)
+    sceg = fetch_unknown(zone_key='US-SCEG', session=session,
+                         target_datetime=target_datetime, logger=logger)
+    return merge_production_outputs((sc, sceg), zone_key)
+
+
+def fetch_unknown(zone_key='US-SC', session=None, target_datetime=None,
+                  logger=logging.getLogger(__name__)):
+    data = EIA.fetch_production(zone_key=zone_key, session=session,
+                                target_datetime=target_datetime, logger=logger)
+    for hour in data:
+        hour.update({
+            'production': {'unknown': hour.pop('value')},
+            'storage': {},  # required by merge_production_outputs
+        })
+
+    return data
+
+
+def main():
+    """Main method, not used by the ElectricityMap backend, just for testing."""
+    import pprint
+    print('fetch_production() ->')
+    print(pprint.pprint(fetch_production()))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
for #1674. historical production only right now, via EIA. combines SC (Santee Cooper) and SCEG (South Carolina Electric & Gas). good capacity data, but no mix, sadly, so everything is currently reported as unknown.

next to do, consumption.

i might also look into extending EIA.py to merge multiple keys itself, so that we can use it in place for multi-key zones like this.