### PR TITLE
Add NL-DK exchange

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -667,16 +667,6 @@
     },
     "rotation": 180
   },
-  "CL-SIC->CL-SING": {
-    "lonlat": [
-      -69.500,
-      -25.958
-    ],
-    "parsers": {
-      "exchange": "CL_SIC.fetch_exchange"
-    },
-    "rotation": 0
-  },
   "CN->RU-AS":{
     "lonlat": [
       123.275128,

--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -859,6 +859,21 @@
     },
     "rotation": 90
   },
+  "DK-DK1->NL": {
+    "capacity": [
+      -700,
+      700
+    ],
+    "lonlat": [
+      8.3,
+      55.2
+    ],
+    "parsers": {
+      "exchangeForecast": "ENTSOE.fetch_exchange_forecast",
+      "exchange": "DK.fetch_exchange"
+    },
+    "rotation": -160
+  },
   "DK-DK1->NO-NO2": {
     "capacity": [
       -1700,

--- a/config/zones.json
+++ b/config/zones.json
@@ -4079,9 +4079,6 @@
       "https://github.com/systemcatch"
     ],
     "flag_file_name": "us.png",
-    "parsers": {
-      "production": "US_SVERI.fetch_production"
-    },
     "timezone": null
   },
   "US-TN": {

--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -149,6 +149,7 @@ def fetch_exchange(zone_key1='DK-DK1', zone_key2='DK-DK2', session=None,
         'DK-DK1->NL': '"ExchangeNetherlands"',
         'DK-DK1->SE': '"ExchangeSweden"',
         'DK-DK1->SE-SE3': '"ExchangeSweden"',
+        'DK-DK1->NL': '"ExchangeNetherlands"',
         'DK-DK2->SE': '("ExchangeSweden" - "BornholmSE4")',  # Exchange from Bornholm to Sweden is included in "ExchangeSweden"
         'DK-DK2->SE-SE4': '("ExchangeSweden" - "BornholmSE4")',  # but Bornholm island is reported separately from DK-DK2 in eMap
         'DK-BHM->SE': '"BornholmSE4"',


### PR DESCRIPTION
Implements https://github.com/tmrowco/electricitymap-contrib/issues/1949

The second commit is to fix test_parser.py after https://github.com/tmrowco/electricitymap-contrib/commit/cf98a829ec155a9ce31bec1fc7d534379dbdde15

I haven't got the front-end running (yet), so I'm unable to visually verify that the position for the exchange arrow looks good. 