### PR TITLE
USA (EIA): start fetching new hourly production mix by fuel type

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -3725,6 +3725,7 @@
     "flag_file_name": "us.png",
     "parsers": {
       "consumptionForecast": "EIA.fetch_consumption_forecast",
+      "consumption": "EIA.fetch_consumption",
       "production": "US_CA.fetch_production"
     },
     "timezone": null
@@ -3944,6 +3945,7 @@
     "flag_file_name": "us.png",
     "parsers": {
       "consumptionForecast": "EIA.fetch_consumption_forecast",
+      "consumption": "EIA.fetch_consumption",
       "production": "US_NEISO.fetch_production"
     },
     "timezone": null
@@ -3988,6 +3990,7 @@
     "flag_file_name": "us.png",
     "parsers": {
       "consumptionForecast": "EIA.fetch_consumption_forecast",
+      "consumption": "EIA.fetch_consumption",
       "production": "US_NY.fetch_production"
     },
     "timezone": null
@@ -4038,6 +4041,7 @@
     "flag_file_name": "us.png",
     "parsers": {
       "consumptionForecast": "EIA.fetch_consumption_forecast",
+      "consumption": "EIA.fetch_consumption",
       "price": "US_PJM.fetch_price",
       "production": "US_PJM.fetch_production"
     },
@@ -4073,6 +4077,7 @@
     "flag_file_name": "us.png",
     "parsers": {
       "consumptionForecast": "EIA.fetch_consumption_forecast",
+      "consumption": "EIA.fetch_consumption",
       "productionPerModeForecast": "US_SPP.fetch_wind_solar_forecasts",
       "production": "US_SPP.fetch_production"
     },
@@ -4106,6 +4111,7 @@
     "timezone": null
   },
   "US-TN": {
+    "comment": "Tennessee",
     "bounding_box": [
       [
         -90.323361,
@@ -4115,6 +4121,14 @@
         -81.934704,
         36.674417
       ]
+    ],
+    "parsers": {
+      "production": "EIA.fetch_production_mix",
+      "consumption": "EIA.fetch_consumption",
+      "consumptionForecast": "EIA.fetch_consumption_forecast"
+    },
+    "contributors": [
+      "https://github.com/snarfed"
     ],
     "flag_file_name": "us.png",
     "timezone": null

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -119,6 +119,9 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 def _fetch_series(zone_key, series_id, session=None, target_datetime=None,
                   logger=None):
     """Fetches and converts a data series."""
+    key = os.environ['EIA_KEY']
+    assert key and key != 'eia_key', key
+
     s = session or requests.Session()
     series = Series(series_id=series_id, session=s)
 

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -98,7 +98,7 @@ def fetch_production_mix(zone_key, session=None, target_datetime=None, logger=No
             })
         mixes.append(mix)
 
-    return merge_production_outputs(mixes, zone_key)
+    return merge_production_outputs(mixes, zone_key, merge_source='eia.gov')
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
@@ -147,7 +147,7 @@ def main():
     from pprint import pprint
     pprint(fetch_consumption_forecast('US-NY'))
     pprint(fetch_production('US-SEC'))
-    pprint(fetch_production_mix('US-CAR'))
+    pprint(fetch_production_mix('US-TN'))
     pprint(fetch_consumption('US-CAR'))
     pprint(fetch_exchange('MX-BC', 'US-CA'))
 

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
+"""Parser for U.S. Energy Information Administration, https://www.eia.gov/ .
 
+Aggregates and standardizes data from most of the US ISOs,
+and exposes them via a unified API.
+
+Requires an API key, set in the EIA_KEY environment variable. Get one here:
+https://www.eia.gov/opendata/register.php
+"""
+import datetime
 import os
 
 import arrow
@@ -8,20 +16,7 @@ os.environ.setdefault('EIA_KEY', 'eia_key')
 from eiapy import Series
 import requests
 
-DAY_AHEAD = {
-    'US-SPP': 'EBA.SWPP-ALL.DF.H',
-    'US-MISO': 'EBA.MISO-ALL.DF.H',
-    'US-CA': 'EBA.CAL-ALL.DF.H',
-    'US-NEISO': 'EBA.ISNE-ALL.DF.H',
-    'US-NY': 'EBA.NYIS-ALL.DF.H',
-    'US-PJM': 'EBA.PJM-ALL.DF.H',
-    'US-BPA': 'EBA.BPAT-ALL.DF.H',
-    'US-IPC': 'EBA.IPCO-ALL.DF.H'
-}
-
-PRODUCTION = {
-    'US-SEC': 'EBA.SEC-ALL.NG.H'
-}
+from .ENTSOE import merge_production_outputs
 
 EXCHANGES = {
     'MX-BC->US-CA': 'EBA.CISO-CFE.ID.H',
@@ -32,25 +27,98 @@ EXCHANGES = {
     'US-NEISO->US-NY': 'EBA.ISNE-NYIS.ID.H',
     'US-NY->US-PJM': 'EBA.NYIS-PJM.ID.H'
 }
+# based on https://www.eia.gov/beta/electricity/gridmonitor/dashboard/electric_overview/US48/US48
+REGIONS = {
+    'US-CA': 'CAL',
+    'US-CAR': 'CAR',
+    'US-SPP': 'CENT',
+    'US-FL': 'FLA',
+    'US-PJM': 'MIDA',
+    'US-MISO': 'MIDW',
+    'US-NEISO': 'NE',
+    'US-NY': 'NY',
+    'US-NW': 'NW',
+    'US-SE': 'SE',
+    'US-SEC': 'SEC',
+    'US-SVERI': 'SW',
+    'US-TN': 'TEN',
+    'US-TX': 'TEX',
+}
+TYPES = {
+    # 'biomass': 'BM',  # not currently supported
+    'coal': 'COL',
+    'gas': 'NG',
+    'hydro': 'WAT',
+    'nuclear': 'NUC',
+    'oil': 'OIL',
+    'unknown': 'OTH',
+    'solar': 'SUN',
+    'wind': 'WND',
+}
+PRODUCTION_SERIES = 'EBA.%s-ALL.NG.H'
+PRODUCTION_MIX_SERIES = 'EBA.%s-ALL.NG.%s.H'
+DEMAND_SERIES = 'EBA.%s-ALL.D.H'
+FORECAST_SERIES = 'EBA.%s-ALL.DF.H'
 
 
-def fetch_consumption_forecast(zone_key, session=None, target_datetime=None,
-                               logger=None):
-    return _fetch_production_or_consumption(
-        zone_key, DAY_AHEAD[zone_key], session=session,
-        target_datetime=target_datetime, logger=logger)
+def fetch_consumption_forecast(zone_key, session=None, target_datetime=None, logger=None):
+    return _fetch_series(zone_key, FORECAST_SERIES % REGIONS[zone_key],
+                         session=session, target_datetime=target_datetime,
+                         logger=logger)
 
 
-def fetch_production(zone_key, session=None, target_datetime=None,
-                     logger=None):
-    return _fetch_production_or_consumption(
-        zone_key, PRODUCTION[zone_key], session=session,
-        target_datetime=target_datetime, logger=logger)
+def fetch_production(zone_key, session=None, target_datetime=None, logger=None):
+    return _fetch_series(zone_key, PRODUCTION_SERIES % REGIONS[zone_key],
+                         session=session, target_datetime=target_datetime,
+                         logger=logger)
 
 
-def _fetch_production_or_consumption(zone_key, series_id, session=None,
-                                     target_datetime=None, logger=None):
-    """Fetches production or consumption forecast, determined by series_id."""
+def fetch_consumption(zone_key, session=None, target_datetime=None, logger=None):
+    consumption = _fetch_series(zone_key, DEMAND_SERIES % REGIONS[zone_key],
+                                session=session, target_datetime=target_datetime,
+                                logger=logger)
+    for point in consumption:
+        point['consumption'] = point.pop('value')
+
+    return consumption
+
+
+def fetch_production_mix(zone_key, session=None, target_datetime=None, logger=None):
+    mixes = []
+    for type, code in TYPES.items():
+        series = PRODUCTION_MIX_SERIES % (REGIONS[zone_key], code)
+        mix = _fetch_series(zone_key, series, session=session,
+                            target_datetime=target_datetime, logger=logger)
+        if not mix:
+            continue
+        for point in mix:
+            point.update({
+                'production': {type: point.pop('value')},
+                'storage': {},  # required by merge_production_outputs()
+            })
+        mixes.append(mix)
+
+    return merge_production_outputs(mixes, zone_key)
+
+
+def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
+    sortedcodes = '->'.join(sorted([zone_key1, zone_key2]))
+    exchange = _fetch_series(sortedcodes, EXCHANGES[sortedcodes], session=session,
+                             target_datetime=target_datetime, logger=logger)
+    for point in exchange:
+        point.update({
+            'sortedZoneKeys': point.pop('zoneKey'),
+            'netFlow': point.pop('value'),
+        })
+        if sortedcodes == 'MX-BC->US-CA':
+            point['netFlow'] = -point['netFlow']
+
+    return exchange
+
+
+def _fetch_series(zone_key, series_id, session=None, target_datetime=None,
+                  logger=None):
+    """Fetches and converts a data series."""
     s = session or requests.Session()
     series = Series(series_id=series_id, session=s)
 
@@ -61,63 +129,28 @@ def _fetch_production_or_consumption(zone_key, series_id, session=None,
         raw_data = series.last(24)
 
     # UTC timestamp with no offset returned.
+    if not raw_data.get('series'):
+        # Series doesn't exist. Probably requesting a fuel from a region that
+        # doesn't have any capacity for that fuel type.
+        return []
 
     return [{
         'zoneKey': zone_key,
         'datetime': parser.parse(datapoint[0]),
         'value': datapoint[1],
-        'source': 'eia.org',
+        'source': 'eia.gov',
     } for datapoint in raw_data['series'][0]['data']]
 
 
-def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime (optional)      -- string in form YYYYMMDDTHHZ
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
-    """
-
-    sortedcodes = '->'.join(sorted([zone_key1, zone_key2]))
-
-    series_id = EXCHANGES[sortedcodes]
-    s = session or requests.Session()
-    exchange_series = Series(series_id=series_id, session=s)
-
-    if target_datetime:
-        raw_data = exchange_series.last_from(24, end=target_datetime)
-    else:
-        # Get the last 24 hours available.
-        raw_data = exchange_series.last(24)['series'][0]['data']
-
-    data = []
-    for datapoint in raw_data:
-        if sortedcodes == 'MX-BC->US-CA':
-            datapoint[1] = -1*datapoint[1]
-
-        exchange = {'sortedZoneKeys': sortedcodes,
-                    'datetime': parser.parse(datapoint[0]),
-                    'netFlow': datapoint[1],
-                    'source': 'mysource.com'}
-
-        data.append(exchange)
-
-    return data
+def main():
+    "Main method, never used by the Electricity Map backend, but handy for testing."
+    from pprint import pprint
+    pprint(fetch_consumption_forecast('US-NY'))
+    pprint(fetch_production('US-SEC'))
+    pprint(fetch_production_mix('US-CAR'))
+    pprint(fetch_consumption('US-CAR'))
+    pprint(fetch_exchange('MX-BC', 'US-CA'))
 
 
 if __name__ == '__main__':
-    "Main method, never used by the Electricity Map backend, but handy for testing."
-
-    print(fetch_consumption_forecast('US-NY'))
-    print(fetch_production('US-SEC'))
-    print(fetch_exchange('MX-BC', 'US-CA'))
+    main()

--- a/parsers/requirements.txt
+++ b/parsers/requirements.txt
@@ -2,7 +2,7 @@ arrow==0.14.2
 beautifulsoup4==4.5.3
 click==6.7
 demjson==2.2.4
-eiapy==0.1.3
+eiapy==0.1.4
 html5lib==0.999999999
 lxml==4.4.1
 mock==2.0.0


### PR DESCRIPTION
this implements #1941. apologies for going ahead with this, @PETILLON-Sebastien @systemcatch! i know you all said you'd tackle it, but i haven't seen any commits or branches, and it looked interesting. i'll happily discard this PR if you all already have work done that you prefer.

this PR significantly refactors EIA.py, adds historical hourly production and consumption to US-TN, and historical hourly consumption to US-CA, -NEISO, -NY, -PJM, and -SPP, based on EIA's new hourly generation mix data: https://www.eia.gov/beta/electricity/gridmonitor/dashboard/electric_overview/US48/US48