### PR TITLE
Update co2eq_parameters.json for Croatia's unknown

### DIFF
--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -319,7 +319,7 @@
       "HR": {
         "unknown": {
           "source": "2018 average estimated from https://www.hops.hr/page-file/oEvvKj779KAhmQg10Gezt2/temeljni-podaci/Temeljni%20podaci%202018.pdf",
-          "value": 279
+          "value": 240
         }
       },
       "HU": {

--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -316,6 +316,12 @@
           "value": 178.67099686684926
         }
       },
+      "HR": {
+        "unknown": {
+          "source": "2018 average estimated from https://www.hops.hr/page-file/oEvvKj779KAhmQg10Gezt2/temeljni-podaci/Temeljni%20podaci%202018.pdf",
+          "value": 279
+        }
+      },
       "HU": {
         "hydro discharge": {
           "source": "2017 average by Tomorrow",


### PR DESCRIPTION
https://www.hops.hr/page-file/oEvvKj779KAhmQg10Gezt2/temeljni-podaci/Temeljni%20podaci%202018.pdf

By suggestion from https://github.com/tmrowco/electricitymap-contrib/issues/1950#issuecomment-532624874
I've tried to make an estimate.
For 2018 it's 6691 GWh hydro, 3206 GWh thermo, 1240 GWh wind. So unknown is 6691 GWh + 3206 GWh = 9897 GWh. Hydro taking 68% of the unknown. Then I did it like this 24*0.68+820*(1-0.68), where 24 represents the CO2 from hydro and 820 the CO2 from coal and 68 the share of hydro from the PDF reference.