### PR TITLE
Update topojson dependency to topojson-client

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -28,7 +28,7 @@
     "moment": "^2.23.0",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
-    "topojson": "^3.0.2"
+    "topojson-client": "^3.0.1"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/web/src/helpers/topos.js
+++ b/web/src/helpers/topos.js
@@ -1,5 +1,5 @@
 const topo = require('../world.json');
-const topojson = require('topojson');
+const topojson = require('topojson-client');
 
 const constructTopos = () => {
   const zones = {};

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -6494,32 +6494,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-topojson-client@3, topojson-client@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.0.0.tgz#1f99293a77ef42a448d032a81aa982b73f360d2f"
+topojson-client@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/topojson-client/-/topojson-client-3.0.1.tgz#774c0343b44fc4ec29c3a2274d7a1a9c3b213cd9"
+  integrity sha512-rfGGzyqefpxOaxvV9OTF9t+1g+WhjGEbAIuCcmKYrQkxr0nttjMMyzZsK+NhLW4cTl2g1bz2jQczPUtEshpbVQ==
   dependencies:
     commander "2"
-
-topojson-server@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/topojson-server/-/topojson-server-3.0.0.tgz#378e78e87c3972a7b5be2c5d604369b6bae69c5e"
-  dependencies:
-    commander "2"
-
-topojson-simplify@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/topojson-simplify/-/topojson-simplify-3.0.2.tgz#8a2403e639531500fafa0c6594e8b0fadebc2c02"
-  dependencies:
-    commander "2"
-    topojson-client "3"
-
-topojson@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/topojson/-/topojson-3.0.2.tgz#fcb927306c3e0fa76656fa58deed4555d2346fb4"
-  dependencies:
-    topojson-client "3.0.0"
-    topojson-server "3.0.0"
-    topojson-simplify "3.0.2"
 
 touch@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
The topojson dependency got deprecated.
We should use topojson-client instead.