### PR TITLE
Fix errors in Taiwan

### DIFF
--- a/parsers/requirements.txt
+++ b/parsers/requirements.txt
@@ -6,7 +6,7 @@ eiapy==0.1.4
 html5lib==0.999999999
 lxml==4.4.1
 mock==2.0.0
-pandas==0.25.1
+pandas==0.24.2
 Pillow==4.0.0
 pytesseract==0.2.0
 ree==2.2.1

--- a/parsers/requirements.txt
+++ b/parsers/requirements.txt
@@ -6,7 +6,7 @@ eiapy==0.1.4
 html5lib==0.999999999
 lxml==4.4.1
 mock==2.0.0
-pandas==0.24.2
+pandas==0.25.1
 Pillow==4.0.0
 pytesseract==0.2.0
 ree==2.2.1


### PR DESCRIPTION
closes #2011 

```shell
(EM) chris@ThinkPad:~/electricitymap$ python parsers/TW.py
{'zoneKey': 'TW', 'datetime': datetime.datetime(2019, 10, 5, 3, 40, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Taipei')), 'production': {'coal': 9611.8, 'gas': 10298.1, 'oil': 501.90000000000003, 'hydro': 581.6999999999999, 'nuclear': 3831.6000000000004, 'solar': 0.0, 'wind': 11.799999999999999, 'unknown': 557.0}, 'capacity': {'coal': 13097.2, 'gas': 16866.4, 'oil': 2572.1, 'hydro': 2091.4999999999995, 'hydro storage': 2602.0, 'nuclear': 3872.0, 'solar': 3144.4, 'wind': 710.9999999999999, 'unknown': 623.2}, 'storage': {'hydro': 1781.8000000000002}, 'source': 'taipower.com.tw'}
```