### PR TITLE
Use UTC for mocking the future data timestamp

### DIFF
--- a/parsers/test/mocks/quality_check.py
+++ b/parsers/test/mocks/quality_check.py
@@ -75,7 +75,7 @@ e3 = {
       'source': 'mysource.com'
       }
 
-future = datetime.datetime.now() + datetime.timedelta(seconds=5*60)
+future = datetime.datetime.utcnow() + datetime.timedelta(seconds=5*60)
 
 e4 = {
       'sortedZoneKeys': 'DK->NO',


### PR DESCRIPTION
When determining if a data timestamp is reasonable, it is compared to
the current UTC time. If someone is runing the parser tests in a
timezone other than UTC, the mock future time needs to be created using
the current UTC time.

This commit mocks parser data timestamps relative to the current UTC
time.