### PR TITLE
Fixes Span Ids for IN-AP (Andhra Pradesh)

### DIFF
--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -83,5 +83,3 @@ if __name__ == '__main__':
     session = Session()
     print(fetch_production('IN-AP', session))
     print(fetch_consumption('IN-AP', session))
-
-lblPowerStatusDate

--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -3,28 +3,31 @@
 from requests import Session
 from .lib import zonekey, IN, web
 
+
 def fetch_production(zone_key='IN-AP', session=None, target_datetime=None, logger=None):
     """Fetch Andhra Pradesh  production"""
     if target_datetime:
-        raise NotImplementedError('This parser is not yet able to parse past dates')
+        raise NotImplementedError(
+            'This parser is not yet able to parse past dates')
 
     zonekey.assert_zone_key(zone_key, 'IN-AP')
 
     html = web.get_response_soup(zone_key,
                                  'https://core.ap.gov.in/CMDashBoard/UserInterface/Power/PowerReport.aspx', session)
-    india_date = IN.read_datetime_from_span_id(html, 'lblPowerStatusDate', 'DD-MM-YYYY HH:mm')
+    india_date = IN.read_datetime_from_span_id(
+        html, 'MainContent_lblPowerStatusDate', 'DD-MM-YYYY HH:mm')
 
-    hydro_value = IN.read_value_from_span_id(html, 'lblHydel')
-    gas_value = IN.read_value_from_span_id(html, 'lblGas')
-    wind_value = IN.read_value_from_span_id(html, 'lblWind')
-    solar_value = IN.read_value_from_span_id(html, 'lblSolar')
+    hydro_value = IN.read_value_from_span_id(html, 'MainContent_lblHydel')
+    gas_value = IN.read_value_from_span_id(html, 'MainContent_lblGas')
+    wind_value = IN.read_value_from_span_id(html, 'MainContent_lblWind')
+    solar_value = IN.read_value_from_span_id(html, 'MainContent_lblSolar')
 
     # All thermal centrals are considered coal based production
     # https://en.wikipedia.org/wiki/Power_sector_of_Andhra_Pradesh
-    thermal_value = IN.read_value_from_span_id(html, 'lblThermal')
+    thermal_value = IN.read_value_from_span_id(html, 'MainContent_lblThermal')
 
-    cgs_value = IN.read_value_from_span_id(html, 'lblCGS')
-    ipp_value = IN.read_value_from_span_id(html, 'lblIPPS')
+    cgs_value = IN.read_value_from_span_id(html, 'MainContent_lblCGS')
+    ipp_value = IN.read_value_from_span_id(html, 'MainContent_lblIPPS')
 
     data = {
         'zoneKey': zone_key,
@@ -53,15 +56,18 @@ def fetch_production(zone_key='IN-AP', session=None, target_datetime=None, logge
 def fetch_consumption(zone_key='IN-AP', session=None, target_datetime=None, logger=None):
     """Fetch Andhra Pradesh consumption"""
     if target_datetime:
-        raise NotImplementedError('This parser is not yet able to parse past dates')
+        raise NotImplementedError(
+            'This parser is not yet able to parse past dates')
 
     zonekey.assert_zone_key(zone_key, 'IN-AP')
 
     html = web.get_response_soup(zone_key,
                                  'https://core.ap.gov.in/CMDashBoard/UserInterface/Power/PowerReport.aspx', session)
-    india_date = IN.read_datetime_from_span_id(html, 'lblPowerStatusDate', 'DD-MM-YYYY HH:mm')
+    india_date = IN.read_datetime_from_span_id(
+        html, 'MainContent_lblPowerStatusDate', 'DD-MM-YYYY HH:mm')
 
-    demand_value = IN.read_value_from_span_id(html, 'lblGridDemand')
+    demand_value = IN.read_value_from_span_id(
+        html, 'MainContent_lblGridDemand')
 
     data = {
         'zoneKey': zone_key,
@@ -77,3 +83,5 @@ if __name__ == '__main__':
     session = Session()
     print(fetch_production('IN-AP', session))
     print(fetch_consumption('IN-AP', session))
+
+lblPowerStatusDate

--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -64,18 +64,12 @@ def fetch_consumption(zone_key='IN-AP', session=None, target_datetime=None, logg
     html = web.get_response_soup(zone_key,
                                  'https://core.ap.gov.in/CMDashBoard/UserInterface/Power/PowerReport.aspx', session)
     india_date = IN.read_datetime_from_span_id(
-<< << << < HEAD
         html, 'MainContent_lblPowerStatusDate', 'DD-MM-YYYY HH:mm')
 
-
-== == == =
-        html, 'lblPowerStatusDate', 'HH:mm DD-MM-YYYY')
->> >>>> > ea71daa4d01200302d25ccaa6ad8a1807de51ee3
-
-    demand_value=IN.read_value_from_span_id(
+    demand_value = IN.read_value_from_span_id(
         html, 'MainContent_lblGridDemand')
 
-    data={
+    data = {
         'zoneKey': zone_key,
         'datetime': india_date.datetime,
         'consumption': demand_value,


### PR DESCRIPTION
Span ids in IN-AP (Andhra Pradesh) were missing `MainContent_` before each one of them, this PR fixes it. 

Relates to #1982