### PR TITLE
Fixed ios bug where navigation required two taps & resize bug

### DIFF
--- a/web/src/components/map.js
+++ b/web/src/components/map.js
@@ -149,7 +149,9 @@ export default class Map {
       this._setupMapColor();
       // For some reason the mapboxgl-canvas element sometimes has
       // the wrong size, so we resize it here just in case.
-      this.map.resize();
+      setTimeout(() => {
+        this.map.resize();
+      }, 500)
     });
 
     // Set a timer to detect when the map has finished loading

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -966,9 +966,9 @@ d3.selectAll('.faq-link')
   });
 
 // Mobile toolbar buttons
-d3.selectAll('.map-button').on('click', () => dispatchApplication('showPageState', 'map'));
-d3.selectAll('.info-button').on('click', () => dispatchApplication('showPageState', 'info'));
-d3.selectAll('.highscore-button')
+d3.selectAll('.map-button').on('click touchend', () => dispatchApplication('showPageState', 'map'));
+d3.selectAll('.info-button').on('click touchend', () => dispatchApplication('showPageState', 'info'));
+d3.selectAll('.highscore-button touchend')
   .on('click', () => dispatchApplication('showPageState', 'highscore'));
 
 // Onboarding modal


### PR DESCRIPTION
Fixes #2029

On ios, the first click was detected as a hover. This makes sure that the event fires either way.

It also fixed an issue where the map was resized before the rest of the content was loaded. It uses setTimeout, so there's probably a better solution, but this should fix it for most users.