### PR TITLE
Use different production data URL for NI

### DIFF
--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -10,7 +10,7 @@ import requests
 TIMEZONE = 'America/Managua'
 
 MAP_URL = 'http://www.cndc.org.ni/graficos/MapaSIN/index.php'
-SUMMARY_URL = 'http://www.cndc.org.ni/graficos/graficaGeneracion_Tipo_TReal.php'
+SUMMARY_URL = 'http://www.cndc.org.ni/graficos/graficaGeneracion_Tipo_TReal0000.php'
 PRICE_URL = 'http://www.cndc.org.ni/consultas/infoRelevanteSIN/consultaCostoMarginal.php'
 
 # This is a list in same order as values for "generacion" variable in MAP_URL


### PR DESCRIPTION
Fixes #1945. Looks like they changed the format of the summary page but still keep the old PHP script around so we can switch to that.