### PR TITLE
Ensure loading screen stops if solar layer cannot render

### DIFF
--- a/web/src/components/layers/solar.js
+++ b/web/src/components/layers/solar.js
@@ -81,7 +81,7 @@ class SolarLayer {
       moment(t_after).fromNow(),
       'made', moment(this.grib2.header.refTime).fromNow());
     if (moment(now) > moment(t_after)) {
-      return console.error('Error while interpolating solar because current time is out of bounds');
+      return callback(new Error('Error while interpolating solar because current time is out of bounds'));
     }
 
     this.k = (now - t_before) / (t_after - t_before);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -601,14 +601,18 @@ function renderMap(state) {
       solar.forecasts[0],
       solar.forecasts[1],
       scales.solarColor,
-      () => {
-        if (getState().application.solarEnabled) {
-          solarLayer.show();
+      (err) => {
+        if (err) {
+          console.error(err.message);
         } else {
-          solarLayer.hide();
+          if (getState().application.solarEnabled) {
+            solarLayer.show();
+          } else {
+            solarLayer.hide();
+          }
+          // Restore setting
+          saveKey('solarEnabled', getState().application.solarEnabled);
         }
-        // Restore setting
-        saveKey('solarEnabled', getState().application.solarEnabled);
         LoadingService.stopLoading('#loading');
       },
     );


### PR DESCRIPTION
This ensures that `LoadingService.stopLoading('#loading');` is always called when `solarLayer.draw` returns, whether there's an error or not.

Resolves #1954.

I'm perfectly happy to make further changes to this as required.