### PR TITLE
Add Kuwait

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - Japan (Shikoku): [Yonden](http://www.yonden.co.jp/denkiyoho/)
 - Japan (Tōhoku-Niigata): [TH-EPCO](http://setsuden.tohoku-epco.co.jp/graph.html)
 - Japan (Tōkyō area): [TEPCO](http://www.tepco.co.jp/forecast/html/images/juyo-j.csv)
+- Kuwait: [Ministry of Electricity & Water](https://www.mew.gov.kw/en/)  
 - Latvia: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - Lithuania: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - Malaysia: [GSO](https://www.gso.org.my/LandingPage.aspx)
@@ -252,6 +253,9 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - India (Andhra Pradesh): [wikipedia.org](https://en.wikipedia.org/wiki/Power_sector_of_Andhra_Pradesh)
 - India (Punjab): [PUNJABSLDC](http://www.punjabsldc.org/realtimepbGen.aspx)
 - India (Chhattisgarh, Delhi, Gujarat, Karnataka, Punjab, Uttar Pradesh): [National Power Portal](https://npp.gov.in/dashBoard/cp-map-dashboard)
+- Kuwait 
+  - Gas & oil: [KAPSARC](https://datasource.kapsarc.org/api/datasets/1.0/kuwait-power-plants-database/attachments/power_plants_xlsx/)
+  - Solar & wind: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=KWT)
 - Latvia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Lithuania: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Malaysia: [GSO](https://www.gso.org.my/SystemData/PowerStation.aspx)

--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -439,6 +439,12 @@
           "value": 680
         }
       },
+      "KW": {
+        "unknown": {
+          "_url": "https://www.iea.org/statistics/?country=KUWAIT&year=2017&category=Key%20indicators&indicator=ElecGenByFuel&mode=chart&dataTable=ELECTRICITYANDHEAT",
+          "source": "IEA 2017; assumes 34.4% gas, 65.6% oil",
+          "value": 595
+        },
       "LT": {
         "hydro discharge": {
           "source": "2018 average by Tomorrow",

--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -444,7 +444,8 @@
           "_url": "https://www.iea.org/statistics/?country=KUWAIT&year=2017&category=Key%20indicators&indicator=ElecGenByFuel&mode=chart&dataTable=ELECTRICITYANDHEAT",
           "source": "IEA 2017; assumes 34.4% gas, 65.6% oil",
           "value": 595
-        },
+        }
+      },
       "LT": {
         "hydro discharge": {
           "source": "2018 average by Tomorrow",

--- a/config/zones.json
+++ b/config/zones.json
@@ -2496,6 +2496,31 @@
     },
     "timezone": "Asia/Seoul"
   },
+  "KW": {
+    "bounding_box": [
+      [
+        46.1550,
+        28.3985
+      ],
+      [
+        48.7948,
+        30.4747 
+      ]
+    ],
+    "capacity": {
+      "gas": 6525,
+      "oil": 8550,
+      "solar": 30.5,
+      "wind": 10
+    },
+    "contributors": [
+      "https://github.com/alixunderplatz"
+    ],
+    "parsers": {
+      "production": "KW.fetch_production"
+    },
+    "timezone": "Asia/Kuwait"
+  },
   "LT": {
     "bounding_box": [
       [

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+# This parser returns Kuwait's electricity system load (assumed to be equal to electricity production)
+# Source: Ministry of Electricity and Water / State of Kuwait
+# URL: https://www.mew.gov.kw/en/
+# Scroll down to see the system load gauge
+# Shares of Electricity production in 2017: 65.6% oil, 34.4% gas (source: IEA; https://www.iea.org/statistics/?country=KUWAIT&indicator=ElecGenByFuel)
+
+import arrow
+import requests
+import re
+
+def fetch_production(zone_key='KW', session=None, logger=None):
+    r = session or requests.session()
+    url = 'https://www.mew.gov.kw/en'
+    response = r.get(url)
+    load = re.findall(r"\((\d{4,5})\)", response.text)
+    load = int(load[0])
+    production = {}
+    production['unknown'] = load
+    
+    datapoint = {
+        'zoneKey': zone_key,
+        'datetime': arrow.now('Asia/Kuwait').datetime,
+        'production': production,
+        'source': 'mew.gov.kw'
+    }
+
+    return datapoint
+
+if __name__ == '__main__':
+    """Main method, never used by the electricityMap backend, but handy for testing."""
+    
+    print('fetch_production() ->')
+    print(fetch_production())


### PR DESCRIPTION
closes #2101 and adds Kuwait to the map
@corradio it's up to you to make this zone colored (due to no breakdown but "unknown") or leave it grey but supply the data in the diagramms (like for the JP-zones) ;)

- read electric load from Ministry of Energy & Water (updated several times / hour)
  - load = production due to no imports/exports with neighbour zones
- assign installed capacity to solar, wind, oil and gas
- assign carbon intensity of 595 g/kWh to the unknown mix (based on IEA shares for 2017)

- Note: KW has no significant solar or wind capacity yet, but huge PV+CSP-solar projects are planned for future (GW-range)

SAMPLE OUTPUT:

```
fetch_production() ->
{'zoneKey': 'KW', 'datetime': datetime.datetime(2019, 11, 24, 12, 6, 49, 945003, tzinfo=tzfile('Asia/Kuwait')), 'production': {'unknown': 6284}, 'source': 'mew.gov.kw'}
```