### PR TITLE
Nova scotia fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - Bulgaria: [TSO](http://tso.bg/default.aspx/page-707/bg)
 - Canada (Alberta): [AESO](http://ets.aeso.ca/ets_web/ip/Market/Reports/CSDReportServlet)
 - Canada (New Brunswick): [NB Power](https://tso.nbpower.com/Public/en/op/market/data.aspx)
-- Canada (Nova Scotia): [Nova Scotia Power](http://www.nspower.ca/en/home/about-us/todayspower.aspx)
+- Canada (Nova Scotia): [Nova Scotia Power](https://www.nspower.ca/clean-energy/todays-energy-stats)
 - Canada (Ontario): [IESO](http://www.ieso.ca/power-data)
 - Canada (Prince Edward Island): [Government of PEI](https://www.princeedwardisland.ca/en/feature/pei-wind-energy/)
 - Canada (Yukon): [Yukon Energy](http://www.yukonenergy.ca/energy-in-yukon/electricity-101/current-energy-consumption)

--- a/config/zones.json
+++ b/config/zones.json
@@ -703,7 +703,8 @@
     },
     "contributors": [
       "https://github.com/corradio",
-      "https://github.com/jarek"
+      "https://github.com/jarek",
+      "https://github.com/scriptator"
     ],
     "flag_file_name": "ca.png",
     "parsers": {

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -38,10 +38,10 @@ def _get_ns_info(requests_obj, logger):
     # As of November 2018, NSPower redirects their web traffic to HTTPS. However we've been
     # getting SSL errors in Python, even though loading these URLs in Firefox 63 gives no errors.
     # This isn't confidential or security-sensitive data, so ignore the SSL errors.
-    mix_url = 'https://www.nspower.ca/system_report/today/currentmix.json'
+    mix_url = 'https://www.nspower.ca/library/CurrentLoad/CurrentMix.json'
     mix_data = requests_obj.get(mix_url, verify=False).json()
 
-    load_url = 'https://www.nspower.ca/system_report/today/currentload.json'
+    load_url = 'https://www.nspower.ca/library/CurrentLoad/CurrentLoad.json'
     load_data = requests_obj.get(load_url, verify=False).json()
 
     production = []

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -35,14 +35,11 @@ def _get_ns_info(requests_obj, logger):
         'wind': 700
     }
 
-    # As of November 2018, NSPower redirects their web traffic to HTTPS. However we've been
-    # getting SSL errors in Python, even though loading these URLs in Firefox 63 gives no errors.
-    # This isn't confidential or security-sensitive data, so ignore the SSL errors.
     mix_url = 'https://www.nspower.ca/library/CurrentLoad/CurrentMix.json'
-    mix_data = requests_obj.get(mix_url, verify=False).json()
+    mix_data = requests_obj.get(mix_url).json()
 
     load_url = 'https://www.nspower.ca/library/CurrentLoad/CurrentLoad.json'
-    load_data = requests_obj.get(load_url, verify=False).json()
+    load_data = requests_obj.get(load_url).json()
 
     production = []
     imports = []


### PR DESCRIPTION
Fixes #2091 by replacing the URL.

Appears to work just fine. Output of `test_parser.py` is:
```
min returned datetime: 2019-11-26T18:00:00+00:00 UTC
max returned datetime: 2019-11-27T18:00:00+00:00 UTC  -- OK, <2h from now :) (now=2019-11-27T18:58:19.099228+00:00 UTC) 
```