### PR TITLE
US_SPP parser - Remove 'load' from api results

### DIFF
--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -52,7 +52,7 @@ def data_processor(df, logger):
     # Remove leading whitespace in column headers.
     df.columns = df.columns.str.strip()
 
-    keys_to_remove = {'GMT MKT Interval', 'Average Actual Load', 'Other', 'Waste Heat'}
+    keys_to_remove = {'GMT MKT Interval', 'Average Actual Load', 'Load', 'Other', 'Waste Heat'}
 
     # Check for new generation columns.
     known_keys = MAPPING.keys() | keys_to_remove


### PR DESCRIPTION
It seems like the api results changed a few days ago and it changed the 'Average Actual Load' key to just 'Load'. This caused the electricity load to be added to the production values as 'Unknown', doubling the total production, and making the co2 number very inaccurate.