### PR TITLE
Add Israel

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - Hungary: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - Iceland: [LANDSNET](https://amper.landsnet.is/generation/api/Values)
 - Ireland: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
+- Israel: [IEC](https://www.iec.co.il/en/pages/default.aspx)  
 - Italy: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)
 - India: [meritindia](http://meritindia.in/)
 - India (Andhra Pradesh): [CORE Dashboard](https://core.ap.gov.in/CMDashBoard/UserInterface/Power/PowerReport.aspx)
@@ -246,6 +247,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Ireland
   - All production types: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
   - Biomass, Solar & Wind: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=IRL)
+- Israel: [Global Power Plant Database](http://datasets.wri.org/dataset/globalpowerplantdatabase)  
 - Italy
   - Wind & Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=ITA)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)

--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -334,6 +334,13 @@
           "value": 381.21842143892457
         }
       },
+      "IL": {
+        "unknown": {
+          "_url": "https://www.iea.org/data-and-statistics?country=ISRAEL&fuel=Electricity%20and%20heat&indicator=Electricity%20generation%20by%20source",
+          "source": "IEA 2018, assumes 30.4% coal, 65.9% gas, 0.5% oil, 2.5% solar, 0.3% wind, 0.4% other",
+          "value": 580
+        }
+      },
       "IN": {
         "unknown": {
           "source": "assumes 43% solar PV and 57% wind",

--- a/config/zones.json
+++ b/config/zones.json
@@ -1882,6 +1882,32 @@
     },
     "timezone": "Europe/Dublin"
   },
+  "IL": {
+    "bounding_box": [
+      [
+        32.8841,
+        29.0121
+      ],
+      [
+        37.4557,
+        34.2585 
+      ]
+    ],
+    "capacity": {
+      "coal": 4840,
+      "gas": 9213,
+      "solar": 378,
+      "wind": 42
+    },
+    "contributors": [
+      "https://github.com/alixunderplatz",
+      "https://github.com/jarek"
+    ],
+    "parsers": {
+      "production": "IL.fetch_production"
+    },
+    "timezone": "Asia/Jerusalem"
+  },
   "IN": {
     "capacity": {
       "solar": 26000,

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+# This parser returns Israel's electricity system load (assumed to be equal to electricity production)
+# Source: Israel Electric Corporation
+# URL: https://www.iec.co.il/en/pages/default.aspx
+# Shares of Electricity production in 2018: 65.6% oil, 34.4% gas (source: IEA; https://www.iea.org/data-and-statistics?country=ISRAEL&fuel=Electricity%20and%20heat&indicator=Electricity%20generation%20by%20source)
+
+
+import arrow
+import requests
+import re
+from bs4 import BeautifulSoup
+
+
+def fetch_production(zone_key='IL', session=None, logger=None):
+    first = requests.get('https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx')
+    first.cookies
+    second = requests.get('https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx', cookies=first.cookies)
+
+    soup = BeautifulSoup(second.content, 'lxml')
+
+    span = soup.find("span", attrs={"class": "statusVal"})
+    value = re.findall("\d+", span.text.replace(",", ""))
+    load = int(value[0])
+    production = {}
+    production['unknown'] = load
+    
+    datapoint = {
+        'zoneKey': zone_key,
+        'datetime': arrow.now('Asia/Jerusalem').datetime,
+        'production': production,
+        'source': 'iec.co.il'
+    }
+
+    return datapoint
+
+
+if __name__ == '__main__':
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
+    
+    print('fetch_production() ->')
+    print(fetch_production())


### PR DESCRIPTION
closes #2103 and adds Israel to the map

@corradio Same as in my last commit for Kuwait: it's up to you to make this zone colored due to no breakdown but "unknown", or leave it grey but supply the data in the diagramms (like for the JP-zones) ;)

@jarek I added you to the contributors for this parser for your very appreciated help with the cookies ;)

- read electric load from Israel Electric Corporation (updated several times / hour)
  - load = production due to no imports/exports with neighbour zones
- assign installed capacity to coal, gas, solar and wind

- assign carbon intensity of 580 g/kWh to the unknown mix ([based on IEA shares for 2018](https://www.iea.org/data-and-statistics?country=ISRAEL&fuel=Electricity%20and%20heat&indicator=Electricity%20generation%20by%20source))

Note: Transition from coal to even more natural gas and to renewables is planned for the future. Insignificant share of <3% for renewables in 2018 so far.

SAMPLE OUTPUT:
```
fetch_production() ->
{'zoneKey': 'IL', 'datetime': datetime.datetime(2019, 12, 22, 1, 41, 6, 105268, tzinfo=tzfile('Israel')), 'production': {'unknown': 6086}, 'source': 'iec.co.il'}
```