### PR TITLE
Fix Peru-parser

### DIFF
--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -22,7 +22,7 @@ MAP_GENERATION = {
 
 
 def parse_date(item):
-    return arrow.get(item['Nombre'], 'M/D/YYYY h:mm:ss A').replace(tzinfo=dateutil.tz.gettz(tz))
+    return arrow.get(item['Nombre'], 'YYYY/MM/DD hh:mm:ss').replace(tzinfo=dateutil.tz.gettz(tz))
 
 
 def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=None):
@@ -32,8 +32,8 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=N
     r = session or requests.session()
     url = 'http://www.coes.org.pe/Portal/portalinformacion/Generacion'
     response = r.post(url, data={
-        'fechaInicial': arrow.now(tz=tz).format('DD/MM/YYYY'),
-        'fechaFinal': arrow.now(tz=tz).replace(days=+1).format('DD/MM/YYYY'),
+        'fechaInicial': arrow.now(tz=tz).replace(days=-1).format('DD/MM/YYYY'),
+        'fechaFinal': arrow.now(tz=tz).format('DD/MM/YYYY'),
         'indicador': 0
     })
     obj = response.json()['GraficoTipoCombustible']['Series']
@@ -64,7 +64,7 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=N
                 })
 
             data[i]['production'][MAP_GENERATION[k]] = \
-                data[i]['production'].get(MAP_GENERATION[k], 0) + v['Valor'] / interval_hours
+                data[i]['production'].get(MAP_GENERATION[k], 0) + v['Valor'] / interval_hours / 2
 
     return list(filter(lambda x: validate(x, logger, required=['gas'], floor=0.0, ) is not None, data))
 

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -32,7 +32,7 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=N
     r = session or requests.session()
     url = 'http://www.coes.org.pe/Portal/portalinformacion/Generacion'
     response = r.post(url, data={
-        'fechaInicial': arrow.now(tz=tz).replace(days=-1).format('DD/MM/YYYY'),
+        'fechaInicial': arrow.now(tz=tz).shift(days=-1).format('DD/MM/YYYY'),
         'fechaFinal': arrow.now(tz=tz).format('DD/MM/YYYY'),
         'indicador': 0
     })

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -64,7 +64,7 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=N
                 })
 
             data[i]['production'][MAP_GENERATION[k]] = \
-                data[i]['production'].get(MAP_GENERATION[k], 0) + v['Valor'] / interval_hours / 2
+                data[i]['production'].get(MAP_GENERATION[k], 0) + v['Valor'] / interval_hours
 
     return list(filter(lambda x: validate(x, logger, required=['gas'], floor=0.0, ) is not None, data))
 


### PR DESCRIPTION
- fixed datetime-format of the raw data
- fixed date values of the data-request
   - **NOTE: seems like fetching real-time data is not possible anymore.** 
Only yesterdays data can be parsed. I haven't found a way to retrieve/view live-data from: http://www.coes.org.pe/Portal/portalinformacion/generacion

Sample output:
`[{'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 1, 2, 0, 30, tzinfo=tzfile('America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 248.67762, 'gas': 1027.1763, 'hydro': 8934.01388, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 1, 2, 1, 0, tzinfo=tzfile('America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 242.39494, 'gas': 957.50884, 'hydro': 8836.51988, 'solar': 0.0}, 'source': 'coes.org.pe'},`