### PR TITLE
Fix Western Australia parser

### DIFF
--- a/parsers/lib/AU_solar.py
+++ b/parsers/lib/AU_solar.py
@@ -69,8 +69,8 @@ def fetch_solar_all(session, hours_in_the_past=2):
     # Requesting yesterday's data in the browser sometimes gives an HTTP 406 Unacceptable error,
     # but it's always worked in the script so far. Could double check and adjust
     # how many hours are fetched if it causes a problem in the future.
-    data_url = SOLAR_URL.format(date=_get_australian_date(days_in_past=1))
-    r = session.get(data_url)
+    data_url = SOLAR_URL
+    r = session.post(data_url, {'day': _get_australian_date(days_in_past=1)})
     data = r.json()
 
     full_production_data = data['output'] + production_data


### PR DESCRIPTION
Fixes AU-WA in #2134 

I've made a correction to an api call in lib/AU_solar.py to get the previous day's solar data - the AUS-WA parser now works for me when I test locally.