### PR TITLE
Update DO.py / fix solar

### DIFF
--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -32,7 +32,7 @@ total_mapping = {
 thermal_plants = {
                  u'AES ANDRES': 'gas',
                  u'BARAHONA CARBON': 'coal',
-                 u'BERSAL': 'unknown',
+                 u'BERSAL': 'oil',
                  u'CEPP 1': 'oil',
                  u'CEPP 2': 'oil',
                  u'CESPM 1': 'oil',

--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -21,7 +21,8 @@ total_mapping = {
                 u'Total T\xe9rmico': 'Thermal',
                 u'Total E\xf3lico': 'Wind',
                 u'Total Hidroel\xe9ctrica': 'Hydro',
-                'Total Generado': 'Generated'
+                u'Total Solar': 'Solar',
+                u'Total Generado': 'Generated'
                 }
 
 # Power plant types
@@ -53,16 +54,16 @@ thermal_plants = {
                  u'LOS OR\xcdGENES POWER PLANT FUEL OIL': 'oil',
                  u'LOS OR\xcdGENES POWER PLANT GAS NATURAL': 'gas',
                  u'METALDOM': 'oil',
-                 u'MONTE PLATA SOLAR': 'solar',
                  u'MONTE RIO': 'oil',
                  u'PALAMARA': 'oil',
                  u'PALENQUE': 'oil',
                  u'PARQUE ENERGETICO LOS MINA CC PARCIAL': 'gas',
                  u'PARQUE ENERGETICO LOS MINA CC TOTAL': 'gas',
-                 u'PARQUE FOTOVOLTAICO MONTECRISTI SOLAR1': 'solar',
                  u'PIMENTEL 1': 'oil',
                  u'PIMENTEL 2': 'oil',
                  u'PIMENTEL 3': 'oil',
+                 u'PUNTA CATALINA 1': 'coal',
+                 u'PUNTA CATALINA 2': 'coal',
                  u'QUISQUEYA 1': 'gas',
                  u'QUISQUEYA 2': 'gas',
                  u'QUISQUEYA 1 SAN PEDRO': 'oil',
@@ -231,6 +232,7 @@ def total_production(df):
         current = df.loc[[hour]]
         hydro = current.iloc[0]['Hydro']
         wind = current.iloc[0]['Wind']
+        solar = current.iloc[0]['Solar']
         if wind > -10:
             wind = max(wind, 0)
 
@@ -241,7 +243,7 @@ def total_production(df):
         if isnan(hydro):
             hydro = None
 
-        prod = {'wind': wind, 'hydro': hydro, 'datetime': dt}
+        prod = {'wind': wind, 'hydro': hydro, 'solar': solar, 'datetime': dt}
         vals.append(prod)
 
     return vals


### PR DESCRIPTION
(First off: seems like historical data could be fetched for Dominican Republic, maybe you want to put that on your to-do, @corradio @robertahunt 
See: http://190.122.102.21:8084/reportesgraficos/reportepostdespacho.aspx)

The DO.py parser was often failing to fetch solar correctly from the plant mapping.
I had a look at the source website, which now offers a total "solar" row that is used by the parser now.
Unfortunately, the last 2 hours of solar aren't fetched (nan is returned), but they are filled later.
Also, 2 large new coal units were comissioned last year. 


- re-wrote how 'solar' is fetched
- added 2 new missing coal units "Punta Catalina" 1+2
- switched 1 type mapping from "unknown" to "oil"

Sample output:
```
fetch_production() ->
[{'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 0, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 29.98, 'coal': 719.88, 'gas': 931.9099999999999, 'hydro': 143.85, 'nuclear': 0.0, 'oil': 323.7, 'solar': nan, 'wind': 4.33, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 1, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 29.76, 'coal': 717.5400000000001, 'gas': 910.31, 'hydro': 49.26, 'nuclear': 0.0, 'oil': 321.15, 'solar': nan, 'wind': 8.53, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 2, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.0, 'coal': 715.7, 'gas': 903.1500000000001, 'hydro': 45.56, 'nuclear': 0.0, 'oil': 303.04, 'solar': nan, 'wind': 9.45, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 3, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 29.48, 'coal': 719.45, 'gas': 886.49, 'hydro': 46.42, 'nuclear': 0.0, 'oil': 286.13, 'solar': nan, 'wind': 10.33, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 4, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 29.12, 'coal': 718.6500000000001, 'gas': 842.58, 'hydro': 46.05, 'nuclear': 0.0, 'oil': 296.96, 'solar': nan, 'wind': 15.75, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 5, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 29.29, 'coal': 716.6700000000001, 'gas': 852.8100000000001, 'hydro': 44.9, 'nuclear': 0.0, 'oil': 291.26, 'solar': nan, 'wind': 16.54, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 6, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 29.85, 'coal': 717.46, 'gas': 842.88, 'hydro': 56.17, 'nuclear': 0.0, 'oil': 289.44, 'solar': nan, 'wind': 13.39, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 7, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.04, 'coal': 721.1800000000001, 'gas': 846.3499999999999, 'hydro': 60.05, 'nuclear': 0.0, 'oil': 254.93000000000004, 'solar': 3.18, 'wind': 10.17, 'geothermal': 0.0, 'unknown': 10.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 8, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.25, 'coal': 722.4499999999999, 'gas': 844.78, 'hydro': 96.43, 'nuclear': 0.0, 'oil': 225.57999999999996, 'solar': 28.46, 'wind': 6.46, 'geothermal': 0.0, 'unknown': 6.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 9, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.23, 'coal': 720.33, 'gas': 832.48, 'hydro': 122.8, 'nuclear': 0.0, 'oil': 198.65, 'solar': 79.54, 'wind': 6.81, 'geothermal': 0.0, 'unknown': 6.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 10, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.02, 'coal': 704.79, 'gas': 824.5900000000001, 'hydro': 136.29, 'nuclear': 0.0, 'oil': 168.92, 'solar': 107.73, 'wind': 8.58, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 11, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.15, 'coal': 698.6500000000001, 'gas': 824.8100000000001, 'hydro': 152.86, 'nuclear': 0.0, 'oil': 126.82999999999998, 'solar': 122.56, 'wind': 12.26, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 12, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.02, 'coal': 701.34, 'gas': 846.45, 'hydro': 147.3, 'nuclear': 0.0, 'oil': 104.13, 'solar': 123.82, 'wind': 17.63, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 13, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.07, 'coal': 703.37, 'gas': 837.77, 'hydro': 77.91, 'nuclear': 0.0, 'oil': 163.69, 'solar': 115.11, 'wind': 51.46, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 14, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.0, 'coal': 703.0, 'gas': 842.72, 'hydro': 56.15, 'nuclear': 0.0, 'oil': 190.79, 'solar': nan, 'wind': 69.56, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}, {'zoneKey': 'DO', 'datetime': datetime.datetime(2020, 1, 6, 15, 0, tzinfo=tzfile('America/Anguilla')), 'production': {'biomass': 30.0, 'coal': 703.0, 'gas': 842.72, 'hydro': 56.15, 'nuclear': 0.0, 'oil': 271.09000000000003, 'solar': nan, 'wind': 69.56, 'geothermal': 0.0, 'unknown': 0.0}, 'storage': {'hydro': None}, 'source': 'oc.org.do'}]

```

