### PR TITLE
More localisation fixes + correct link for adding new regions doc

### DIFF
--- a/parsers/README.md
+++ b/parsers/README.md
@@ -1,4 +1,4 @@
 # Parsers
 A parser is a file responsible for fetching data about the power system in a given region.
 
-If you want to **create a new parser**, check out the [example.py](https://github.com/tmrowco/electricitymap-contrib/blob/master/parsers/example.py) file, or read the [instructions](https://github.com/tmrowco/electricitymap-contrib/blob/master/README.md#adding-a-new-country).
+If you want to **create a new parser**, check out the [example.py](https://github.com/tmrowco/electricitymap-contrib/blob/master/parsers/example.py) file, or read the [instructions](https://github.com/tmrowco/electricitymap-contrib/blob/master/README.md#adding-a-new-region).

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -155,7 +155,7 @@ class Component extends React.PureComponent {
           </div>
           <div className="country-table-container" />
           <div className="zone-details-no-parser-message">
-            {__('country-panel.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-country')}
+            <span dangerouslySetInnerHTML={{ __html: __('country-panel.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region') }} />
           </div>
 
           <hr />

--- a/web/src/layout/leftpanel/infotext.js
+++ b/web/src/layout/leftpanel/infotext.js
@@ -44,7 +44,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(({ dispatchApplicati
         dangerouslySetInnerHTML={{
           __html: __(
             'panel-initial-text.contribute',
-            'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-country'
+            'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region'
           ),
         }}
       />

--- a/web/src/layout/leftpanel/mobileinfotab.js
+++ b/web/src/layout/leftpanel/mobileinfotab.js
@@ -41,7 +41,7 @@ export default () => (
         </label>
       </p>
       <p>
-        {__('panel-initial-text.thisproject')} <a href="https://github.com/tmrowco/electricitymap-contrib" target="_blank">{__('panel-initial-text.opensource')}</a> ({__('panel-initial-text.see')} <a href="https://github.com/tmrowco/electricitymap-contrib#data-sources" target="_blank">{__('panel-initial-text.datasources')}</a>). <span dangerouslySetInnerHTML={{ __html: __('panel-initial-text.contribute', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-country') }} />.
+        {__('panel-initial-text.thisproject')} <a href="https://github.com/tmrowco/electricitymap-contrib" target="_blank">{__('panel-initial-text.opensource')}</a> ({__('panel-initial-text.see')} <a href="https://github.com/tmrowco/electricitymap-contrib#data-sources" target="_blank">{__('panel-initial-text.datasources')}</a>). <span dangerouslySetInnerHTML={{ __html: __('panel-initial-text.contribute', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region') }} />.
       </p>
       <p>
         {__('footer.foundbugs')} <a href="https://github.com/tmrowco/electricitymap-contrib/issues/new" target="_blank">{__('footer.here')}</a>.<br />

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -75,7 +75,9 @@ export default connect(mapStateToProps)(props => (
           </div>
         </div>
         <div id="new-version" className="flash-message">
-          <div className="inner">{__('misc.newversion')}</div>
+          <div className="inner">
+            <span dangerouslySetInnerHTML={{ __html: __('misc.newversion') }} />
+          </div>
         </div>
 
         <div

--- a/web/src/layout/tooltips.js
+++ b/web/src/layout/tooltips.js
@@ -58,7 +58,7 @@ export default () => (
         {__('tooltips.temporaryDataOutage')}
       </div>
       <div className="no-parser-text">
-        <span dangerouslySetInnerHTML={{ __html: __('country-panel.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region') }} />
+        <span dangerouslySetInnerHTML={{ __html: __('tooltips.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region') }} />
       </div>
     </div>
     <div id="exchange-tooltip" className="tooltip panel">

--- a/web/src/layout/tooltips.js
+++ b/web/src/layout/tooltips.js
@@ -58,7 +58,7 @@ export default () => (
         {__('tooltips.temporaryDataOutage')}
       </div>
       <div className="no-parser-text">
-        {__('tooltips.noParserInfo')}
+        <span dangerouslySetInnerHTML={{ __html: __('country-panel.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region') }} />
       </div>
     </div>
     <div id="exchange-tooltip" className="tooltip panel">


### PR DESCRIPTION
Inspired by #2146 and a similar bug I came across (see the screenshot), I went through the localisations that contained some HTML and wrapped them with `dangerouslySetInnerHTML` spans if they weren't made so previously (most of such localisations are presented in FAQ and they were already handled well).

Localisations fixed:

* `country-panel.noParserInfo`
* `tooltips.noParserInfo`
* `misc.newversion`

![image](https://user-images.githubusercontent.com/1216874/72074558-6e2ae200-32f2-11ea-84a7-2a239623bebd.png)

I also updated the links pointing to adding new regions doc to a correct header link https://github.com/tmrowco/electricitymap-contrib#adding-a-new-region.
