### PR TITLE
Migrate LanguageSelect component to React

### DIFF
--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -29,6 +29,7 @@
     "jsx-a11y/anchor-is-valid": "warn",
     "jsx-a11y/alt-text": "warn",
     "jsx-a11y/click-events-have-key-events": "warn",
+    "jsx-a11y/no-noninteractive-element-interactions": "warn",
     "jsx-a11y/no-static-element-interactions": "warn",
     "max-len": "warn",
     "no-await-in-loop": "warn",

--- a/web/src/components/languageselect.js
+++ b/web/src/components/languageselect.js
@@ -1,45 +1,62 @@
-const d3 = Object.assign(
-  {},
-  require('d3-array'),
-  require('d3-collection'),
-  require('d3-selection'),
-);
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { map } from 'lodash';
 
-const { languageNames } = require('../../locales-config.json');
+import { __ } from '../helpers/translation';
+import { languageNames } from '../../locales-config.json';
 
-export default class LanguageSelect {
-  constructor(selectorId) {
-    this.selectorId = selectorId;
-    this.visibleListItems = [];
-  }
+const mapStateToProps = state => ({
+  isMobile: state.application.isMobile,
+});
 
+const LanguageSelect = ({ isMobile }) => {
+  const [showLanguages, setShowLanguages] = useState(false);
+  const [showTooltip, setShowTooltip] = useState(false);
 
-  render() {
-    this._createListItems();
-    this._setItemNames();
-    this._setItemClickHandlers();
-  }
+  // Mouseovers will trigger on click on mobile and is therefore only set on desktop
+  const handleMouseOver = () => {
+    if (!isMobile) setShowTooltip(true);
+  };
+  const handleMouseOut = () => {
+    if (!isMobile) setShowTooltip(false);
+  };
+  const handleClick = () => {
+    setShowLanguages(!showLanguages);
+  };
+  const handleLanguageSelect = (key) => {
+    window.location.href = window.isCordova ? `index_${key}.html` : `${window.location.href}&lang=${key}`;
+  };
 
-  _createListItems() {
-    this.selector = d3.select(this.selectorId)
-      .selectAll('li')
-      .data(Object.entries(languageNames));
+  return (
+    <div>
+      <button
+        type="button"
+        className="layer-button language-select-button"
+        onClick={handleClick}
+        onFocus={handleMouseOver}
+        onMouseOver={handleMouseOver}
+        onMouseOut={handleMouseOut}
+        onBlur={handleMouseOut}
+      />
+      {showTooltip && (
+        <div id="language-select-button-tooltip" className="layer-button-tooltip">
+          <div className="tooltip-container">
+            <div className="tooltip-text">{__('tooltips.selectLanguage')}</div>
+            <div className="arrow" />
+          </div>
+        </div>
+      )}
+      {showLanguages && (
+        <div id="language-select-container">
+          {map(languageNames, (language, key) => (
+            <li key={key} onClick={() => handleLanguageSelect(key)}>
+              {language}
+            </li>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
-    const itemLinks = this.selector.enter().append('li');
-
-    this.visibleListItems = itemLinks.nodes();
-    this.selector = itemLinks.merge(this.selector);
-  }
-
-  _setItemNames() {
-    this.selector.text(([key, language]) => language);
-  }
-
-  _setItemClickHandlers() {
-    if (window.isCordova) {
-      this.selector.on('click', ([key, language]) => { window.location.href = `index_${key}.html`; });
-    } else {
-      this.selector.on('click', ([key, language]) => { window.location.href = `${window.location.href}&lang=${key}`; });
-    }
-  }
-}
+export default connect(mapStateToProps)(LanguageSelect);

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -1,20 +1,13 @@
 import React from 'react';
 
+import LanguageSelect from '../components/languageselect';
+
 // Modules
 import { __ } from '../helpers/translation';
 
 export default () => (
   <div className="layer-buttons-container">
-    <div>
-      <button type="button" className="layer-button language-select-button" />
-      <div id="language-select-button-tooltip" className="layer-button-tooltip hidden">
-        <div className="tooltip-container">
-          <div className="tooltip-text">{__('tooltips.selectLanguage')}</div>
-          <div className="arrow" />
-        </div>
-      </div>
-      <div id="language-select-container" className="hidden" />
-    </div>
+    <LanguageSelect />
     <div>
       <button type="button" className="layer-button wind-button" />
       <div id="wind-layer-button-tooltip" className="layer-button-tooltip hidden">

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -15,7 +15,6 @@ import SearchBar from './components/searchbar';
 import ZoneMap from './components/map';
 import FAQ from './components/faq';
 import TimeSlider from './components/timeslider';
-import LanguageSelect from './components/languageselect';
 import CountryTable from './components/countrytable';
 import AreaGraph from './components/areagraph';
 import LineGraph from './components/linegraph';
@@ -205,8 +204,6 @@ const faq = new FAQ('.faq');
 const mobileFaq = new FAQ('.mobile-faq');
 
 const zoneDetailsTimeSlider = new TimeSlider('.zone-time-slider', dataEntry => dataEntry.stateDatetime);
-
-const languageSelect = new LanguageSelect('#language-select-container');
 
 // Initialise mobile app (cordova)
 const app = {
@@ -847,25 +844,6 @@ const prodConsButtonTootltip = d3.select('#production-toggle-tooltip');
 d3.select('.production-toggle-info').on('click', () => {
   prodConsButtonTootltip.classed('hidden', !prodConsButtonTootltip.classed('hidden'));
 });
-
-function selectLanguage() {
-  getState().application.selectLanguageShown = !getState().application.selectLanguageShown;
-  d3.select('#language-select-container').classed('hidden', !getState().application.selectLanguageShown);
-}
-
-d3.select('.language-select-button').on('click', selectLanguage);
-const selectLanguageButtonTooltip = d3.select('#language-select-button-tooltip');
-if (!getState().application.isMobile) {
-  // Mouseovers will trigger on click on mobile and is therefore only set on desktop
-  d3.select('.language-select-button').on('mouseover', () => {
-    selectLanguageButtonTooltip.classed('hidden', false);
-  });
-  d3.select('.language-select-button').on('mouseout', () => {
-    selectLanguageButtonTooltip.classed('hidden', true);
-  });
-}
-
-languageSelect.render();
 
 // Collapse button
 document.getElementById('left-panel-collapse-button').addEventListener('click', () =>

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -23,7 +23,6 @@ const initialApplicationState = {
   clientType: window.isCordova ? 'mobileapp' : 'web',
   colorBlindModeEnabled: cookieGetBool('colorBlindModeEnabled', false),
   brightModeEnabled: cookieGetBool('brightModeEnabled', true),
-  selectLanguageShown: false,
   customDate: null,
   electricityMixMode: 'consumption',
   isCordova: window.isCordova,


### PR DESCRIPTION
Part of https://github.com/tmrowco/electricitymap-contrib/issues/1681#issuecomment-572014604.

I quickly tested hovering (with the tooltip), toggling the language selection button and selecting the language.

**Note:** The fade in/out animation for the tooltip and the language list seems to have been part of D3 default behaviour - I didn't bring it across in this PR as I thought it didn't add any value and I prefered to keep the render code clean and minimal. @corradio if you feel that we should keep the animation in this PR, please let me know, it should still be pretty straightforward to add it to React.
