### PR TITLE
Don't center the map around zones clicked on the map

### DIFF
--- a/web/src/components/zonelist.js
+++ b/web/src/components/zonelist.js
@@ -88,6 +88,7 @@ const ZoneList = ({
   const handleClick = (countryCode) => {
     dispatchApplication('showPageState', 'country');
     dispatchApplication('selectedZoneName', countryCode);
+    dispatchApplication('centeredZoneName', countryCode);
   };
 
   // Keyboard navigation

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -348,6 +348,7 @@ try {
     .setCo2color(co2color)
     .setScrollZoom(!getState().application.isEmbedded)
     .onDragEnd(() => {
+      dispatchApplication('centeredZoneName', null);
       // Somehow there is a drag event sent before the map data is loaded.
       // We want to ignore it.
       if (!mapDraggedSinceStart && getState().data.grid.datetime) {
@@ -530,7 +531,7 @@ function renderMap(state) {
     if (selectedZoneName) {
       console.log(`Centering on selectedZoneName ${selectedZoneName}`);
       // eslint-disable-next-line no-use-before-define
-      centerOnZoneName(state, selectedZoneName, 4);
+      dispatchApplication('centeredZoneName', selectedZoneName);
       hasCenteredMap = true;
     } else if (callerLocation) {
       console.log('Centering on browser location @', callerLocation);
@@ -1411,9 +1412,9 @@ observe(state => state.application.windEnabled, (windEnabled, state) => {
   }
 });
 
-observe(state => state.application.selectedZoneName, (selectedZoneName, state) => {
-  if (selectedZoneName) {
-    centerOnZoneName(state, selectedZoneName, 4);
+observe(state => state.application.centeredZoneName, (centeredZoneName, state) => {
+  if (centeredZoneName) {
+    centerOnZoneName(state, centeredZoneName, 4);
   }
 });
 

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -20,6 +20,7 @@ const initialApplicationState = {
   version: VERSION,
   callerLocation: null,
   callerZone: null,
+  centeredZoneName: null,
   clientType: window.isCordova ? 'mobileapp' : 'web',
   colorBlindModeEnabled: cookieGetBool('colorBlindModeEnabled', false),
   brightModeEnabled: cookieGetBool('brightModeEnabled', true),


### PR DESCRIPTION
Resolves #2156.

I introduced `centeredZoneName` (separately from `selectedZoneName`) to the application state to handle the cases differently.

Now the map centers on load if `countryCode` is provided in query params and when clicking on the zone list, but it doesn't center when different zones are selected by clicking on the map.
