### PR TITLE
More rigorous data validity checks in LineGraph accessors

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -156,21 +156,21 @@ const countryTable = new CountryTable('.country-table-container', modeColor, mod
 
 const countryHistoryCarbonGraph = new LineGraph(
   '#country-history-carbon',
-  d => moment(d.stateDatetime).toDate(),
+  d => d && d.stateDatetime && moment(d.stateDatetime).toDate(),
   d => (getState().application.electricityMixMode === 'consumption'
-    ? (d || {}).co2intensity
-    : (d || {}).co2intensityProduction),
+    ? d && d.co2intensity
+    : d && d.co2intensityProduction),
   d => (getState().application.electricityMixMode === 'consumption'
-    ? (d || {}).co2intensity
-    : (d || {}).co2intensityProduction),
+    ? d && d.co2intensity
+    : d && d.co2intensityProduction),
   d => 'g/kWh'
 );
 
 const countryHistoryPricesGraph = new LineGraph(
   '#country-history-prices',
-  d => moment(d.stateDatetime).toDate(),
-  d => (d.price || {}).value,
-  d => d.price && d.price.value != null,
+  d => d && d.stateDatetime && moment(d.stateDatetime).toDate(),
+  d => d && d.price && d.price.value,
+  d => d && d.price && d.price.value != null,
 ).gradient(false);
 
 const countryTableExchangeTooltip = new Tooltip('#countrypanel-exchange-tooltip');


### PR DESCRIPTION
Hopefully fixes #2167.

Apparently one of the `LineGraph` accessors was trying to read `d.price` when `d` datapoint was undefined - I added some additional checks to all these accessors to prevent the issue from happening or at least to bump the error to a place where it should be easier to determine _why_ it was happening.

My first thought was that this got introduced with #2148, but this issue seems `LineGraph` specific so now I'm not sure how it could have :thinking: Hopefully moving `LineGraph` to React would make these less likely to happen.
