### PR TITLE
Fix the way DOM nodes are iterated in FAQ component

### DIFF
--- a/web/src/components/faq.js
+++ b/web/src/components/faq.js
@@ -98,7 +98,10 @@ const FAQ = ({ className }) => {
   const ref = useRef(null);
   setTimeout(() => {
     if (ref && ref.current) {
-      ref.current.querySelectorAll('.entry-link').forEach((link) => {
+      const links = ref.current.querySelectorAll('.entry-link');
+      // This seems to be the most browser-compatible way to iterate through a list of nodes.
+      // See: https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example.
+      Array.prototype.forEach.call(links, (link) => {
         const entryKey = link.href.split('#')[1];
         if (entryKey) {
           link.onclick = () => { setAnswerVisible(entryKey, true); };


### PR DESCRIPTION
Fixes #2165.

The issue was introduced in #2160 - apparently not all browsers support `forEach` on DOM nodes lists.

#### References

* https://developer.mozilla.org/en-US/docs/Web/API/NodeList#Example
* https://css-tricks.com/snippets/javascript/loop-queryselectorall-matches/
