### PR TITLE
Add solar to US-MISO parser

### DIFF
--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -13,6 +13,7 @@ mapping = {'Coal': 'coal',
            'Natural Gas': 'gas',
            'Nuclear': 'nuclear',
            'Wind': 'wind',
+           'Solar': 'solar',
            'Other': 'unknown'}
 
 wind_forecast_url = 'https://api.misoenergy.org/MISORTWDDataBroker/DataBrokerServices.asmx?messageType=getWindForecast&returnType=json'


### PR DESCRIPTION
Solar production was recently added to the MISO real-time displays: https://www.misoenergy.org/markets-and-operations/real-time--market-data/real-time-displays/

Tested locally:

```
$ python test_parser.py US-MISO
parser result:
{'zoneKey': 'US-MISO', 'datetime': datetime.datetime(2020, 1, 20, 15, 20, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York')), 'production': {'coal': 33316.0, 'gas': 28002.0, 'nuclear': 13429.0, 'wind': 1896.0, 'solar': 233.0, 'unknown': 1475.0}, 'storage': {}, 'source': 'misoenergy.org'}
---------------------
took 0.19s
min returned datetime: 2020-01-20T20:20:00+00:00 UTC
max returned datetime: 2020-01-20T20:20:00+00:00 UTC  -- OK, <2h from now :) (now=2020-01-20T20:25:22.670350+00:00 UTC)
```
