### PR TITLE
Added utc=True for use with old versions of pandas

### DIFF
--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -151,6 +151,7 @@ def fetch_production(zone_key = 'US-SPP', session=None, target_datetime=None, lo
         raw_data.rename(columns={'GMTTime':'GMT MKT Interval'},inplace=True)
 
         raw_data['GMT MKT Interval'] = pd.to_datetime(raw_data['GMT MKT Interval'], utc=True)
+        end = target_datetime
         start = target_datetime - datetime.timedelta(days=1)
         start = max(start, raw_data['GMT MKT Interval'].min())
         raw_data = raw_data[(raw_data['GMT MKT Interval'] >= start)&(raw_data['GMT MKT Interval']<= end)]

--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -55,7 +55,7 @@ def data_processor(df, logger):
     # Remove leading whitespace in column headers.
     df.columns = df.columns.str.strip()
     df = df.rename(columns={'Gas Self': 'Natural Gas Self'}) #Fix naming error which otherwise misclassifies Gas Self as Unknown
-
+    print(df.columns)
     #Some historical csvs split the production into 'Market' and 'Self',
     #So first we need to combine those.
     for col in df.columns:
@@ -150,8 +150,7 @@ def fetch_production(zone_key = 'US-SPP', session=None, target_datetime=None, lo
         #In some cases the timeseries column is named differently, so we standardize it
         raw_data.rename(columns={'GMTTime':'GMT MKT Interval'},inplace=True)
 
-        raw_data['GMT MKT Interval'] = pd.to_datetime(raw_data['GMT MKT Interval'])
-        end = target_datetime
+        raw_data['GMT MKT Interval'] = pd.to_datetime(raw_data['GMT MKT Interval'], utc=True)
         start = target_datetime - datetime.timedelta(days=1)
         start = max(start, raw_data['GMT MKT Interval'].min())
         raw_data = raw_data[(raw_data['GMT MKT Interval'] >= start)&(raw_data['GMT MKT Interval']<= end)]


### PR DESCRIPTION
The server version of pandas (0.23.4) raises an error when fetching data from SPP because it does not automatically assume it is in utc.