### PR TITLE
Fix Western Australia parser: add browser headers to CSV URL requests

### DIFF
--- a/parsers/AU_WA.py
+++ b/parsers/AU_WA.py
@@ -5,6 +5,7 @@ import datetime
 import arrow
 import requests
 import pandas as pd
+import io
 
 from .lib import AU_solar
 
@@ -12,6 +13,16 @@ from .lib import AU_solar
 timezone = 'Australia/Perth'
 
 HOURS_TO_GET = 24
+
+
+def get_csv_data(url):
+    response = requests.get(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.76 Safari/537.36"
+        },
+    )
+    return io.StringIO(response.content.decode("utf-8"))
 
 
 def fetch_production(zone_key='AUS-WA', session=None, target_datetime=None, logger=None):
@@ -24,7 +35,7 @@ def fetch_production(zone_key='AUS-WA', session=None, target_datetime=None, logg
     allSolar = AU_solar.fetch_solar_all(session, HOURS_TO_GET)
 
     urlMeta = 'http://wa.aemo.com.au/aemo/data/wa/infographic/facility-meta.csv'
-    dfFacilityMeta = pd.read_csv(urlMeta)
+    dfFacilityMeta = pd.read_csv(get_csv_data(urlMeta))
     dfFacilityMeta = dfFacilityMeta.drop(['PARTICIPANT_CODE', 'FACILITY_TYPE',
                                           'ALTERNATE_FUEL', 'GENERATION_TYPE',
                                           'YEAR_COMMISSIONED', 'YEAR_COMMISSIONED',
@@ -32,7 +43,7 @@ def fetch_production(zone_key='AUS-WA', session=None, target_datetime=None, logg
                                           'RAMP_UP', 'RAMP_DOWN', 'AS_AT'], axis=1)
 
     urlIntervals = 'http://wa.aemo.com.au/aemo/data/wa/infographic/facility-intervals-last96.csv'
-    dfFacilityIntervals = pd.read_csv(urlIntervals)
+    dfFacilityIntervals = pd.read_csv(get_csv_data(urlIntervals))
     dfFacilityIntervals = dfFacilityIntervals.drop(['PARTICIPANT_CODE', 'PCT_ALT_FUEL',
                                                     'PEAK_MW', 'OUTAGE_MW', 'PEAK_OUTAGE_MW',
                                                     'INTERVALS_GENERATING', 'TOTAL_INTERVALS',


### PR DESCRIPTION
Addresses #2134 

The Western Australia parser is currently offline because the following lines in `fetch_production` are returning a 403 forbidden error:
```
urlMeta = 'http://wa.aemo.com.au/aemo/data/wa/infographic/facility-meta.csv'
dfFacilityMeta = pd.read_csv(urlMeta)
```
I have no issues downloading that CSV file on my computer: it seems like the website has started to block requests from non-browser user agents.

This PR adds a function that requests the CSV urls with a browser user-agent header and returns a StringIO object that is then passed to `pd.read_csv()`. I've tested it locally and the parser works for me with these changes.