### PR TITLE
Added solar threshold so negative values are capped to 0

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -92,6 +92,9 @@ def fetch_production_mix(zone_key, session=None, target_datetime=None, logger=No
         if not mix:
             continue
         for point in mix:
+            if type == 'solar' and point['value'] < 0:
+                point['value'] = 0
+
             point.update({
                 'production': {type: point.pop('value')},
                 'storage': {},  # required by merge_production_outputs()


### PR DESCRIPTION
Not sure if this is the right place to add this threshold, however, US-TN values from EIA apparently are negative quite often (basically every night) and thus the output is failing our quality checks and then no data can be imported into the database. It seems like this is a common issue for US data (see #2183 and #2178 ). This would cap any negative solar values from EIA to 0. 

I say this might not be the right place for this because perhaps we should make this a blanket measure for all parsers? Also does anyone know why these values are negative? perhaps it is to reflect solar-battery setups that charge in the night?