### PR TITLE
Fix AUS-WA for change in source data format

### DIFF
--- a/parsers/AU_WA.py
+++ b/parsers/AU_WA.py
@@ -76,9 +76,9 @@ def fetch_production(zone_key='AUS-WA', session=None, target_datetime=None, logg
         # so multiply by 2 to get MW value
         production['capacity'] *= 2
 
-        production.ix['oil'] = production.ix['Distillate']
+        production.loc['oil'] = production.loc['Distillate']
         production.drop('Distillate', inplace=True)
-        production.ix['unknown'] = production.ix['Landfill Gas']
+        production.loc['unknown'] = production.loc['Landfill Gas']
         production.drop('Landfill Gas', inplace=True)
         production.index = production.index.str.lower()
 

--- a/parsers/AU_WA.py
+++ b/parsers/AU_WA.py
@@ -66,7 +66,10 @@ def fetch_production(zone_key='AUS-WA', session=None, target_datetime=None, logg
             continue
 
         tempdf = dfCombined.loc[dfCombined['PERIOD'] == timestamp]
-        production = pd.DataFrame(tempdf.groupby('PRIMARY_FUEL').sum())
+        production = pd.DataFrame(
+            data=tempdf.groupby('PRIMARY_FUEL').sum(),
+            columns=['ACTUAL_MW', 'POTENTIAL_MWH']
+            )
         production.columns = ['production', 'capacity']
 
         # capacity is specified to be "MWh" and the data points are very 30 minutes


### PR DESCRIPTION
The AUS-WA parser is currently down with this error:
```
ValueError: Length mismatch: Expected axis has 4 elements, new values have 2 elements
```
It looks like there has been a change in the source data - line 69 was returning columns for latitude and longitude as well as the production and capacity data.

This PR fixes that issue, as well as replacing the [deprecated](https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated) `.ix` indexer with `.log`