### PR TITLE
Added DUK, NEVP, SC (BA), SOCO

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -3963,6 +3963,29 @@
     },
     "timezone": null
   },
+  "US-DUK": {
+    "comment": "Duke Energy Carolinas",
+    "bounding_box": [
+      [
+        -83.2518,
+        34.2505
+      ],
+      [
+        -79.1045,
+        36.2525
+      ]
+    ],
+    "parsers": {
+      "production": "EIA.fetch_production_mix",
+      "consumption": "EIA.fetch_consumption",
+      "consumptionForecast": "EIA.fetch_consumption_forecast"
+    },
+    "contributors": [
+      "https://github.com/systemcatch"
+    ],
+    "flag_file_name": "us.png",
+    "timezone": "US/Eastern"
+  },
   "US-SEC": {
     "bounding_box": [
       [
@@ -4183,6 +4206,29 @@
     },
     "timezone": null
   },
+  "US-NEVP": {
+    "comment": "Nevada Power Company",
+    "bounding_box": [
+      [
+        -118.7481,
+        35.8322
+      ],
+      [
+        -112.9336,
+        41.9947
+      ]
+    ],
+    "parsers": {
+      "production": "EIA.fetch_production_mix",
+      "consumption": "EIA.fetch_consumption",
+      "consumptionForecast": "EIA.fetch_consumption_forecast"
+    },
+    "contributors": [
+      "https://github.com/systemcatch"
+    ],
+    "flag_file_name": "us.png",
+    "timezone": null
+  },
   "US-NV": {
     "bounding_box": [
       [
@@ -4281,15 +4327,47 @@
     "timezone": null
   },
   "US-SC": {
+    "comment": "South Carolina Public Service Authority",
     "bounding_box": [
       [
-        -83.110764,
-        31.964076
+        -81.6726,
+        32.7536
       ],
       [
-        -78.58189,
-        35.06872
+        -78.9549,
+        34.4838
       ]
+    ],
+    "parsers": {
+      "production": "EIA.fetch_production_mix",
+      "consumption": "EIA.fetch_consumption",
+      "consumptionForecast": "EIA.fetch_consumption_forecast"
+    },
+    "contributors": [
+      "https://github.com/systemcatch"
+    ],
+    "flag_file_name": "us.png",
+    "timezone": "US/Eastern"
+  },
+  "US-SOCO": {
+    "comment": "Southern Company Services, Inc",
+    "bounding_box": [
+      [
+        -88.9689,
+        30.3916
+      ],
+      [
+        -81.915,
+        34.5297
+      ]
+    ],
+    "parsers": {
+      "production": "EIA.fetch_production_mix",
+      "consumption": "EIA.fetch_consumption",
+      "consumptionForecast": "EIA.fetch_consumption_forecast"
+    },
+    "contributors": [
+      "https://github.com/systemcatch"
     ],
     "flag_file_name": "us.png",
     "timezone": null
@@ -4317,12 +4395,12 @@
     "timezone": null,
     "bounding_box": [
       [
-        -104.55665897762971,
-        42.01833904950752
+        -103.9005,
+        33.5302
       ],
       [
-        -95.95355839210612,
-        46.44202068870379
+        -95.6571,
+        48.2931
       ]
     ]
   },

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -29,19 +29,26 @@ EXCHANGES = {
     'US-NY->US-PJM': 'EBA.NYIS-PJM.ID.H'
 }
 # based on https://www.eia.gov/beta/electricity/gridmonitor/dashboard/electric_overview/US48/US48
+# or https://www.eia.gov/opendata/qb.php?category=3390101
+# List includes regions and Balancing Authorities. 
 REGIONS = {
     'US-BPA': 'BPAT',
     'US-CA': 'CAL',
     'US-CAR': 'CAR',
+    'US-DUK': 'DUK', #Duke Energy Carolinas
     'US-SPP': 'CENT',
     'US-FL': 'FLA',
     'US-PJM': 'MIDA',
     'US-MISO': 'MIDW',
     'US-NEISO': 'NE',
+    'US-NEVP': 'NEVP', #Nevada Power Company
     'US-NY': 'NY',
     'US-NW': 'NW',
+    'US-SC': 'SC', #South Carolina Public Service Authority
     'US-SE': 'SE',
     'US-SEC': 'SEC',
+    'US-SOCO': 'SOCO', #Southern Company Services Inc - Trans
+    'US-SWPP': 'SWPP', #Southwest Power Pool
     'US-SVERI': 'SW',
     'US-TN': 'TEN',
     'US-TX': 'TEX',


### PR DESCRIPTION
Added some balancing authority zones for US. Specifically DUK, NEVP, SC, and SOCO. Naming based on abbreviations from EIA (https://www.eia.gov/opendata/qb.php?category=3390101). 

Bounding boxes based on https://hifld-geoplatform.opendata.arcgis.com/datasets/control-areas/data

Zone geometries to be updated later, but we want to get the parser data in our database asap. 