### PR TITLE
Fix bad key in Peru parser

### DIFF
--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -108,7 +108,7 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=g
                 datetimes.append(dt)
                 data.append({
                     'zoneKey': zone_key,
-                    'dt': dt.datetime,
+                    'datetime': dt.datetime,
                     'production': {},
                     'source': 'coes.org.pe'
                 })


### PR DESCRIPTION
ref #2241 

```
(EM) chris@ThinkPad:~/electricitymap$ python test_parser.py PE
parser result:
[{'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 0, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 245.57206, 'gas': 2622.33428, 'hydro': 8487.11606, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 1, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 207.81862, 'gas': 2629.73896, 'hydro': 8493.27932, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 1, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 197.37632, 'gas': 2604.5952, 'hydro': 8314.81624, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 199.05856, 'gas': 2585.02918, 'hydro': 8161.43298, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 2, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 214.31484, 'gas': 2529.72198, 'hydro': 7993.9451, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 3, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 190.92692, 'gas': 2601.47322, 'hydro': 7908.0194, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 3, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 90.228, 'gas': 2574.572, 'hydro': 8011.8591, 'solar': -0.734}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 4, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 61.18, 'gas': 2575.906, 'hydro': 7866.0771, 'solar': -0.734}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 4, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 145.224, 'gas': 2565.398, 'hydro': 7878.8011, 'solar': -0.734}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 5, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 114.956, 'gas': 2626.74, 'hydro': 7929.89718, 'solar': -0.724}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 5, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 266.28, 'gas': 2582.2955, 'hydro': 8360.53542, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 6, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 255.28, 'gas': 2582.2955, 'hydro': 8514.50024, 'solar': 1.34}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 6, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 257.26, 'gas': 2582.2955, 'hydro': 8489.88216, 'solar': 37.62}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 7, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 254.86, 'gas': 2582.2955, 'hydro': 8581.41362, 'solar': 133.84}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 7, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 239.14, 'gas': 2641.09438, 'hydro': 8748.90372, 'solar': 222.44}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 8, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 235.28, 'gas': 2692.09832, 'hydro': 8696.54614, 'solar': 284.58}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 8, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 235.04, 'gas': 2940.3155, 'hydro': 8925.77428, 'solar': 327.2}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 9, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 233.72, 'gas': 3182.93068, 'hydro': 8956.83644, 'solar': 359.2}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 9, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 263.34, 'gas': 3397.86464, 'hydro': 9006.3114, 'solar': 390.92}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 10, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 263.34, 'gas': 3458.86416, 'hydro': 9077.65728, 'solar': 405.26}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 10, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 1.8, 'wind': 285.34, 'gas': 3500.50436, 'hydro': 9241.98882, 'solar': 403.44}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 11, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 291.7, 'gas': 3605.57114, 'hydro': 9367.64292, 'solar': 388.22}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 11, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 354.8, 'gas': 3603.38336, 'hydro': 9442.9783, 'solar': 358.46}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 12, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 360.0, 'gas': 3524.79198, 'hydro': 9436.04822, 'solar': 347.62}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 12, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 410.2, 'gas': 3529.69706, 'hydro': 9301.76542, 'solar': 361.1}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 13, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 416.6, 'gas': 3548.5722, 'hydro': 9261.97078, 'solar': 339.14}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 13, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 0.0, 'unknown': 0.0, 'coal': 0.0, 'oil': 0.0, 'wind': 395.0, 'gas': 3544.41786, 'hydro': 9163.70294, 'solar': 341.18}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 0, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.07, 'unknown': 17.2, 'coal': 0.0, 'oil': 0.0, 'wind': 139.9878, 'gas': 2401.60506, 'hydro': 8547.94488, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 1, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.23, 'unknown': 17.2, 'coal': 0.0, 'oil': 0.0, 'wind': 132.676, 'gas': 2315.10226, 'hydro': 8630.71632, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 1, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.1, 'unknown': 16.8, 'coal': 0.0, 'oil': 169.00744, 'wind': 180.01806, 'gas': 2381.23686, 'hydro': 8182.65246, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 2, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.02, 'unknown': 16.8, 'coal': 0.0, 'oil': 169.63168, 'wind': 221.44786, 'gas': 2403.4839, 'hydro': 7992.66814, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 2, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.08, 'unknown': 16.8, 'coal': 0.0, 'oil': 171.3343, 'wind': 265.86718, 'gas': 2140.56474, 'hydro': 8080.1611, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 3, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.13, 'unknown': 16.8, 'coal': 0.0, 'oil': 169.3491, 'wind': 245.9615, 'gas': 2089.96362, 'hydro': 8067.59328, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 3, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 31.54, 'unknown': 16.8, 'coal': 0.0, 'oil': 171.52372, 'wind': 220.89358, 'gas': 2212.53496, 'hydro': 7930.43974, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 4, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.35, 'unknown': 16.8, 'coal': 0.0, 'oil': 170.87954, 'wind': 200.5711, 'gas': 2109.07742, 'hydro': 8003.86558, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 4, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.59, 'unknown': 16.8, 'coal': 0.0, 'oil': 168.44026, 'wind': 193.6013, 'gas': 2095.0623, 'hydro': 8073.67728, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 5, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 31.05, 'unknown': 16.8, 'coal': 0.0, 'oil': 167.82974, 'wind': 161.08062, 'gas': 2169.88354, 'hydro': 8185.28412, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 5, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 31.89, 'unknown': 14.8, 'coal': 0.0, 'oil': 166.28894, 'wind': 145.69544, 'gas': 2174.0961, 'hydro': 8317.51578, 'solar': 0.14444}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 6, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.06, 'unknown': 14.8, 'coal': 0.0, 'oil': 171.49828, 'wind': 128.4619, 'gas': 2217.9931, 'hydro': 8649.64408, 'solar': 1.71624}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 6, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.60114, 'unknown': 14.8, 'coal': 0.0, 'oil': 169.09266, 'wind': 126.19532, 'gas': 2224.75724, 'hydro': 8651.06284, 'solar': 9.00122}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 7, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.89408, 'unknown': 14.8, 'coal': 0.0, 'oil': 170.91546, 'wind': 116.62964, 'gas': 2247.06718, 'hydro': 8712.58402, 'solar': 27.66378}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 7, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.3926, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.44582, 'wind': 113.28786, 'gas': 2649.68562, 'hydro': 8816.03122, 'solar': 64.70302}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 8, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.6348, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.52198, 'wind': 102.05836, 'gas': 2807.31948, 'hydro': 8859.76224, 'solar': 163.74918}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 8, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.4523, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.7864, 'wind': 99.96934, 'gas': 3078.42164, 'hydro': 9305.41468, 'solar': 241.96796}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 9, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.5735, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.83224, 'wind': 100.72722, 'gas': 3421.21526, 'hydro': 9241.90718, 'solar': 355.68032}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 9, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 28.13, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.70102, 'wind': 140.6546, 'gas': 3572.5906, 'hydro': 9274.39694, 'solar': 441.21832}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 10, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.57, 'unknown': 15.2, 'coal': 0.0, 'oil': 169.88464, 'wind': 118.99864, 'gas': 3722.31446, 'hydro': 9360.8512, 'solar': 330.33356}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 10, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.5, 'unknown': 15.4, 'coal': 0.0, 'oil': 170.2233, 'wind': 226.3888, 'gas': 3790.55454, 'hydro': 9432.04896, 'solar': 364.26402}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 11, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.5, 'unknown': 15.4, 'coal': 0.0, 'oil': 169.24754, 'wind': 239.5344, 'gas': 3925.32356, 'hydro': 9410.15442, 'solar': 334.52504}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 11, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 31.3, 'unknown': 15.4, 'coal': 0.0, 'oil': 169.9239, 'wind': 282.7704, 'gas': 3884.56588, 'hydro': 9246.74302, 'solar': 297.63418}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 12, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.44, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.73826, 'wind': 309.25314, 'gas': 4178.9041, 'hydro': 9214.63314, 'solar': 219.04938}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 12, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 31.84, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.1909, 'wind': 363.73452, 'gas': 4150.57994, 'hydro': 9250.77372, 'solar': 219.22292}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 13, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.29, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.31204, 'wind': 324.91814, 'gas': 3935.08974, 'hydro': 9365.62474, 'solar': 234.76386}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 13, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 31.03, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.97182, 'wind': 304.61788, 'gas': 4122.48766, 'hydro': 9372.30488, 'solar': 132.8766}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 14, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 35.38, 'unknown': 15.2, 'coal': 0.0, 'oil': 166.5404, 'wind': 259.87724, 'gas': 4137.58432, 'hydro': 9335.77492, 'solar': 130.1334}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 14, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 34.64, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.97258, 'wind': 262.7367, 'gas': 4214.31432, 'hydro': 9426.10402, 'solar': 140.7361}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 15, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.77, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.13494, 'wind': 302.9988, 'gas': 4217.78846, 'hydro': 9358.73666, 'solar': 119.30488}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 15, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 34.17, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.42098, 'wind': 334.85606, 'gas': 4190.45754, 'hydro': 9354.5042, 'solar': 86.88634}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 16, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 36.79, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.50876, 'wind': 370.20616, 'gas': 4150.22568, 'hydro': 9236.57088, 'solar': 47.50664}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 16, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 34.63, 'unknown': 15.2, 'coal': 0.0, 'oil': 167.52782, 'wind': 372.10562, 'gas': 4227.36072, 'hydro': 9071.95512, 'solar': 29.42606}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 17, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 35.29, 'unknown': 15.2, 'coal': 0.0, 'oil': 171.47896, 'wind': 409.44868, 'gas': 3885.75724, 'hydro': 9127.64956, 'solar': 19.10104}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 17, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 35.53, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.09864, 'wind': 481.22138, 'gas': 3780.15018, 'hydro': 9035.69902, 'solar': 10.58282}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 18, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 34.18, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.21978, 'wind': 523.14142, 'gas': 3726.78778, 'hydro': 8756.10004, 'solar': 1.588}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 18, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 27.06, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.14034, 'wind': 531.24558, 'gas': 3700.00368, 'hydro': 8849.47442, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 19, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 29.99, 'unknown': 13.2, 'coal': 0.0, 'oil': 169.62668, 'wind': 525.11496, 'gas': 3778.57846, 'hydro': 9257.4019, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 19, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 34.08, 'unknown': 13.2, 'coal': 0.0, 'oil': 171.18242, 'wind': 535.09302, 'gas': 3777.3025, 'hydro': 9187.70522, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 20, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.01, 'unknown': 13.2, 'coal': 0.0, 'oil': 169.42176, 'wind': 531.49388, 'gas': 3544.84686, 'hydro': 9314.68014, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 20, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.87, 'unknown': 13.2, 'coal': 0.0, 'oil': 170.41096, 'wind': 506.38148, 'gas': 3523.74392, 'hydro': 9301.65004, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 21, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 27.89, 'unknown': 15.2, 'coal': 0.0, 'oil': 169.95516, 'wind': 415.316, 'gas': 3606.02324, 'hydro': 9177.4347, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 21, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.32, 'unknown': 13.2, 'coal': 0.0, 'oil': 169.54146, 'wind': 411.26926, 'gas': 3652.10842, 'hydro': 9132.7641, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 22, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.73, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.06402, 'wind': 367.71806, 'gas': 4007.55314, 'hydro': 9153.5796, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 22, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 30.87, 'unknown': 15.2, 'coal': 0.0, 'oil': 168.71668, 'wind': 304.69506, 'gas': 3794.73356, 'hydro': 9095.69216, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 23, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.04, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.63454, 'wind': 294.81632, 'gas': 3338.21604, 'hydro': 9064.98606, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 24, 23, 30, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 32.66, 'unknown': 15.2, 'coal': 0.0, 'oil': 170.48126, 'wind': 309.60896, 'gas': 3091.12452, 'hydro': 8923.09246, 'solar': 0.0}, 'source': 'coes.org.pe'}, {'zoneKey': 'PE', 'datetime': datetime.datetime(2020, 2, 25, 0, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/Lima')), 'production': {'biomass': 33.27, 'unknown': 15.2, 'coal': 0.0, 'oil': 0.0, 'wind': 288.45974, 'gas': 2842.39796, 'hydro': 8644.95096, 'solar': 185.605}, 'source': 'coes.org.pe'}]
---------------------
took 4.23s
min returned datetime: 2020-02-24T05:30:00+00:00 UTC
max returned datetime: 2020-02-25T18:30:00+00:00 UTC  -- OK, <2h from now :) (now=2020-02-25T18:51:04.001503+00:00 UTC)
```