### PR TITLE
Corrected_CL_datetimes

### DIFF
--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -22,12 +22,7 @@ def timestamp_creator(date, hour):
 
     arr_date = arrow.get(date, "YYYY-MM-DD")
 
-    # NOTE in the data source each day starts on hour 1 and ends on 24!
-
-    if hour == 24:
-        arr_dt = arr_date.shift(days=+1)
-    else:
-        arr_dt = arr_date.replace(hour=hour)
+    hour -= 1 # NOTE: hora 1 refers to 00:00 to 01:00
 
     dt = arr_dt.replace(tzinfo='Chile/Continental').datetime
 

--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -22,9 +22,10 @@ def timestamp_creator(date, hour):
 
     arr_date = arrow.get(date, "YYYY-MM-DD")
 
-    hour -= 1 # NOTE: hora 1 refers to 00:00 to 01:00
-
-    dt = arr_dt.replace(tzinfo='Chile/Continental').datetime
+    hour -= 1
+    dt = pd.to_datetime(date, format='%Y-%m-%d').tz_localize('Chile/Continental')
+    dt = dt + pd.DateOffset(hours=hour)
+    dt = dt.tz_convert('UTC')
 
     return dt
 

--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -3,6 +3,7 @@
 """Parser for the electricity grid of Chile"""
 
 import arrow
+import pandas as pd
 import logging
 import requests
 from collections import defaultdict


### PR DESCRIPTION
The hours provided on the website range from 1-24, these refer to the index (starting at 1) of the hour blocks rather than the hour at which each of the blocks start.

This was checked by looking at average solar generation and using the previous method the peak production was around 13:30 whereas using the updated times it is around 12:30

![image](https://user-images.githubusercontent.com/29051639/75783764-fb217300-5d58-11ea-929a-3ea667f4af54.png)
