### PR TITLE
Add for attribute to make color-bind mode easier to click

### DIFF
--- a/web/src/layout/leftpanel/infotext.js
+++ b/web/src/layout/leftpanel/infotext.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = dispatch => ({
 export default connect(mapStateToProps, mapDispatchToProps)(({ dispatchApplication }) => (
   <div className="info-text small-screen-hidden">
     <p>
-      <label className="checkbox-container" for="checkbox-colorblind">
+      <label className="checkbox-container" htmlFor="checkbox-colorblind">
         {__('legends.colorblindmode')}
         <input type="checkbox" id="checkbox-colorblind" />
         <span className="checkmark" />

--- a/web/src/layout/leftpanel/infotext.js
+++ b/web/src/layout/leftpanel/infotext.js
@@ -21,7 +21,7 @@ const mapDispatchToProps = dispatch => ({
 export default connect(mapStateToProps, mapDispatchToProps)(({ dispatchApplication }) => (
   <div className="info-text small-screen-hidden">
     <p>
-      <label className="checkbox-container">
+      <label className="checkbox-container" for="checkbox-colorblind">
         {__('legends.colorblindmode')}
         <input type="checkbox" id="checkbox-colorblind" />
         <span className="checkmark" />


### PR DESCRIPTION
On the production website, there's an option for color blind mode, with a little checkbox when you visit on a mobile device:

![Screenshot 2020-03-06 at 11 51 55](https://user-images.githubusercontent.com/17906/76077668-71181b00-5fa1-11ea-8fff-9ae182b1206c.png)

Only the checkbox is clickable, when I'd expect the label to trigger the change, and after looking at the code I could see that there was no `for` attribute on the corresponding label the checkbox.

This PR adds a the React specific "htmlFor" value on for the label, which should make the whole label clickable, rather than just the checkbox one.

However, I can't test it locally so I think I need some pointers on how to do so.

I've checked out the code with `git clone git@github.com:tmrowco/electricitymap-contrib.git`, and run `docker-compose build` stuff, then `docker-compose up`, to get a local version running.

I have the local app running, but I'm not seeing the the same info page - I go to the [info page], and I don't see the colorblind mode. 

I know it's in the codebase, as I've been able to make the PR, but it's not clear how to see it.

What do I need to change to see this, and check my PR works as intended?

Ta,

[1]: https://www.electricitymap.org/?page=info&solar=false&remote=true&wind=false

![Screenshot 2020-03-06 at 11 51 47](https://user-images.githubusercontent.com/17906/76077761-a3c21380-5fa1-11ea-8227-670abe6393e0.png)
