### PR TITLE
update SG PV production cap

### DIFF
--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -105,7 +105,9 @@ def get_solar(session, logger):
             logger.warning(msg, extra={'key': 'SG'})
             return None
     else:
-        if solar > 200.0:
+        if solar > 400.0:
+            # 2020-03-06 https://www.ema.gov.sg/solarmap.aspx specifies installed PV capacity as 231 MWac
+            # give it some buffer for future growth but cap in case we greatly mis-read the data
             msg = "Solar generation is way over capacity - got {}".format(val)
             logger.warning(msg, extra={'key': 'SG'})
             return None


### PR DESCRIPTION
https://www.ema.gov.sg/solarmap.aspx currently specifies installed PV capacity as 231 MWac. The previous limit was added in early 2018 so there may well have been growth since. I've given it 400 MW to give some buffer for future growth.

The limit could arguably be 300 MW, comments welcome.

This was brought up in Slack by @q--, thank you!