### PR TITLE
Check that theme is defined when passing it to map setCo2color

### DIFF
--- a/web/src/components/map.js
+++ b/web/src/components/map.js
@@ -325,7 +325,9 @@ export default class Map {
 
   setCo2color(arg, theme) {
     this.co2color = arg;
-    this.theme = theme;
+    if (theme) {
+      this.theme = theme;
+    }
     this._setupMapColor();
     return this;
   }


### PR DESCRIPTION
`theme` param is not always passed to `setCo2color` (see below). Prior to this PR, it was unconditionally set in the method, which occasionally led to the state of `this.theme` being `undefined` in the map component.

https://github.com/tmrowco/electricitymap-contrib/blob/77b70262ec4b2a01a5d860d13672eb400947f59c/web/src/main.js#L309

That was a probable cause of [this Sentry issue](https://sentry.io/organizations/tomorrow/issues/1382469375/?project=1295430&query=is%3Aunresolved+device.brand%3ASamsung+device%3ASM-T720&statsPeriod=14d), so hopefully this PR resolves it.
