### PR TITLE
Update Poland solar capacity data - March reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Northern Ireland:[ENTSO-E] (https://m-transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Panama: [ETESA] (https://www.cnd.com.pa/informes.php?cat=5)
 - Poland  
-  - Solar: [PSE Twitter](https://twitter.com/pse_pl/status/1229378459601903617)
+  - Solar: [PSE Twitter](https://twitter.com/pse_pl/status/1237695748147462144)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Portugal
   - Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=PTA)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3324,7 +3324,7 @@
       "hydro storage": 1780,
       "nuclear": 0,
       "oil": 415,
-      "solar": 1472,
+      "solar": 1597,
       "wind": 5825
     },
     "contributors": [


### PR DESCRIPTION
Monthly update of poland solar capacity data according to newest tweet from PSE (Polish ElectroEnergetic Network)