### PR TITLE
SE wind capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -3605,7 +3605,7 @@
       "nuclear": 9100,
       "oil": 2251,
       "solar": 140,
-      "wind": 6120
+      "wind": 8984
     },
     "contributors": [
       "https://github.com/corradio"


### PR DESCRIPTION
Installed wind capacity in Sweden updated with 2019 statistics (8984 MW from 6120 MW).
Delete this commit if it already has been edited