### PR TITLE
Use React Motion in CircularGauge instead of D3 interpolation

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,6 +29,7 @@
     "moment": "^2.23.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-motion": "^0.5.2",
     "react-redux": "^7.1.3",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",

--- a/web/src/components/circulargauge.js
+++ b/web/src/components/circulargauge.js
@@ -1,89 +1,52 @@
+import React from 'react';
+import { Motion, spring } from 'react-motion';
+import { isFinite } from 'lodash';
+import { arc } from 'd3-shape';
+
 /* eslint-disable jsx-a11y/mouse-events-have-key-events */
 // TODO: re-enable rule
 
-import React from 'react';
+const CircularGauge = React.memo(({
+  fontSize = '1rem',
+  onMouseMove,
+  onMouseOut,
+  onMouseOver,
+  percentage = 0,
+  radius = 32,
+  thickness = 6,
+}) => {
+  const percentageFill = p => arc()
+    .startAngle(0)
+    .outerRadius(radius)
+    .innerRadius(radius - thickness)
+    .endAngle((p / 100) * 2 * Math.PI)();
 
-import * as d3Selection from 'd3-selection';
-import * as d3Transition from 'd3-transition';
-import * as d3Shape from 'd3-shape';
-import * as d3Interpolate from 'd3-interpolate';
-
-const d3 = {
-  ...d3Selection,
-  ...d3Transition,
-  ...d3Shape,
-  ...d3Interpolate,
-};
-
-const DEFAULT_RADIUS = '32';
-
-export default class extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.foregroundRef = React.createRef();
-
-    this.state = {
-      prevPercentage: 0,
-    };
-
-    const radius = this.props.radius || DEFAULT_RADIUS;
-    const lineWidth = this.props.lineWidth || '6';
-
-    this.arc = d3.arc()
-      .startAngle(0)
-      .innerRadius(radius - lineWidth)
-      .outerRadius(radius);
-  }
-
-  render() {
-    const fontSize = this.props.fontSize || '1rem';
-    const radius = this.props.radius || DEFAULT_RADIUS;
-    const percentage = Number.isNaN(this.props.percentage)
-      ? 0
-      : (this.props.percentage || 0);
-
-    const i = d3.interpolate(
-      (this.state.prevPercentage / 100) * 2 * Math.PI,
-      (percentage / 100) * 2 * Math.PI
-    );
-    d3.select(this.foregroundRef.current)
-      .transition()
-      .duration(500)
-      .attrTween(
-        'd',
-        () => t => this.arc.endAngle(i(t))(),
-      )
-      .on('end', () => this.setState({ prevPercentage: percentage }));
-
-    const { onMouseMove, onMouseOut, onMouseOver } = this.props;
-
-    return (
-      <div
-        onMouseOver={() => onMouseOver && onMouseOver()}
-        onMouseOut={() => onMouseOut && onMouseOut()}
-        onMouseMove={e => onMouseMove && onMouseMove(e.clientX, e.clientY)}
-      >
-        <svg width={radius * 2} height={radius * 2}>
-          <g transform={`translate(${radius},${radius})`}>
-            <g className="circular-gauge">
-              <path className="background" d={this.arc.endAngle(2 * Math.PI)()} />
-              <path
-                className="foreground"
-                d={this.arc.endAngle((percentage / 100) * 2 * Math.PI)()}
-                ref={this.foregroundRef}
-              />
-              <text style={{ textAnchor: 'middle', fontWeight: 'bold', fontSize }} dy="0.4em">
-                {
-                  this.props.percentage != null && !Number.isNaN(this.props.percentage)
-                    ? `${Math.round(percentage)}%`
-                    : '?'
-                }
-              </text>
-            </g>
+  return (
+    <div
+      onMouseOver={() => onMouseOver && onMouseOver()}
+      onMouseOut={() => onMouseOut && onMouseOut()}
+      onMouseMove={e => onMouseMove && onMouseMove(e.clientX, e.clientY)}
+    >
+      <svg width={radius * 2} height={radius * 2}>
+        <g transform={`translate(${radius},${radius})`}>
+          <g className="circular-gauge">
+            <path className="background" d={percentageFill(100)} />
+            <Motion
+              defaultStyle={{ percentage: 0 }}
+              style={{ percentage: spring(isFinite(percentage) ? percentage : 0) }}
+            >
+              {interpolated => (
+                <path className="foreground" d={percentageFill(interpolated.percentage)} />
+              )}
+            </Motion>
+            <text style={{ textAnchor: 'middle', fontWeight: 'bold', fontSize }} dy="0.4em">
+              {isFinite(percentage) ? `${Math.round(percentage)}%` : '?'}
+            </text>
           </g>
-        </svg>
-      </div>
-    );
-  }
-}
+        </g>
+      </svg>
+    </div>
+  );
+});
+
+export default CircularGauge;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5734,6 +5734,10 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -6322,20 +6326,20 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-prop-types@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
-  dependencies:
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
-prop-types@^15.7.2:
+prop-types@^15.5.8, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 protocol-buffers-schema@^3.3.1:
   version "3.3.2"
@@ -6455,6 +6459,12 @@ quote-stream@^1.0.1, quote-stream@~1.0.2:
     minimist "^1.1.3"
     through2 "^2.0.0"
 
+raf@^3.1.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  dependencies:
+    performance-now "^2.1.0"
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.6.tgz#d302c522948588848a8d300c932b44c24231da80"
@@ -6502,6 +6512,14 @@ react-dom@^16.12.0:
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+
+react-motion@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
+  dependencies:
+    performance-now "^0.2.0"
+    prop-types "^15.5.8"
+    raf "^3.1.0"
 
 react-redux@^7.1.3:
   version "7.1.3"


### PR DESCRIPTION
Resolves #2286 using [React Motion](https://github.com/chenglou/react-motion).

The animations seem smooth and roughly the same and they seem to be triggered all the time for me now when hovering over different zones on the map.
