### PR TITLE
Fix mounting of OnboardingModal

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -251,7 +251,7 @@ thirdPartyServices.trackWithCurrentApplicationState('Visit');
 
 // do not display onboarding when we've seen it or we're embedded
 if (!getState().application.onboardingSeen && !getState().application.isEmbedded) {
-  onboardingModal = new OnboardingModal('#main');
+  onboardingModal = new OnboardingModal('#app');
   thirdPartyServices.trackWithCurrentApplicationState('onboardingModalShown');
 }
 

--- a/web/src/scss/content/map/_map.scss
+++ b/web/src/scss/content/map/_map.scss
@@ -1,12 +1,3 @@
-#main {
-    position: fixed; /* This is done in order to ensure that dragging will not affect the body */
-    width: 100vw;
-    height: inherit;
-    display: flex;
-    flex-direction: column; /* children will be stacked vertically */
-    align-items: stretch; /* force children to take 100% width */
-}
-
 #map-container {
     position: relative;
     flex-grow: 1; /* This takes up available horizontal space */


### PR DESCRIPTION
While testing the `OnboardingModal` component, I figured I couldn't make it appear in the UI and then I realized that the mount CSS selector was wrong, which probably means none of the users were able to see the onboarding modal for a while now :astonished: 

So I changed the reference `#main` -> `#app` and removed some old SCSS code for `#main` that was never applied - [blame](https://github.com/tmrowco/electricitymap-contrib/blame/9ad12a36473fca289b2d69726b3780cc32c79730/web/src/scss/content/map/_map.scss) points to #2115, it seems like that code was introduced there.
