### PR TITLE
Fixes to how useRemoteEndpoint state is managed

### DIFF
--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -4,8 +4,8 @@ import { getKey } from '../helpers/storage';
 
 import dataReducer from './dataReducer';
 
-const isLocalhost = window.location.href.indexOf('electricitymap') !== -1
-  || window.location.href.indexOf('192.') !== -1;
+const isProduction = () => window.location.href.includes('electricitymap');
+const isLocalhost = () => !isProduction() && !window.location.href.includes('192.');
 
 const cookieGetBool = (key, defaultValue) => {
   const val = getKey(key);
@@ -33,8 +33,8 @@ const initialApplicationState = {
   isLeftPanelCollapsed: false,
   isMobile:
   (/android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i).test(navigator.userAgent),
-  isProduction: window.location.href.indexOf('electricitymap') !== -1,
-  isLocalhost,
+  isProduction: isProduction(),
+  isLocalhost: isLocalhost(),
   legendVisible: true,
   locale: window.locale,
   onboardingSeen: cookieGetBool('onboardingSeen', false),
@@ -45,7 +45,7 @@ const initialApplicationState = {
   selectedZoneName: null,
   selectedZoneTimeIndex: null,
   solarEnabled: cookieGetBool('solarEnabled', false),
-  useRemoteEndpoint: document.domain === '' || isLocalhost,
+  useRemoteEndpoint: false,
   windEnabled: cookieGetBool('windEnabled', false),
 
   // TODO(olc): refactor this state


### PR DESCRIPTION
After an incident with production upon merging of #2289, where https://www.electricitymap.org/ seems to have been fetching data from localhost while https://www.electricitymap.org/?remote=true worked fine (discovered by @corradio), I looked into how `useRemoteEndpoint` was being used and found 3 issues that this PR fixes:

* The `isLocalhost` constant seems to have been defined precisely as _not localhost_ so I changed it to its negative (this was making the initial value of `useRemoteEndpoint` [counterintuitive](https://github.com/tmrowco/electricitymap-contrib/compare/fbarl/fix-remote-endpoint-state?expand=1#diff-371801a35ab77b5d7dfd7aaf1dff84caL48))
* The `ENDPOINT` constant was initialized early on based on the initial state of the Redux state, instead of always being based on the current version of `useRemoteEndpoint` value - I changed it to a function to always take the latest state
* I also added stricter conditions to `getEndpoint` function for when to use the local endpoint - this is what ultimately fixes the problem as since #2289, `useRemoteEndpoint` is used as a mirror of the `remote` search param, while `ENDPOINT` constant was taking it as a condition for using the remote API endpoint (now the two are been decoupled)
