### PR TITLE
added clarification on data tooltip

### DIFF
--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -88,7 +88,7 @@
         "hideSolarLayer": "Hide solar layer",
         "toggleDarkMode": "Toggle dark-mode",
         "noParserInfo": "No data available",
-        "temporaryDataOutage": "Data temporarily unavailable",
+        "temporaryDataOutage": "Live data temporarily unavailable",
         "production": "production",
         "consumption": "consumption",
         "cpinfo": "<b>consumption</b> takes imports and exports into account, <b>production</b> ignores them",


### PR DESCRIPTION
For some US zones, while we don't have live data we do have historical data. To make sure this is clear, I want to update the tooltip you get when hovering over zones with a temporary data outage to clarify that specifically "live" data is unavailable.