### PR TITLE
Default showPageState to 'map' if page search param was not specified

### DIFF
--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -121,7 +121,7 @@ const applicationReducer = (state = initialApplicationState, action) => {
       return Object.assign({}, state, {
         customDate: searchParams.get('datetime'),
         selectedZoneName: searchParams.get('countryCode'),
-        showPageState: searchParams.get('page'),
+        showPageState: searchParams.get('page') || 'map', // Default to map view if page was not specified
         solarEnabled: searchParams.get('solar') === 'true',
         useRemoteEndpoint: searchParams.get('remote') === 'true',
         windEnabled: searchParams.get('wind') === 'true',


### PR DESCRIPTION
Fixes #2323.

If the app was opened without a `page` search param set, the initial `UPDATE_STATE_FROM_URL` would set `showPageState` to `undefined` which was resulting in nothing being rendered on the mobile app.

This PR uses `map` as a fallback value for `showPageState`, basically enforcing it to always be in a non-empty state.

Note that this is just a simple hotfix and a bigger routing PR is in the making that will hopefully make URL state management more explicit and less fragile - #2317.
