### PR TITLE
Added US zones to exceptions

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -63,7 +63,10 @@ def validate_production(obj, zone_key):
          obj.get('production', {}).get('coal', None) is None and
          obj.get('production', {}).get('oil', None) is None and
          obj.get('production', {}).get('gas', None) is None and zone_key
-         not in ['CH', 'NO', 'AUS-TAS', 'DK-BHM', 'US-NEISO'])):
+         not in ['CH', 'NO', 'AUS-TAS', 'DK-BHM', 'US-NEISO',
+                'US-CAR-YAD','US-NW-SCL','US-NW-CHPD',
+                'US-NW-WWA','US-NW-GCPD','US-NW-TWPR',
+                'US-NW-WAUW','US-SE-SEPA','US-NW-GWA'])):
         raise ValidationError(
             "Coal, gas or oil or unknown production value is required for"
             " %s" % zone_key)


### PR DESCRIPTION
Some of the new US zones do not have coal, oil, gas, or unknown production, but were not yet added to quality checks exceptions. This adds them.