### PR TITLE
Fix circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
           name: Start environment
           command: |
             set -euo pipefail
-            docker-compose up -d
+            docker-compose up -d web mockserver
             sleep 20
             docker-compose logs web
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,9 @@ jobs:
           name: Start environment
           command: |
             set -euo pipefail
+            # Only start the `web` and `mockserver` containers
+            # and avoid the `watch` container from starting and compiling
+            # the already built frontend
             docker-compose up -d web mockserver
             sleep 20
             docker-compose logs web


### PR DESCRIPTION
Fixes https://github.com/tmrowco/electricitymap-contrib/issues/2331

Turns out a `watch` container was also started, which would cause unnecessary reload of the API