### PR TITLE
Fix broken exchanges

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -534,7 +534,7 @@
       49.016577
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "CA_AB.fetch_exchange"
     },
     "rotation": 0
   },
@@ -554,7 +554,7 @@
       49.044392
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "CA_BC.fetch_exchange"
     },
     "rotation": 0
   },
@@ -624,7 +624,7 @@
       46.139
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "US_NEISO.fetch_exchange"
     },
     "rotation": 90
   },
@@ -674,7 +674,7 @@
       43.5523
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "US_NY.fetch_exchange"
     },
     "rotation": -45
   },
@@ -694,7 +694,7 @@
       45.011
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "US_NEISO.fetch_exchange"
     },
     "rotation": 0
   },
@@ -714,7 +714,7 @@
       45.004
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "US_NY.fetch_exchange"
     },
     "rotation": 0
   },

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -164,7 +164,8 @@ def fetch_exchange(zone_key1='CA-AB', zone_key2='CA-BC', session=None, target_da
     flows = {
         'CA-AB->CA-BC': df_exchanges[1][1]['British Columbia'],
         'CA-AB->CA-SK': df_exchanges[1][1]['Saskatchewan'],
-        'CA-AB->US-MT': df_exchanges[1][1]['Montana']
+        'CA-AB->US-MT': df_exchanges[1][1]['Montana'],
+        'CA-AB->US-NW-NWMT': df_exchanges[1][1]['Montana']
     }
     sortedZoneKeys = '->'.join(sorted([zone_key1, zone_key2]))
     if sortedZoneKeys not in flows:

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -38,11 +38,11 @@ def fetch_exchange(zone_key1=None, zone_key2=None, session=None, target_datetime
     datetime = arrow.get(
         arrow.get(obj[0], 'DD-MMM-YY HH:mm:ss').datetime, timezone).datetime
 
-    if (zone_key1 == 'CA-BC' and zone_key2 == 'US-BPA'):
-        sortedZoneKeys = 'CA-BC->US-BPA'
+    sortedZoneKeys = '->'.join(sorted([zone_key1, zone_key2]))
+
+    if sortedZoneKeys == 'CA-BC->US-BPA' or sortedZoneKeys == 'CA-BC->US-NW-BPAT':
         netFlow = float(obj[1])
-    elif (zone_key1 == 'CA-AB' and zone_key2 == 'CA-BC'):
-        sortedZoneKeys = 'CA-AB->CA-BC'
+    elif sortedZoneKeys == 'CA-AB->CA-BC':
         netFlow = -1 * float(obj[2])
     else:
         raise NotImplementedError('This exchange pair is not implemented')

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -199,7 +199,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None,
 
     s = session or requests.Session()
 
-    if sorted_zone_keys == 'MX-BC->US-CA':
+    if sorted_zone_keys == 'MX-BC->US-CA' or sorted_zone_keys == 'MX-BC->US-CAL-CISO':
         netflow = fetch_MX_exchange(s)
         exchange = {
           'sortedZoneKeys': sorted_zone_keys,

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -201,7 +201,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
     # For directions, note that ISO-NE always reports its import as negative
 
-    if sorted_zone_keys == 'CA-NB->US-NEISO':
+    if sorted_zone_keys == 'CA-NB->US-NEISO' or sorted_zone_keys == 'CA-NB->US-NE-ISNE':
         # CA-NB->US-NEISO means import to NEISO should be positive
         multiplier = -1
 
@@ -209,7 +209,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
             '_nstmp_zone0': '4010'  # ".I.SALBRYNB345 1"
         }
 
-    elif sorted_zone_keys == "CA-QC->US-NEISO":
+    elif sorted_zone_keys == "CA-QC->US-NEISO" or sorted_zone_keys == 'CA-QC->US-NE-ISNE':
         # CA-QC->US-NEISO means import to NEISO should be positive
         multiplier = -1
 
@@ -218,7 +218,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
             '_nstmp_zone1': '4013'  # ".I.HQHIGATE120 2"
         }
 
-    elif sorted_zone_keys == 'US-NEISO->US-NY':
+    elif sorted_zone_keys == 'US-NEISO->US-NY' or sorted_zone_keys == 'US-NE-ISNE->US-NY-NYIS':
         # US-NEISO->US-NY means import to NEISO should be negative
         multiplier = 1
 

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -192,16 +192,19 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
     # In the source CSV, positive is flow into NY, negative is flow out of NY.
     # In Electricity Map, A->B means flow to B is positive.
-    if sorted_zone_keys == 'US-NEISO->US-NY':
+    if sorted_zone_keys == 'US-NEISO->US-NY' or sorted_zone_keys == 'US-NE-ISNE->US-NY-NYIS':
         direction = 1
         relevant_exchanges = ['SCH - NE - NY', 'SCH - NPX_1385', 'SCH - NPX_CSC']
     elif sorted_zone_keys == 'US-NY->US-PJM':
         direction = -1
         relevant_exchanges = ['SCH - PJ - NY', 'SCH - PJM_HTP', 'SCH - PJM_NEPTUNE', 'SCH - PJM_VFT']
+    elif sorted_zone_keys == 'US-MIDA-PJM->US-NY-NYIS':
+        direction = 1
+        relevant_exchanges = ['SCH - PJ - NY', 'SCH - PJM_HTP', 'SCH - PJM_NEPTUNE', 'SCH - PJM_VFT']
     elif sorted_zone_keys == 'CA-ON->US-NY':
         direction = 1
         relevant_exchanges = ['SCH - OH - NY']
-    elif sorted_zone_keys == 'CA-QC->US-NY':
+    elif sorted_zone_keys == 'CA-QC->US-NY' or sorted_zone_keys == 'CA-QC->US-NY-NYIS':
         direction = 1
         relevant_exchanges = ['SCH - HQ_CEDARS', 'SCH - HQ - NY']
     else:

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -353,6 +353,9 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
     if sortedcodes == 'US-NY->US-PJM':
         flows = combine_NY_exchanges()
+    elif sortedcodes == 'US-MIDA-PJM->US-NY-NYIS':
+        flows = combine_NY_exchanges()
+        flows = [(-total, dt) for total,dt in flows]
     elif sortedcodes == 'US-MISO->US-PJM':
         flow = get_miso_exchange()
         exchange = {
@@ -362,7 +365,15 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
             'source': 'pjm.com'
         }
         return exchange
-
+    elif sortedcodes == 'US-MIDA-PJM->US-MIDW-MISO':
+        flow = get_miso_exchange()
+        exchange = {
+            'sortedZoneKeys': sortedcodes,
+            'datetime': flow[1],
+            'netFlow': -flow[0],
+            'source': 'pjm.com'
+        }
+        return exchange
     else:
         raise NotImplementedError('This exchange pair is not implemented')
 


### PR DESCRIPTION
Exchanges that were not using EIA were still broken since they were not using the new zone names in the individual parser files. This should fix this for all except US-CA/US-CAL-CISO which will take more investigation to split up among the BAs