### PR TITLE
Generalized Toggle component

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
     "sprintf-js": "^1.1.2",
+    "styled-components": "^5.0.1",
     "topojson": "^3.0.2"
   },
   "devDependencies": {
@@ -82,7 +83,7 @@
     "lint": "eslint --quiet src",
     "server-dev": "nodemon server.js",
     "watch": "webpack --watch --progress --mode development",
-    "watch-en": "webpack --watch --progress --mode development --config-name en",
+    "watch-en": "yarn install && webpack --watch --progress --mode development --config-name en",
     "watch-poll": "webpack --watch --watch-poll --progress --mode development"
   },
   "browserslist": [

--- a/web/package.json
+++ b/web/package.json
@@ -83,7 +83,7 @@
     "lint": "eslint --quiet src",
     "server-dev": "nodemon server.js",
     "watch": "webpack --watch --progress --mode development",
-    "watch-en": "yarn install && webpack --watch --progress --mode development --config-name en",
+    "watch-en": "webpack --watch --progress --mode development --config-name en",
     "watch-poll": "webpack --watch --watch-poll --progress --mode development"
   },
   "browserslist": [

--- a/web/src/components/infotooltip.js
+++ b/web/src/components/infotooltip.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+const Wrapper = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: flex-end;
+  position: absolute;
+  transition: all 0.4s;
+
+  ${props => (props.visible ? css`
+    opacity: 1;
+    transform: translateX(0px);
+    visibility: visible;
+  ` : css`
+    opacity: 0;
+    transform: translateX(10px);
+    visibility: hidden;
+  `)}
+`;
+
+const Content = styled.div`
+  background-color: #efefef;
+  border-radius: 4px;
+  box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
+  color: black;
+  font-size: 0.9rem;
+  padding: 5px 10px;
+  text-align: center;
+`;
+
+const InfoTooltip = ({ htmlContent, style, visible }) => (
+  <Wrapper style={style} visible={visible}>
+    <Content dangerouslySetInnerHTML={{ __html: htmlContent }} />
+  </Wrapper>
+);
+
+export default InfoTooltip;

--- a/web/src/components/toggle.js
+++ b/web/src/components/toggle.js
@@ -1,10 +1,6 @@
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
-import styled from 'styled-components';
 import { findIndex, isEmpty } from 'lodash';
-
-import { __ } from '../helpers/translation';
-import { dispatchApplication } from '../store';
+import styled, { css } from 'styled-components';
 
 const ToggleContainer = styled.div`
   border: none;
@@ -17,7 +13,7 @@ const ToggleContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   align-content: center;
-  background-color: $lighter-gray;
+  background-color: #efefef;
   border-radius: 18px;
   transition: box-shadow 0.4s;
 
@@ -47,7 +43,7 @@ const Item = styled.div`
   transition: all 0.4s;
   z-index: 9;
 
-  ${props => props.active && `
+  ${props => props.active && css`
     background: #ffffff;
     height: 28px;
     box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
@@ -84,9 +80,6 @@ const TooltipContainer = styled.div`
   align-items: center;
   justify-content: flex-end;
   top: 4px;
-  visibility: hidden;
-  opacity: 0;
-  transform: translateX(10px);
   transition: opacity 0.4s, visibility 0.4s, transform 0.4s;
 
   /* Position */
@@ -94,11 +87,15 @@ const TooltipContainer = styled.div`
   width: 204px;
   top: 49px;
 
-  ${props => props.visible && `
-    visibility: visible;
+  ${props => (props.visible ? css`
     opacity: 1;
     transform: translateX(0px);
-  `}
+    visibility: visible;
+  ` : css`
+    opacity: 0;
+    transform: translateX(10px);
+    visibility: hidden;
+  `)}
 `;
 
 const TooltipContent = styled.div`
@@ -145,21 +142,4 @@ const Toggle = ({
   );
 };
 
-const mapStateToProps = state => ({
-  electricityMixMode: state.application.electricityMixMode,
-});
-
-const ProdConsToggle = ({ electricityMixMode }) => (
-  <Toggle
-    className="prodcons-toggle-container"
-    infoHTML={__('tooltips.cpinfo')}
-    onChange={value => dispatchApplication('electricityMixMode', value)}
-    options={[
-      { value: 'production', label: __('tooltips.production') },
-      { value: 'consumption', label: __('tooltips.consumption') },
-    ]}
-    value={electricityMixMode}
-  />
-);
-
-export default connect(mapStateToProps)(ProdConsToggle);
+export default Toggle;

--- a/web/src/components/toggle.js
+++ b/web/src/components/toggle.js
@@ -2,20 +2,21 @@ import React, { useState } from 'react';
 import { findIndex, isEmpty } from 'lodash';
 import styled, { css } from 'styled-components';
 
-const ToggleContainer = styled.div`
-  border: none;
-  outline: none;
-  box-sizing: border-box;
-  cursor: pointer;
-  box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
-  height: 36px;
-  transition: all 0.4s;
-  display: flex;
-  justify-content: flex-end;
+import InfoTooltip from './infotooltip';
+
+const Wrapper = styled.div`
   align-content: center;
   background-color: #efefef;
+  border: none;
   border-radius: 18px;
-  transition: box-shadow 0.4s;
+  box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  height: 36px;
+  justify-content: flex-end;
+  outline: none;
+  transition: all 0.4s;
 
   &:hover {
     box-shadow: 2px 0px 20px 0px rgba(0,0,0,0.25);
@@ -23,19 +24,19 @@ const ToggleContainer = styled.div`
 `;
 
 const Options = styled.div`
+  align-content: center;
+  align-self: center;
   background: #efefef;
   border-radius: 14px;
   box-shadow: inset 0 1px 4px 0 rgba(0, 0, 0, 0.10);
   display: flex;
-  height: 28px;
   flex-direction: row;
+  height: 28px;
   justify-content: flex-end;
-  align-content: center;
-  align-self: center;
-  margin: 0 8px 0 4px;
+  margin: 0 4px;
 `;
 
-const Item = styled.div`
+const OptionItem = styled.div`
   border-radius: 14px 4px 4px 14px;
   font-size: 14px;
   line-height: 28px;
@@ -45,67 +46,31 @@ const Item = styled.div`
 
   ${props => props.active && css`
     background: #ffffff;
-    height: 28px;
-    box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
-    z-index: 8;
     border-radius: 14px;
+    box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
+    height: 28px;
+    z-index: 8;
   `}
 `;
 
 const InfoButton = styled.div`
-  height: 28px; 
-  width: 28px;
-  border-radius: 18px;
-  background: #ffffff;
-  display: flex;
-  justify-content: center;
   align-content: center;
   align-self: center;
-  margin: 0 4px;
+  background: #ffffff;
+  border-radius: 18px;
   box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.1);
+  display: flex;
   font-weight: bold;
+  height: 28px;
+  justify-content: center;
   line-height: 28px;
+  margin: 0 4px;
   transition: all 0.4s;
+  width: 28px;
 
   &:hover {
     box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.2);
   }
-`;
-
-const TooltipContainer = styled.div`
-  position: absolute;
-  left: -168px;
-  width: 150px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  top: 4px;
-  transition: opacity 0.4s, visibility 0.4s, transform 0.4s;
-
-  /* Position */
-  left: 4px;
-  width: 204px;
-  top: 49px;
-
-  ${props => (props.visible ? css`
-    opacity: 1;
-    transform: translateX(0px);
-    visibility: visible;
-  ` : css`
-    opacity: 0;
-    transform: translateX(10px);
-    visibility: hidden;
-  `)}
-`;
-
-const TooltipContent = styled.div`
-  color: black;
-  background-color: #efefef;
-  border-radius: 4px;
-  text-align: center;
-  font-size: 0.9rem;
-  padding: 5px 10px;
-  box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
 `;
 
 const Toggle = ({
@@ -122,23 +87,25 @@ const Toggle = ({
   const nextValue = options[nextIndex].value;
 
   return (
-    <ToggleContainer className={className}>
+    <Wrapper className={className}>
       <Options onClick={() => onChange(nextValue)}>
         {options.map(o => (
-          <Item key={o.value} active={o.value === value}>
+          <OptionItem key={o.value} active={o.value === value}>
             {o.label}
-          </Item>
+          </OptionItem>
         ))}
       </Options>
       {!isEmpty(infoHTML) && (
         <React.Fragment>
           <InfoButton onClick={() => setTooltipVisible(!tooltipVisible)}>i</InfoButton>
-          <TooltipContainer visible={tooltipVisible}>
-            <TooltipContent dangerouslySetInnerHTML={{ __html: infoHTML }} />
-          </TooltipContainer>
+          <InfoTooltip
+            htmlContent={infoHTML}
+            style={{ left: 4, width: 204, top: 49 }}
+            visible={tooltipVisible}
+          />
         </React.Fragment>
       )}
-    </ToggleContainer>
+    </Wrapper>
   );
 };
 

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -10,23 +10,25 @@ import Header from './header';
 import LayerButtons from './layerbuttons';
 import LeftPanel from './leftpanel';
 import Legend from './legend';
-import ProdConsToggle from './prodconstoggle';
 import Tabs from './tabs';
 import Tooltips from './tooltips';
 
 // Modules
 import { __ } from '../helpers/translation';
+import { dispatchApplication } from '../store';
 import OnboardingModal from '../components/onboardingmodal';
+import Toggle from '../components/toggle';
 
 // TODO: Move all styles from styles.css to here
 // TODO: Remove all unecessary id and class tags
 
 const mapStateToProps = state => ({
   brightModeEnabled: state.application.brightModeEnabled,
+  electricityMixMode: state.application.electricityMixMode,
   isLeftPanelCollapsed: state.application.isLeftPanelCollapsed,
 });
 
-export default connect(mapStateToProps)(props => (
+const Main = ({ brightModeEnabled, electricityMixMode, isLeftPanelCollapsed }) => (
   <React.Fragment>
     <div
       style={{
@@ -46,7 +48,7 @@ export default connect(mapStateToProps)(props => (
           <div id="zones" className="map-layer" />
           <canvas id="wind" className="map-layer" />
           <canvas id="solar" className="map-layer" />
-          <div id="watermark" className={`watermark small-screen-hidden ${props.brightModeEnabled ? 'brightmode' : ''}`}>
+          <div id="watermark" className={`watermark small-screen-hidden ${brightModeEnabled ? 'brightmode' : ''}`}>
             <a href="http://www.tmrow.com/mission?utm_source=electricitymap.org&utm_medium=referral&utm_campaign=watermark" target="_blank">
               <div id="built-by-tomorrow" />
             </a>
@@ -55,7 +57,16 @@ export default connect(mapStateToProps)(props => (
             </a>
           </div>
           <Legend />
-          <ProdConsToggle />
+          <Toggle
+            className="production-consumption-toggle"
+            infoHTML={__('tooltips.cpinfo')}
+            onChange={value => dispatchApplication('electricityMixMode', value)}
+            options={[
+              { value: 'production', label: __('tooltips.production') },
+              { value: 'consumption', label: __('tooltips.consumption') },
+            ]}
+            value={electricityMixMode}
+          />
           <LayerButtons />
         </div>
 
@@ -83,7 +94,7 @@ export default connect(mapStateToProps)(props => (
 
         <div
           id="left-panel-collapse-button"
-          className={`small-screen-hidden ${props.isLeftPanelCollapsed ? 'collapsed' : ''}`}
+          className={`small-screen-hidden ${isLeftPanelCollapsed ? 'collapsed' : ''}`}
           role="button"
           tabIndex="0"
         >
@@ -97,4 +108,6 @@ export default connect(mapStateToProps)(props => (
     <Tooltips />
     <OnboardingModal />
   </React.Fragment>
-));
+);
+
+export default connect(mapStateToProps)(Main);

--- a/web/src/layout/prodconstoggle.js
+++ b/web/src/layout/prodconstoggle.js
@@ -1,13 +1,118 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import styled from 'styled-components';
 import { findIndex, isEmpty } from 'lodash';
 
 import { __ } from '../helpers/translation';
 import { dispatchApplication } from '../store';
 
-// TODO: Move styles from styles.css to here
+const ToggleContainer = styled.div`
+  border: none;
+  outline: none;
+  box-sizing: border-box;
+  cursor: pointer;
+  box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
+  height: 36px;
+  transition: all 0.4s;
+  display: flex;
+  justify-content: flex-end;
+  align-content: center;
+  background-color: $lighter-gray;
+  border-radius: 18px;
+  transition: box-shadow 0.4s;
+
+  &:hover {
+    box-shadow: 2px 0px 20px 0px rgba(0,0,0,0.25);
+  }
+`;
+
+const Options = styled.div`
+  background: #efefef;
+  border-radius: 14px;
+  box-shadow: inset 0 1px 4px 0 rgba(0, 0, 0, 0.10);
+  display: flex;
+  height: 28px;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-content: center;
+  align-self: center;
+  margin: 0 8px 0 4px;
+`;
+
+const Item = styled.div`
+  border-radius: 14px 4px 4px 14px;
+  font-size: 14px;
+  line-height: 28px;
+  padding: 0 12px;
+  transition: all 0.4s;
+  z-index: 9;
+
+  ${props => props.active && `
+    background: #ffffff;
+    height: 28px;
+    box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
+    z-index: 8;
+    border-radius: 14px;
+  `}
+`;
+
+const InfoButton = styled.div`
+  height: 28px; 
+  width: 28px;
+  border-radius: 18px;
+  background: #ffffff;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  align-self: center;
+  margin: 0 4px;
+  box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.1);
+  font-weight: bold;
+  line-height: 28px;
+  transition: all 0.4s;
+
+  &:hover {
+    box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.2);
+  }
+`;
+
+const TooltipContainer = styled.div`
+  position: absolute;
+  left: -168px;
+  width: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  top: 4px;
+  visibility: hidden;
+  opacity: 0;
+  transform: translateX(10px);
+  transition: opacity 0.4s, visibility 0.4s, transform 0.4s;
+
+  /* Position */
+  left: 4px;
+  width: 204px;
+  top: 49px;
+
+  ${props => props.visible && `
+    visibility: visible;
+    opacity: 1;
+    transform: translateX(0px);
+  `}
+`;
+
+const TooltipContent = styled.div`
+  color: black;
+  background-color: #efefef;
+  border-radius: 4px;
+  text-align: center;
+  font-size: 0.9rem;
+  padding: 5px 10px;
+  box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
+`;
 
 const Toggle = ({
+  className,
   infoHTML,
   onChange,
   options,
@@ -20,23 +125,23 @@ const Toggle = ({
   const nextValue = options[nextIndex].value;
 
   return (
-    <div className="prodcons-toggle-container">
-      <div className="production-toggle" onClick={() => onChange(nextValue)}>
+    <ToggleContainer className={className}>
+      <Options onClick={() => onChange(nextValue)}>
         {options.map(o => (
-          <div key={o.value} className={`production-toggle-item production ${o.value === value ? 'production-toggle-active-overlay' : ''}`}>
+          <Item key={o.value} active={o.value === value}>
             {o.label}
-          </div>
+          </Item>
         ))}
-      </div>
+      </Options>
       {!isEmpty(infoHTML) && (
         <React.Fragment>
-          <div className="production-toggle-info" onClick={() => setTooltipVisible(!tooltipVisible)}>i</div>
-          <div id="production-toggle-tooltip" className={`layer-button-tooltip ${tooltipVisible ? '' : 'hidden'}`}>
-            <div className="tooltip-text" dangerouslySetInnerHTML={{ __html: infoHTML }} />
-          </div>
+          <InfoButton onClick={() => setTooltipVisible(!tooltipVisible)}>i</InfoButton>
+          <TooltipContainer visible={tooltipVisible}>
+            <TooltipContent dangerouslySetInnerHTML={{ __html: infoHTML }} />
+          </TooltipContainer>
         </React.Fragment>
       )}
-    </div>
+    </ToggleContainer>
   );
 };
 
@@ -46,6 +151,7 @@ const mapStateToProps = state => ({
 
 const ProdConsToggle = ({ electricityMixMode }) => (
   <Toggle
+    className="prodcons-toggle-container"
     infoHTML={__('tooltips.cpinfo')}
     onChange={value => dispatchApplication('electricityMixMode', value)}
     options={[

--- a/web/src/layout/prodconstoggle.js
+++ b/web/src/layout/prodconstoggle.js
@@ -1,32 +1,59 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import { findIndex, isEmpty } from 'lodash';
 
 import { __ } from '../helpers/translation';
+import { dispatchApplication } from '../store';
 
 // TODO: Move styles from styles.css to here
+
+const Toggle = ({
+  infoHTML,
+  onChange,
+  options,
+  value,
+}) => {
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+
+  const activeIndex = findIndex(options, { value });
+  const nextIndex = (activeIndex + 1) % options.length;
+  const nextValue = options[nextIndex].value;
+
+  return (
+    <div className="prodcons-toggle-container">
+      <div className="production-toggle" onClick={() => onChange(nextValue)}>
+        {options.map(o => (
+          <div key={o.value} className={`production-toggle-item production ${o.value === value ? 'production-toggle-active-overlay' : ''}`}>
+            {o.label}
+          </div>
+        ))}
+      </div>
+      {!isEmpty(infoHTML) && (
+        <React.Fragment>
+          <div className="production-toggle-info" onClick={() => setTooltipVisible(!tooltipVisible)}>i</div>
+          <div id="production-toggle-tooltip" className={`layer-button-tooltip ${tooltipVisible ? '' : 'hidden'}`}>
+            <div className="tooltip-text" dangerouslySetInnerHTML={{ __html: infoHTML }} />
+          </div>
+        </React.Fragment>
+      )}
+    </div>
+  );
+};
 
 const mapStateToProps = state => ({
   electricityMixMode: state.application.electricityMixMode,
 });
 
-export default connect(mapStateToProps)(props => (
-  <div className="prodcons-toggle-container">
-    <div className="production-toggle">
-      <div className={`production-toggle-item production ${props.electricityMixMode === 'production' ? 'production-toggle-active-overlay' : ''}`}>
-        {__('tooltips.production')}
-      </div>
-      <div className={`production-toggle-item consumption ${props.electricityMixMode !== 'production' ? 'production-toggle-active-overlay' : ''}`}>
-        {__('tooltips.consumption')}
-      </div>
-    </div>
-    <div className="production-toggle-info">
-      i
-    </div>
-    <div id="production-toggle-tooltip" className="layer-button-tooltip hidden">
-      <div className="tooltip-container">
-        <div className="tooltip-text" dangerouslySetInnerHTML={{ __html: __('tooltips.cpinfo') }} />
-        <div className="arrow" />
-      </div>
-    </div>
-  </div>
-));
+const ProdConsToggle = ({ electricityMixMode }) => (
+  <Toggle
+    infoHTML={__('tooltips.cpinfo')}
+    onChange={value => dispatchApplication('electricityMixMode', value)}
+    options={[
+      { value: 'production', label: __('tooltips.production') },
+      { value: 'consumption', label: __('tooltips.consumption') },
+    ]}
+    value={electricityMixMode}
+  />
+);
+
+export default connect(mapStateToProps)(ProdConsToggle);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -687,19 +687,6 @@ if (!getState().application.isMobile) {
   });
 }
 
-// Production/Consumption
-function toggleElectricityMixMode() {
-  dispatchApplication('electricityMixMode', getState().application.electricityMixMode === 'consumption'
-    ? 'production'
-    : 'consumption');
-}
-d3.select('.production-toggle').on('click', toggleElectricityMixMode);
-
-const prodConsButtonTootltip = d3.select('#production-toggle-tooltip');
-d3.select('.production-toggle-info').on('click', () => {
-  prodConsButtonTootltip.classed('hidden', !prodConsButtonTootltip.classed('hidden'));
-});
-
 // Collapse button
 document.getElementById('left-panel-collapse-button').addEventListener('click', () =>
   dispatchApplication('isLeftPanelCollapsed', !getState().application.isLeftPanelCollapsed));

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -69,8 +69,8 @@
 
 .production-consumption-toggle {
     position: absolute;
-    top: 10px;
-    right: 360px;
+    top: 70px;
+    right: 16px;
 
     @include respond-to('small') {
         top: 16px;
@@ -90,6 +90,11 @@
     transform: translateX(0px);
     transition: opacity 0.4s, visibility 0.4s, transform 0.4s;
 
+    .tooltip-container {
+        display: flex;
+        align-items: center;
+    }
+
     .tooltip-text {
         background-color:$lighter-gray;
         color: black;
@@ -100,17 +105,20 @@
         box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
     }
 
+    .arrow {
+        display:none;
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 7.5px 0 7.5px 10px;
+        border-color: transparent transparent transparent $lighter-gray;
+    }
+
     &.hidden {
         visibility: hidden;
         opacity: 0;
         transform: translateX(10px);
     }
-}
-
-#production-toggle-tooltip {
-    left: 4px;
-    width: 204px;
-    top: 49px;
 }
 
 #language-select-container {

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -177,15 +177,6 @@
         box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
     }
 
-    .arrow {
-        display:none;
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-width: 7.5px 0 7.5px 10px;
-        border-color: transparent transparent transparent $lighter-gray;
-    }
-
     &.hidden {
         visibility: hidden;
         opacity: 0;
@@ -197,10 +188,6 @@
     left: 4px;
     width: 204px;
     top: 49px;
-
-    .tooltip-text {
-        text-align: center;
-    }
 }
 
 #language-select-container {

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -71,81 +71,9 @@
     position: absolute;
     top: 70px;
     right: 16px;
-    border: none;
-    outline: none;
-    box-sizing: border-box;
-    cursor: pointer;
-    box-shadow: 0px 0px 10px 0px rgba(0,0,0,0.15);
-    height: 36px;
-    transition: all 0.4s;
-    display: flex;
-    justify-content: flex-end;
-    align-content: center;
-    background-color: $lighter-gray;
-    border-radius: 18px;
-    transition: box-shadow 0.4s;
-
-    &:hover {
-        box-shadow: 2px 0px 20px 0px rgba(0,0,0,0.25);
-    }
 
     @include respond-to('small') {
         top: 16px;
-    }
-}
-
-.production-toggle {
-    background: $light-gray;
-    border-radius: 14px;
-    box-shadow: inset 0 1px 4px 0 rgba(0, 0, 0, 0.10);
-    display: flex;
-    height: 28px; 
-    flex-direction: row;
-    justify-content: flex-end;
-    align-content: center;
-    align-self: center;
-    margin: 0 8px 0 4px;
-}
-
-.production-toggle-item {
-    font-size: 14px; 
-    line-height: 28px;
-    padding: 0 12px;
-    border-radius: 14px 4px 4px 14px;
-    z-index: 9;
-
-    &.active {
-        background: $white;
-        box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
-    }
-}
-
-.production-toggle-active-overlay {
-    background: #FFFFFF;
-    height: 28px;
-    box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.15);
-    z-index: 8;
-    border-radius: 14px;
-    transition: all 0.4s;
-}
-
-.production-toggle-info {
-    height: 28px; 
-    width: 28px;
-    border-radius: 18px;
-    background: #FFFFFF;
-    display: flex;
-    justify-content: center;
-    align-content: center;
-    align-self: center;
-    margin: 0 4px;
-    box-shadow: 0px 0px 2px 0px gitrgba(0,0,0,0.1);
-    font-weight: bold;
-    line-height: 28px;
-    transition: all 0.4s;
-
-    &:hover {
-        box-shadow: 0px 0px 4px 0px rgba(0,0,0,0.2);
     }
 }
 
@@ -161,11 +89,6 @@
     opacity: 1;
     transform: translateX(0px);
     transition: opacity 0.4s, visibility 0.4s, transform 0.4s;
-
-    .tooltip-container {
-        display: flex;
-        align-items: center;
-    }
 
     .tooltip-text {
         background-color:$lighter-gray;

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -67,10 +67,10 @@
     background-image: url(../images/language_select.svg);
 }
 
-.prodcons-toggle-container {
+.production-consumption-toggle {
     position: absolute;
-    top: 70px;
-    right: 16px;
+    top: 10px;
+    right: 360px;
 
     @include respond-to('small') {
         top: 16px;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8,6 +8,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
 "@babel/core@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.2.tgz#ea5b99693bcfc058116f42fa1dd54da412b29d91"
@@ -41,6 +48,16 @@
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
   dependencies:
     "@babel/types" "^7.7.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.9.0":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.4.tgz#12441e90c3b3c4159cdecf312075bf1a8ce2dbce"
+  integrity sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
+  dependencies:
+    "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -122,6 +139,15 @@
     "@babel/template" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/helper-function-name@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
+  integrity sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-get-function-arity@^7.0.0", "@babel/helper-get-function-arity@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz#c604886bc97287a1d1398092bc666bc3d7d7aa2d"
@@ -133,6 +159,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-hoist-variables@^7.7.0":
   version "7.7.0"
@@ -151,6 +184,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz#356438e2569df7321a8326644d4b790d2122cb74"
   dependencies:
     "@babel/types" "^7.7.4"
+
+"@babel/helper-module-imports@^7.0.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
+  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-module-imports@^7.7.0":
   version "7.7.0"
@@ -238,6 +278,18 @@
   dependencies:
     "@babel/types" "^7.7.4"
 
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
 "@babel/helper-wrap-function@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz#15af3d3e98f8417a60554acbb6c14e75e0b33b74"
@@ -263,6 +315,15 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.8.3":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.0.0", "@babel/parser@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.4.tgz#75ab2d7110c2cf2fa949959afb05fa346d2231bb"
@@ -270,6 +331,11 @@
 "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
+
+"@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
+  integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
 
 "@babel/plugin-proposal-async-generator-functions@^7.7.0":
   version "7.7.0"
@@ -711,6 +777,15 @@
     "@babel/parser" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/template@^7.8.3":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
+  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.6"
+    "@babel/types" "^7.8.6"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.7.4":
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558"
@@ -721,6 +796,21 @@
     "@babel/helper-split-export-declaration" "^7.7.4"
     "@babel/parser" "^7.7.4"
     "@babel/types" "^7.7.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
+"@babel/traverse@^7.4.5":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
+  integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
@@ -754,6 +844,37 @@
     esutils "^2.0.2"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@emotion/is-prop-valid@^0.8.3":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@mapbox/geojson-area@0.2.2":
   version "0.2.2"
@@ -1356,6 +1477,21 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+"babel-plugin-styled-components@>= 1":
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
+  integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -1949,6 +2085,11 @@ camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
 
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
+
 caniuse-api@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
@@ -2448,6 +2589,11 @@ csextends@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/csextends/-/csextends-1.2.0.tgz#6374b210984b54d4495f29c99d3dd069b80543e5"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -2498,6 +2644,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -4005,7 +4160,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   dependencies:
@@ -7201,6 +7356,11 @@ shallow-copy@~0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shapefile@^0.6.2:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/shapefile/-/shapefile-0.6.6.tgz#6fee152b9fb2b1c85f690285b692fb68c95a5f4f"
@@ -7596,6 +7756,22 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+styled-components@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.0.1.tgz#57782a6471031abefb2db5820a1876ae853bc619"
+  integrity sha512-E0xKTRIjTs4DyvC1MHu/EcCXIj6+ENCP8hP01koyoADF++WdBUOrSGwU1scJRw7/YaYOhDvvoad6VlMG+0j53A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.3"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -7626,7 +7802,7 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   dependencies:


### PR DESCRIPTION
Resolves #2325.

Tested on desktop and mobile, also for cases of toggle containing more than 2 options and the info tip not being passed.

#### Major changes

* Generalized `ProdConsToggle` component into a more robust stateless `Toggle` component with the same styles
* Pulled out the fading info tooltip into a separate `InfoTooltip` component - this component can be reused when addressing #2345 and could potentially converge to the `Tooltip` component in a longer run
* I moved all the relevant CSS styles into the component files here and I chose to do it with the newly introduced `styled-components` - the main reason I didn't use JS to embed styles in props is because I didn't know how to manage `&:hover` state nicely on the CSS level (without introducing a React component variable that would track hovers). @corradio WDYT about that? I can always switch away in this PR if we find another suitable alternative (see #2261).