### PR TITLE
Add wrapper to right-controls

### DIFF
--- a/web/src/components/toggle.js
+++ b/web/src/components/toggle.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { findIndex, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import styled, { css } from 'styled-components';
 
 import InfoTooltip from './infotooltip';
@@ -74,7 +74,6 @@ const InfoButton = styled.div`
 `;
 
 export default ({
-  className,
   infoHTML,
   onChange,
   options,
@@ -83,7 +82,7 @@ export default ({
   const [tooltipVisible, setTooltipVisible] = useState(false);
 
   return (
-    <Wrapper className={className}>
+    <Wrapper>
       <Options>
         {options.map(o => (
           <OptionItem key={o.value} active={o.value === value} onClick={() => onChange(o.value)}>

--- a/web/src/components/toggle.js
+++ b/web/src/components/toggle.js
@@ -73,7 +73,7 @@ const InfoButton = styled.div`
   }
 `;
 
-const Toggle = ({
+export default ({
   className,
   infoHTML,
   onChange,
@@ -82,15 +82,11 @@ const Toggle = ({
 }) => {
   const [tooltipVisible, setTooltipVisible] = useState(false);
 
-  const activeIndex = findIndex(options, { value });
-  const nextIndex = (activeIndex + 1) % options.length;
-  const nextValue = options[nextIndex].value;
-
   return (
     <Wrapper className={className}>
-      <Options onClick={() => onChange(nextValue)}>
+      <Options>
         {options.map(o => (
-          <OptionItem key={o.value} active={o.value === value}>
+          <OptionItem key={o.value} active={o.value === value} onClick={() => onChange(o.value)}>
             {o.label}
           </OptionItem>
         ))}
@@ -108,5 +104,3 @@ const Toggle = ({
     </Wrapper>
   );
 };
-
-export default Toggle;

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -57,16 +57,17 @@ const Main = ({ brightModeEnabled, electricityMixMode, isLeftPanelCollapsed }) =
             </a>
           </div>
           <Legend />
-          <Toggle
-            className="production-consumption-toggle"
-            infoHTML={__('tooltips.cpinfo')}
-            onChange={value => dispatchApplication('electricityMixMode', value)}
-            options={[
-              { value: 'production', label: __('tooltips.production') },
-              { value: 'consumption', label: __('tooltips.consumption') },
-            ]}
-            value={electricityMixMode}
-          />
+          <div className="controls-container">
+            <Toggle
+              infoHTML={__('tooltips.cpinfo')}
+              onChange={value => dispatchApplication('electricityMixMode', value)}
+              options={[
+                { value: 'production', label: __('tooltips.production') },
+                { value: 'consumption', label: __('tooltips.consumption') },
+              ]}
+              value={electricityMixMode}
+            />
+          </div>
           <LayerButtons />
         </div>
 

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -67,7 +67,7 @@
     background-image: url(../images/language_select.svg);
 }
 
-.production-consumption-toggle {
+.controls-container {
     position: absolute;
     top: 70px;
     right: 16px;


### PR DESCRIPTION
I've added a wrapper to start wrapper controls that appear on the right.
For now I've only wrapped the toggle but I'd be good if we could put them all there!