### PR TITLE
Poland capacity update

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
 - Northern Ireland:[ENTSO-E] (https://m-transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Panama: [ETESA] (https://www.cnd.com.pa/informes.php?cat=5)
 - Poland  
-  - Solar: [PSE Twitter](https://twitter.com/pse_pl/status/1237695748147462144)
+  - Solar: [PSE Twitter](https://twitter.com/pse_pl/status/1248502288152293378)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Portugal
   - Solar: [IRENA](http://resourceirena.irena.org/gateway/countrySearch/?countryCode=PTA)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3687,7 +3687,7 @@
       "hydro storage": 1780,
       "nuclear": 0,
       "oil": 359,
-      "solar": 1597,
+      "solar": 1695,
       "wind": 5953
     },
     "contributors": [

--- a/config/zones.json
+++ b/config/zones.json
@@ -3680,15 +3680,15 @@
       ]
     ],
     "capacity": {
-      "biomass": 597,
-      "coal": 30289,
-      "gas": 2401,
-      "hydro": 593,
+      "biomass": 880,
+      "coal": 29963,
+      "gas": 2812,
+      "hydro": 605,
       "hydro storage": 1780,
       "nuclear": 0,
-      "oil": 415,
+      "oil": 359,
       "solar": 1597,
-      "wind": 5825
+      "wind": 5953
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
New set of data is available in entsoe so I am updating the data here (except solar - this is being updated according to PSE tweets once a month) :
Old Values:
    "capacity": {
      "biomass": 597,
      "coal": 30289,
      "gas": 2401,
      "hydro": 593,
      "hydro storage": 1780,
      "nuclear": 0,
      "oil": 415,
      "solar": 1597,
      "wind": 5825
    },

New Values:
    "capacity": {
      "biomass": 880,
      "coal": 29963,
      "gas": 2812,
      "hydro": 605,
      "hydro storage": 1780,
      "nuclear": 0,
      "oil": 359,
      "solar": 1597,
      "wind": 5953
    },

As previously discussed (pull request #1764 ) Gas and Fossil Coal-derived numbers has been added together

Also I am adding monthly update of solar capacity according to data presented on Twitter by Polish ElectroEnergetic Network (https://twitter.com/pse_pl/status/1248502288152293378) as they have been published 3 days after my initial pull request.
New value of solar capacity is 1695.
README.md  file has been updated accordingly.