### PR TITLE
Migrate layer buttons to React + fix language selection bugs

### DIFF
--- a/web/src/components/brightmodetoggle.js
+++ b/web/src/components/brightmodetoggle.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { noop } from 'lodash';
+
+// Modules
+import { __ } from '../helpers/translation';
+import { saveKey } from '../helpers/storage';
+import { dispatchApplication } from '../store';
+
+export default () => {
+  const isMobile = useSelector(state => state.application.isMobile);
+
+  const brightModeEnabled = useSelector(state => state.application.brightModeEnabled);
+  const toggleBrightMode = () => {
+    dispatchApplication('brightModeEnabled', !brightModeEnabled);
+    saveKey('brightModeEnabled', !brightModeEnabled);
+  };
+
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const showTooltip = () => { setTooltipVisible(true); };
+  const hideTooltip = () => { setTooltipVisible(false); };
+
+  return (
+    <div>
+      <button
+        type="button"
+        className={`layer-button brightmode-button ${brightModeEnabled ? 'active' : ''}`}
+        onFocus={isMobile ? noop : showTooltip}
+        onMouseOver={isMobile ? noop : showTooltip}
+        onMouseOut={isMobile ? noop : hideTooltip}
+        onBlur={isMobile ? noop : hideTooltip}
+        onClick={toggleBrightMode}
+      />
+      {tooltipVisible && (
+        <div className="layer-button-tooltip">
+          <div className="tooltip-container">
+            <div className="tooltip-text">{__('tooltips.toggleDarkMode')}</div>
+            <div className="arrow" />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/src/components/buttontoggle.js
+++ b/web/src/components/buttontoggle.js
@@ -1,20 +1,22 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { noop } from 'lodash';
+import styled from 'styled-components';
+import { isEmpty, noop } from 'lodash';
 
-// Modules
-import { __ } from '../helpers/translation';
-import { saveKey } from '../helpers/storage';
-import { dispatchApplication } from '../store';
+const Button = styled.button`
+  background-color: #FFFFFF;
+  background-image: ${props => (props.active
+    ? `url(../images/${props.icon}_active.svg)`
+    : `url(../images/${props.icon}.svg)`)};
+`;
 
-export default () => {
+const ButtonToggle = ({
+  active,
+  icon,
+  onChange,
+  tooltip,
+}) => {
   const isMobile = useSelector(state => state.application.isMobile);
-
-  const brightModeEnabled = useSelector(state => state.application.brightModeEnabled);
-  const toggleBrightMode = () => {
-    dispatchApplication('brightModeEnabled', !brightModeEnabled);
-    saveKey('brightModeEnabled', !brightModeEnabled);
-  };
 
   const [tooltipVisible, setTooltipVisible] = useState(false);
   const showTooltip = () => { setTooltipVisible(true); };
@@ -22,19 +24,21 @@ export default () => {
 
   return (
     <div>
-      <button
+      <Button
         type="button"
-        className={`layer-button brightmode-button ${brightModeEnabled ? 'active' : ''}`}
+        className="layer-button"
         onFocus={isMobile ? noop : showTooltip}
         onMouseOver={isMobile ? noop : showTooltip}
         onMouseOut={isMobile ? noop : hideTooltip}
         onBlur={isMobile ? noop : hideTooltip}
-        onClick={toggleBrightMode}
+        onClick={onChange}
+        active={active}
+        icon={icon}
       />
-      {tooltipVisible && (
+      {tooltipVisible && !isEmpty(tooltip) && (
         <div className="layer-button-tooltip">
           <div className="tooltip-container">
-            <div className="tooltip-text">{__('tooltips.toggleDarkMode')}</div>
+            <div className="tooltip-text">{tooltip}</div>
             <div className="arrow" />
           </div>
         </div>
@@ -42,3 +46,5 @@ export default () => {
     </div>
   );
 };
+
+export default ButtonToggle;

--- a/web/src/components/languageselect.js
+++ b/web/src/components/languageselect.js
@@ -1,52 +1,29 @@
 import React, { useState } from 'react';
-import { connect } from 'react-redux';
 import { map } from 'lodash';
 
 import { __ } from '../helpers/translation';
 import { languageNames } from '../../locales-config.json';
 
-const mapStateToProps = state => ({
-  isMobile: state.application.isMobile,
-});
+import ButtonToggle from './buttontoggle';
 
-const LanguageSelect = ({ isMobile }) => {
-  const [showLanguages, setShowLanguages] = useState(false);
-  const [showTooltip, setShowTooltip] = useState(false);
+const LanguageSelect = () => {
+  const [languagesVisible, setLanguagesVisible] = useState(false);
+  const toggleLanguagesVisible = () => {
+    setLanguagesVisible(!languagesVisible);
+  };
 
-  // Mouseovers will trigger on click on mobile and is therefore only set on desktop
-  const handleMouseOver = () => {
-    if (!isMobile) setShowTooltip(true);
-  };
-  const handleMouseOut = () => {
-    if (!isMobile) setShowTooltip(false);
-  };
-  const handleClick = () => {
-    setShowLanguages(!showLanguages);
-  };
   const handleLanguageSelect = (key) => {
     window.location.href = window.isCordova ? `index_${key}.html` : `${window.location.href}&lang=${key}`;
   };
 
   return (
     <div>
-      <button
-        type="button"
-        className="layer-button language-select-button"
-        onClick={handleClick}
-        onFocus={handleMouseOver}
-        onMouseOver={handleMouseOver}
-        onMouseOut={handleMouseOut}
-        onBlur={handleMouseOut}
+      <ButtonToggle
+        onChange={toggleLanguagesVisible}
+        tooltip={__('tooltips.selectLanguage')}
+        icon="language_select"
       />
-      {showTooltip && (
-        <div id="language-select-button-tooltip" className="layer-button-tooltip">
-          <div className="tooltip-container">
-            <div className="tooltip-text">{__('tooltips.selectLanguage')}</div>
-            <div className="arrow" />
-          </div>
-        </div>
-      )}
-      {showLanguages && (
+      {languagesVisible && (
         <div id="language-select-container">
           {map(languageNames, (language, key) => (
             <li key={key} onClick={() => handleLanguageSelect(key)}>
@@ -59,4 +36,4 @@ const LanguageSelect = ({ isMobile }) => {
   );
 };
 
-export default connect(mapStateToProps)(LanguageSelect);
+export default LanguageSelect;

--- a/web/src/components/languageselect.js
+++ b/web/src/components/languageselect.js
@@ -16,6 +16,7 @@ const LanguageSelect = () => {
   const searchParams = useSearchParams();
   const handleLanguageSelect = (languageKey) => {
     // TODO: Figure a better way to switch between languages that doesn't require a page refresh.
+    // See https://github.com/tmrowco/electricitymap-contrib/issues/2382.
     if (window.isCordova) {
       window.location.href = `index_${languageKey}.html`;
     } else {

--- a/web/src/components/languageselect.js
+++ b/web/src/components/languageselect.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { map } from 'lodash';
 
 import { __ } from '../helpers/translation';
+import { useSearchParams } from '../helpers/router';
 import { languageNames } from '../../locales-config.json';
 
 import ButtonToggle from './buttontoggle';
@@ -12,8 +13,15 @@ const LanguageSelect = () => {
     setLanguagesVisible(!languagesVisible);
   };
 
-  const handleLanguageSelect = (key) => {
-    window.location.href = window.isCordova ? `index_${key}.html` : `${window.location.href}&lang=${key}`;
+  const searchParams = useSearchParams();
+  const handleLanguageSelect = (languageKey) => {
+    // TODO: Figure a better way to switch between languages that doesn't require a page refresh.
+    if (window.isCordova) {
+      window.location.href = `index_${languageKey}.html`;
+    } else {
+      searchParams.set('lang', languageKey);
+      window.location.search = `?${searchParams.toString()}`;
+    }
   };
 
   return (

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -114,6 +114,15 @@ export function setWindEnabled(windEnabled) {
   updateSearchParams(searchParams);
 }
 
+// TODO: Get rid of this when a better system is put in place for switching languages.
+// See https://github.com/tmrowco/electricitymap-contrib/issues/2382.
+export function hideLanguageSearchParam() {
+  const searchParams = getSearchParams();
+  searchParams.delete('lang');
+  history.replace(`?${searchParams.toString()}`);
+}
+hideLanguageSearchParam();
+
 //
 // Redux state sync
 //

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -1,31 +1,47 @@
 import React from 'react';
-
-import LanguageSelect from '../components/languageselect';
-import BrightModeToggle from '../components/brightmodetoggle';
+import { useSelector } from 'react-redux';
 
 import { __ } from '../helpers/translation';
+import { saveKey } from '../helpers/storage';
+import { dispatchApplication } from '../store';
 
-export default () => (
-  <div className="layer-buttons-container">
-    <LanguageSelect />
-    <div>
-      <button type="button" className="layer-button wind-button" />
-      <div id="wind-layer-button-tooltip" className="layer-button-tooltip hidden">
-        <div className="tooltip-container">
-          <div className="tooltip-text">{__('tooltips.showWindLayer')}</div>
-          <div className="arrow" />
+import LanguageSelect from '../components/languageselect';
+import ButtonToggle from '../components/buttontoggle';
+
+export default () => {
+  const brightModeEnabled = useSelector(state => state.application.brightModeEnabled);
+  const toggleBrightMode = () => {
+    dispatchApplication('brightModeEnabled', !brightModeEnabled);
+    saveKey('brightModeEnabled', !brightModeEnabled);
+  };
+
+  return (
+    <div className="layer-buttons-container">
+      <LanguageSelect />
+      <div>
+        <button type="button" className="layer-button wind-button" />
+        <div id="wind-layer-button-tooltip" className="layer-button-tooltip hidden">
+          <div className="tooltip-container">
+            <div className="tooltip-text">{__('tooltips.showWindLayer')}</div>
+            <div className="arrow" />
+          </div>
         </div>
       </div>
-    </div>
-    <div>
-      <button type="button" className="layer-button solar-button" />
-      <div id="solar-layer-button-tooltip" className="layer-button-tooltip hidden">
-        <div className="tooltip-container">
-          <div className="tooltip-text">{__('tooltips.showSolarLayer')}</div>
-          <div className="arrow" />
+      <div>
+        <button type="button" className="layer-button solar-button" />
+        <div id="solar-layer-button-tooltip" className="layer-button-tooltip hidden">
+          <div className="tooltip-container">
+            <div className="tooltip-text">{__('tooltips.showSolarLayer')}</div>
+            <div className="arrow" />
+          </div>
         </div>
       </div>
+      <ButtonToggle
+        active={brightModeEnabled}
+        onChange={toggleBrightMode}
+        tooltip={__('tooltips.toggleDarkMode')}
+        icon="brightmode"
+      />
     </div>
-    <BrightModeToggle />
-  </div>
-);
+  );
+};

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -3,12 +3,21 @@ import { useSelector } from 'react-redux';
 
 import { __ } from '../helpers/translation';
 import { saveKey } from '../helpers/storage';
+import {
+  useSolarEnabled,
+  setSolarEnabled,
+} from '../helpers/router';
 import { dispatchApplication } from '../store';
 
 import LanguageSelect from '../components/languageselect';
 import ButtonToggle from '../components/buttontoggle';
 
 export default () => {
+  const solarEnabled = useSolarEnabled();
+  const toggleSolar = () => {
+    setSolarEnabled(!solarEnabled);
+  };
+
   const brightModeEnabled = useSelector(state => state.application.brightModeEnabled);
   const toggleBrightMode = () => {
     dispatchApplication('brightModeEnabled', !brightModeEnabled);
@@ -27,15 +36,12 @@ export default () => {
           </div>
         </div>
       </div>
-      <div>
-        <button type="button" className="layer-button solar-button" />
-        <div id="solar-layer-button-tooltip" className="layer-button-tooltip hidden">
-          <div className="tooltip-container">
-            <div className="tooltip-text">{__('tooltips.showSolarLayer')}</div>
-            <div className="arrow" />
-          </div>
-        </div>
-      </div>
+      <ButtonToggle
+        active={solarEnabled}
+        onChange={toggleSolar}
+        tooltip={__(solarEnabled ? 'tooltips.hideSolarLayer' : 'tooltips.showSolarLayer')}
+        icon="weather/sun"
+      />
       <ButtonToggle
         active={brightModeEnabled}
         onChange={toggleBrightMode}

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -4,6 +4,8 @@ import { useSelector } from 'react-redux';
 import { __ } from '../helpers/translation';
 import { saveKey } from '../helpers/storage';
 import {
+  useWindEnabled,
+  setWindEnabled,
   useSolarEnabled,
   setSolarEnabled,
 } from '../helpers/router';
@@ -13,6 +15,11 @@ import LanguageSelect from '../components/languageselect';
 import ButtonToggle from '../components/buttontoggle';
 
 export default () => {
+  const windEnabled = useWindEnabled();
+  const toggleWind = () => {
+    setWindEnabled(!windEnabled);
+  };
+
   const solarEnabled = useSolarEnabled();
   const toggleSolar = () => {
     setSolarEnabled(!solarEnabled);
@@ -27,15 +34,12 @@ export default () => {
   return (
     <div className="layer-buttons-container">
       <LanguageSelect />
-      <div>
-        <button type="button" className="layer-button wind-button" />
-        <div id="wind-layer-button-tooltip" className="layer-button-tooltip hidden">
-          <div className="tooltip-container">
-            <div className="tooltip-text">{__('tooltips.showWindLayer')}</div>
-            <div className="arrow" />
-          </div>
-        </div>
-      </div>
+      <ButtonToggle
+        active={windEnabled}
+        onChange={toggleWind}
+        tooltip={__(windEnabled ? 'tooltips.hideWindLayer' : 'tooltips.showWindLayer')}
+        icon="weather/wind"
+      />
       <ButtonToggle
         active={solarEnabled}
         onChange={toggleSolar}

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import LanguageSelect from '../components/languageselect';
+import BrightModeToggle from '../components/brightmodetoggle';
 
-// Modules
 import { __ } from '../helpers/translation';
 
 export default () => (
@@ -26,14 +26,6 @@ export default () => (
         </div>
       </div>
     </div>
-    <div>
-      <button type="button" className="layer-button brightmode-button" />
-      <div id="brightmode-layer-button-tooltip" className="layer-button-tooltip hidden">
-        <div className="tooltip-container">
-          <div className="tooltip-text">{__('tooltips.toggleDarkMode')}</div>
-          <div className="arrow" />
-        </div>
-      </div>
-    </div>
+    <BrightModeToggle />
   </div>
 );

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -604,22 +604,6 @@ window.retryFetch = () => {
 // Declare and attach all event handlers that will
 // cause events to be emitted
 
-// BrightMode
-function toggleBright() {
-  dispatchApplication('brightModeEnabled', !getState().application.brightModeEnabled);
-}
-d3.select('.brightmode-button').on('click', toggleBright);
-const brightModeButtonTooltip = d3.select('#brightmode-layer-button-tooltip');
-if (!getState().application.isMobile) {
-  // Mouseovers will trigger on click on mobile and is therefore only set on desktop
-  d3.select('.brightmode-button').on('mouseover', () => {
-    brightModeButtonTooltip.classed('hidden', false);
-  });
-  d3.select('.brightmode-button').on('mouseout', () => {
-    brightModeButtonTooltip.classed('hidden', true);
-  });
-}
-
 // Wind
 function toggleWind() {
   if (typeof windLayer === 'undefined') { return; }
@@ -845,10 +829,8 @@ observe(state => state.application.colorBlindModeEnabled, (colorBlindModeEnabled
 
 // Observe for bright mode changes
 observe(state => state.application.brightModeEnabled, (brightModeEnabled) => {
-  d3.selectAll('.brightmode-button').classed('active', brightModeEnabled);
-  saveKey('brightModeEnabled', brightModeEnabled);
   // update Theme
-  if (getState().application.brightModeEnabled) {
+  if (brightModeEnabled) {
     theme = themes.bright;
   } else {
     theme = themes.dark;

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -28,9 +28,8 @@ import {
   history,
   isRemoteEndpoint,
   isSolarEnabled,
-  navigateTo,
   isWindEnabled,
-  setWindEnabled,
+  navigateTo,
   getCurrentPage,
   getCustomDatetime,
   getZoneId,
@@ -603,25 +602,6 @@ window.retryFetch = () => {
 // Declare and attach all event handlers that will
 // cause events to be emitted
 
-// Wind
-function toggleWind() {
-  if (typeof windLayer === 'undefined') { return; }
-  setWindEnabled(!isWindEnabled());
-}
-d3.select('.wind-button').on('click', toggleWind);
-
-const windLayerButtonTooltip = d3.select('#wind-layer-button-tooltip');
-
-if (!getState().application.isMobile) {
-  // Mouseovers will trigger on click on mobile and is therefore only set on desktop
-  d3.select('.wind-button').on('mouseover', () => {
-    windLayerButtonTooltip.classed('hidden', false);
-  });
-  d3.select('.wind-button').on('mouseout', () => {
-    windLayerButtonTooltip.classed('hidden', true);
-  });
-}
-
 // Collapse button
 document.getElementById('left-panel-collapse-button').addEventListener('click', () =>
   dispatchApplication('isLeftPanelCollapsed', !getState().application.isLeftPanelCollapsed));
@@ -840,10 +820,6 @@ observe(state => state.application.solarEnabled, (solarEnabled, state) => {
 // bool can be removed from Redux and managed through the URL state.
 // See https://github.com/tmrowco/electricitymap-contrib/issues/2310
 observe(state => state.application.windEnabled, (windEnabled, state) => {
-  d3.selectAll('.wind-button').classed('active', windEnabled);
-
-  windLayerButtonTooltip.select('.tooltip-text').text(translation.translate(windEnabled ? 'tooltips.hideWindLayer' : 'tooltips.showWindLayer'));
-
   const now = getCustomDatetime() ? moment(getCustomDatetime()) : (new Date()).getTime();
   if (windEnabled && typeof windLayer !== 'undefined') {
     if (!wind || windLayer.isExpired(now, wind.forecasts[0], wind.forecasts[1])) {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -29,7 +29,6 @@ import {
   isRemoteEndpoint,
   isSolarEnabled,
   navigateTo,
-  setSolarEnabled,
   isWindEnabled,
   setWindEnabled,
   getCurrentPage,
@@ -623,25 +622,6 @@ if (!getState().application.isMobile) {
   });
 }
 
-// Solar
-function toggleSolar() {
-  if (typeof solarLayer === 'undefined') { return; }
-  setSolarEnabled(!isSolarEnabled());
-}
-d3.select('.solar-button').on('click', toggleSolar);
-
-const solarLayerButtonTooltip = d3.select('#solar-layer-button-tooltip');
-
-if (!getState().application.isMobile) {
-  // Mouseovers will trigger on click on mobile and is therefore only set on desktop
-  d3.select('.solar-button').on('mouseover', () => {
-    solarLayerButtonTooltip.classed('hidden', false);
-  });
-  d3.select('.solar-button').on('mouseout', () => {
-    solarLayerButtonTooltip.classed('hidden', true);
-  });
-}
-
 // Collapse button
 document.getElementById('left-panel-collapse-button').addEventListener('click', () =>
   dispatchApplication('isLeftPanelCollapsed', !getState().application.isLeftPanelCollapsed));
@@ -843,10 +823,6 @@ observe(state => state.application.brightModeEnabled, (brightModeEnabled) => {
 // bool can be removed from Redux and managed through the URL state.
 // See https://github.com/tmrowco/electricitymap-contrib/issues/2310
 observe(state => state.application.solarEnabled, (solarEnabled, state) => {
-  d3.selectAll('.solar-button').classed('active', solarEnabled);
-
-  solarLayerButtonTooltip.select('.tooltip-text').text(translation.translate(solarEnabled ? 'tooltips.hideSolarLayer' : 'tooltips.showSolarLayer'));
-
   const now = getCustomDatetime() ? moment(getCustomDatetime()) : (new Date()).getTime();
   if (solarEnabled && typeof solarLayer !== 'undefined') {
     if (!solar || solarLayer.isExpired(now, solar.forecasts[0], solar.forecasts[1])) {

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -54,15 +54,6 @@
     }
 }
 
-.brightmode-button {
-    background-image: url(../images/brightmode.svg);
-
-    &.active{
-        background-image: url(../images/brightmode_active.svg);
-        background-color: #FFFFFF;
-    }
-}
-
 .language-select-button{
     background-image: url(../images/language_select.svg);
 }

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -36,15 +36,6 @@
     }
 }
 
-.wind-button {
-    background-image: url(../images/weather/wind.svg);
-
-    &.active {
-        background-image: url(../images/weather/wind_active.svg);
-        background-color: #FFFFFF;
-    }
-}
-
 .language-select-button{
     background-image: url(../images/language_select.svg);
 }

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -36,10 +36,6 @@
     }
 }
 
-.language-select-button{
-    background-image: url(../images/language_select.svg);
-}
-
 .controls-container {
     position: absolute;
     top: 70px;

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -45,15 +45,6 @@
     }
 }
 
-.solar-button {
-    background-image: url(../images/weather/sun.svg);
-
-    &.active{
-        background-image: url(../images/weather/sun_active.svg);
-        background-color: #FFFFFF;
-    }
-}
-
 .language-select-button{
     background-image: url(../images/language_select.svg);
 }

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -59,7 +59,7 @@
         <link rel="alternate" href="<%- alternateUrls[i] %>" hreflang="<%= supportedLocales[i] %>" />
         <% } %>
         <% if (typeof fullUrl != 'undefined') { %>
-        <link rel="alternate" href="<%- fullUrl.replace('&lang=' + locale, '').replace('/?lang=' + locale, '/?').replace(/\?$/, '').replace('/?&', '/?') %>" hreflang="x-default" />
+        <link rel="alternate" href="<%- fullUrl.replace(/[?|&]lang=[^&]*/, '') %>" hreflang="x-default" />
         <link rel="canonical" href="<%- fullUrl %>" />
         <% } %>
 


### PR DESCRIPTION
#### Changes

* Created `ButtonToggle` React component and used it for wind, solar and brightness toggles - fixes #2345
* Made `LanguageSelect` use `ButtonToggle` which reduced its complexity
* Fixed the way `LanguageSelect` updates the `lang` search param as now it could be the only param so might need to be preceeded by `?` instead of `&` - see https://github.com/tmrowco/electricitymap-contrib/commit/834ae8b3c95b032f025ed182cbf4eb29713dfc46
* Hiding the `lang` query param by `i18n` seems to have broken (probably when React Router took more control of the routes in #2317) so I added a small bit of code that removes it from the URL on JS initialization - see https://github.com/tmrowco/electricitymap-contrib/commit/355172fbace207c45139781c7e1c89540dd9df62

Hopefully we'll have a better solution for the last two points once #2382 is in place.
