### PR TITLE
Added singapore to 'unknown' fossil free exceptions

### DIFF
--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -49,7 +49,7 @@ exports.fossilFuelAccessor = (zoneKey, k, v) => {
   return (k == 'coal' ||
           k == 'gas' ||
           k == 'oil' ||
-          (k === 'unknown' && (zoneKey !== 'GB-ORK' && zoneKey !== 'UA' && zoneKey != 'SG')) ||
+          (k === 'unknown' && (zoneKey !== 'GB-ORK' && zoneKey !== 'UA' && zoneKey !== 'SG')) ||
           k == 'other') ? 1 : 0;
 }
 

--- a/config/co2eq_parameters.js
+++ b/config/co2eq_parameters.js
@@ -49,7 +49,7 @@ exports.fossilFuelAccessor = (zoneKey, k, v) => {
   return (k == 'coal' ||
           k == 'gas' ||
           k == 'oil' ||
-          (k === 'unknown' && (zoneKey !== 'GB-ORK' && zoneKey !== 'UA')) ||
+          (k === 'unknown' && (zoneKey !== 'GB-ORK' && zoneKey !== 'UA' && zoneKey != 'SG')) ||
           k == 'other') ? 1 : 0;
 }
 


### PR DESCRIPTION
After doing some digging into Singapore's makeup, found that the 'other' category from their website contains only biomass, waste, and solar. So I think this should be classified as fossil free.

Some references:
the government specifies the 'other' category as containing: "Others’ refer to other energy products that are not classified. These include Solar, Biomass, and Waste (such as Municipal Waste and Biogas). Municipal Waste is waste produced by residential, commercial and public services that is collected by local authorities for disposal in a central location for the production of electricity and/or heat."
https://www.ema.gov.sg/Singapore-Energy-Statistics-2019/Ch08/index8

https://www.ema.gov.sg/TemStatistic.aspx?pagesid=20140926wbNYp2Yh8iqy&pagemode=live&sta_sid=20140802NEeM2zyMguvz