### PR TITLE
Added threshold for negative values - EIA zones

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -36,6 +36,29 @@ REVERSE_EXCHANGES = [
     'MX-NO->US-TEX-ERCO'
 ]
 
+
+NEGATIVE_PRODUCTION_THRESHOLDS = {
+    'default': -10,
+    'zoneOverrides': {
+        'US-SW-SRP': {
+            'coal': -50,
+            'unknown': -50
+        },
+        'US-CAL-CISO': {
+            'unknown': -50,
+            'solar': -100
+        },
+        'US-SE-AEC': {
+            'coal': -50,
+            'gas': -20
+        },
+        'US-CAR-CPLE': {
+            'coal': -20
+        }
+    }
+}
+
+
 EXCHANGES = {
 
 #Old exchanges with old zones, to be updated/removed once clients have had time to switch
@@ -359,6 +382,15 @@ def fetch_production_mix(zone_key, session=None, target_datetime=None, logger=No
         if not mix:
             continue
         for point in mix:
+            negative_threshold = NEGATIVE_PRODUCTION_THRESHOLDS['zoneOverrides']\
+                .get(zone_key, {})\
+                .get(type, NEGATIVE_PRODUCTION_THRESHOLDS['default'])
+
+            if type != 'hydro' and \
+                    point['value'] < 0 and \
+                    point['value'] >= negative_threshold:
+                point['value'] = 0
+
             if type == 'hydro' and point['value'] < 0:
                 point.update({
                     'production': {},# required by merge_production_outputs()


### PR DESCRIPTION
There are quite a few instances where EIA reports negative production. I suspect this is onsite demand. At the moment, this prevents the parser data from being put into the database, as we have checks to prevent this. Here I set some zone-specific negative thresholds, and if the data is within that threshold, but negative, it is set to 0.

For the coal and gas plants it seems the production dips right before the plant starts up, which makes sense as they start turning on the generators, so I think it is reasonable to assume this is on site consumption.

Some references:
https://www.eia.gov/opendata/qb.php?category=3390127&sdid=EBA.CISO-ALL.NG.SUN.H
https://www.eia.gov/opendata/qb.php?category=3390169&sdid=EBA.SRP-ALL.NG.COL.H