### PR TITLE
Added US-NW-DOPD to exceptions and fixed naming error

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -65,8 +65,9 @@ def validate_production(obj, zone_key):
          obj.get('production', {}).get('gas', None) is None and zone_key
          not in ['CH', 'NO', 'AUS-TAS', 'DK-BHM', 'US-NEISO',
                 'US-CAR-YAD','US-NW-SCL','US-NW-CHPD',
-                'US-NW-WWA','US-NW-GCPD','US-NW-TWPR',
-                'US-NW-WAUW','US-SE-SEPA','US-NW-GWA'])):
+                'US-NW-WWA','US-NW-GCPD','US-NW-TPWR',
+                'US-NW-WAUW','US-SE-SEPA','US-NW-GWA',
+                'US-NW-DOPD'])):
         raise ValidationError(
             "Coal, gas or oil or unknown production value is required for"
             " %s" % zone_key)


### PR DESCRIPTION
Both US-NW-DOPD and US-NW-TPWR only have hydro production - they should not need to report any fossil fuel production. This adds them to the exceptions.

References:
https://www.eia.gov/opendata/qb.php?category=3390159
https://www.eia.gov/opendata/qb.php?category=3390129