### PR TITLE
Checked us zones, separated old US from new US

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -518,16 +518,6 @@
     },
     "rotation": 90
   },
-  "CA-AB->US-MT": {
-    "lonlat": [
-      -111.920238,
-      49.016577
-    ],
-    "parsers": {
-      "exchange": "CA_AB.fetch_exchange"
-    },
-    "rotation": 180
-  },
   "CA-AB->US-NW-NWMT": {
     "lonlat": [
       -111.920238,
@@ -535,16 +525,6 @@
     ],
     "parsers": {
       "exchange": "CA_AB.fetch_exchange"
-    },
-    "rotation": 180
-  },
-  "CA-BC->US-BPA": {
-    "lonlat": [
-      -119.300532,
-      49.044392
-    ],
-    "parsers": {
-      "exchange": "CA_BC.fetch_exchange"
     },
     "rotation": 180
   },
@@ -608,23 +588,13 @@
     },
     "rotation": -45
   },
-  "CA-NB->US-NEISO": {
-    "lonlat": [
-      -67.7771,
-      46.139
-    ],
-    "parsers": {
-      "exchange": "CA_NB.fetch_exchange"
-    },
-    "rotation": -90
-  },
   "CA-NB->US-NE-ISNE": {
     "lonlat": [
       -67.7771,
       46.139
     ],
     "parsers": {
-      "exchange": "US_NEISO.fetch_exchange"
+      "exchange": "CA_NB.fetch_exchange"
     },
     "rotation": -90
   },
@@ -638,35 +608,15 @@
     },
     "rotation": 90
   },
-  "CA-ON->US-MISO": {
-    "lonlat": [
-      -84.188,
-      46.476
-    ],
-    "parsers": {
-      "exchange": "CA_ON.fetch_exchange"
-    },
-    "rotation": -145
-  },
   "CA-ON->US-MIDW-MISO": {
     "lonlat": [
       -84.188,
       46.476
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
-    },
-    "rotation": -145
-  },
-  "CA-ON->US-NY": {
-    "lonlat": [
-      -78.9147,
-      43.5523
-    ],
-    "parsers": {
       "exchange": "CA_ON.fetch_exchange"
     },
-    "rotation": 135
+    "rotation": -145
   },
   "CA-ON->US-NY-NYIS": {
     "lonlat": [
@@ -674,19 +624,9 @@
       43.5523
     ],
     "parsers": {
-      "exchange": "US_NY.fetch_exchange"
+      "exchange": "CA_ON.fetch_exchange"
     },
     "rotation": 135
-  },
-  "CA-QC->US-NEISO": {
-    "lonlat": [
-      -71.737,
-      45.011
-    ],
-    "parsers": {
-      "exchange": "US_NEISO.fetch_exchange"
-    },
-    "rotation": 180
   },
   "CA-QC->US-NE-ISNE": {
     "lonlat": [
@@ -695,16 +635,6 @@
     ],
     "parsers": {
       "exchange": "US_NEISO.fetch_exchange"
-    },
-    "rotation": 180
-  },
-  "CA-QC->US-NY": {
-    "lonlat": [
-      -73.768,
-      45.004
-    ],
-    "parsers": {
-      "exchange": "US_NY.fetch_exchange"
     },
     "rotation": 180
   },
@@ -1874,23 +1804,13 @@
     },
     "rotation": 0
   },
-  "MX-BC->US-CA": {
-    "lonlat": [
-      -116.027,
-      32.607
-    ],
-    "parsers": {
-      "exchange": "US_CA.fetch_exchange"
-    },
-    "rotation": -10
-  },
   "MX-BC->US-CAL-CISO": {
     "lonlat": [
       -116.027,
       32.607
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "US_CA.fetch_exchange"
     },
     "rotation": -10
   },
@@ -1974,30 +1894,10 @@
     },
     "rotation": 150
   },
-  "MX-NE->US":{
-    "lonlat": [
-      -98.042,
-      26.057
-    ],
-    "parsers": {
-      "exchange": "MX.fetch_exchange"
-    },
-    "rotation": 0
-  },
   "MX-NE->US-TEX-ERCO":{
     "lonlat": [
       -98.042,
       26.057
-    ],
-    "parsers": {
-      "exchange": "EIA.fetch_exchange"
-    },
-    "rotation": 0
-  },
-  "MX-NO->US":{
-    "lonlat": [
-      -107.292,
-      31.709
     ],
     "parsers": {
       "exchange": "MX.fetch_exchange"
@@ -2446,16 +2346,6 @@
       "exchange": "EIA.fetch_exchange"
     },
     "rotation": 180
-  },
-  "US->US-CAL-CISO": {
-    "lonlat": [
-      -115.846,
-      35.962
-    ],
-    "parsers": {
-      "exchange": "US_CA.fetch_exchange"
-    },
-    "rotation": -135
   },
   "US-CAL-BANC->US-NW-BPAT": {
     "lonlat": [
@@ -3213,7 +3103,7 @@
       41.99881
     ],
     "parsers": {
-      "exchange": "EIA.fetch_exchange"
+      "exchange": "US_PJM.fetch_exchange"
     },
     "rotation": -124
   },
@@ -3396,6 +3286,26 @@
       "exchange": "EIA.fetch_exchange"
     },
     "rotation": -87
+  },
+  "US-NW-AVRN->US-NW-BPAT": {
+    "lonlat": [
+      -122.6819706,
+      45.5206888
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": 180
+  },
+  "US-NW-AVRN->US-NW-PACW": {
+    "lonlat": [
+      -122.6819706,
+      45.5206888
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": 0
   },
   "US-NW-BPAT->US-NW-TPWR": {
     "lonlat": [
@@ -3907,6 +3817,16 @@
       "exchange": "EIA.fetch_exchange"
     },
     "rotation": -62
+  },
+  "US-SW-PNM->US-SW-SRP": {
+    "lonlat": [
+      -110.765242868,
+      33.711766337
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": -90
   },
   "US-SW-PNM->US-SW-TEPC": {
     "lonlat": [

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -134,7 +134,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
     if sorted_zone_keys == 'CA-NB->CA-QC':
         value = flows['QUEBEC']
-    elif sorted_zone_keys == 'CA-NB->US-NEISO':
+    elif sorted_zone_keys == 'CA-NB->US-NE-ISNE':
         # all of these exports are to Maine
         # (see https://www.nbpower.com/en/about-us/our-energy/system-map/),
         # currently this is mapped to ISO-NE

--- a/parsers/CA_ON.py
+++ b/parsers/CA_ON.py
@@ -52,9 +52,9 @@ MAP_GENERATION = {
 MAP_EXCHANGE = {
     'MANITOBA': 'CA-MB->CA-ON',
     'MANITOBA SK': 'CA-MB->CA-ON',
-    'MICHIGAN': 'CA-ON->US-MISO',
-    'MINNESOTA': 'CA-ON->US-MISO',
-    'NEW-YORK': 'CA-ON->US-NY',
+    'MICHIGAN': 'CA-ON->US-MIDW-MISO',
+    'MINNESOTA': 'CA-ON->US-MIDW-MISO',
+    'NEW-YORK': 'CA-ON->US-NY-NYIS',
     'PQ.AT': 'CA-ON->CA-QC',
     'PQ.B5D.B31L': 'CA-ON->CA-QC',
     'PQ.D4Z': 'CA-ON->CA-QC',

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -33,15 +33,15 @@ REVERSE_EXCHANGES = [
     'CA-QC->US-NY-NYIS',
     'CA-ON->US-NY-NYIS',
     'MX-NE->US-TEX-ERCO',
-    'MX-NO->US-TEX-ERCO'
+    'MX-NO->US-TEX-ERCO',
+    'US-SW-PNM->US-SW-SRP' # For some reason EBA.SRP-PNM.ID.H exists in EIA, but PNM-SRP does not. Probably because it is unidirectional
 ]
 
 EXCHANGES = {
-
 #Old exchanges with old zones, to be updated/removed once clients have had time to switch
     'US-CA->MX-BC': 'EBA.CISO-CFE.ID.H',
     'US-BPA->US-IPC': 'EBA.BPAT-IPCO.ID.H',
-    'US-SPP->US-TX': 'SWPP.ID.H-EBA.ERCO',
+    'US-SPP->US-TX': 'EBA.SWPP-ERCO.ID.H',
     'US-MISO->US-PJM': 'EBA.MISO-PJM.ID.H',
     'US-MISO->US-SPP': 'EBA.MISO-SWPP.ID.H',
     'US-NEISO->US-NY': 'EBA.ISNE-NYIS.ID.H',
@@ -210,6 +210,7 @@ EXCHANGES = {
     'US-SW-GRIF->US-SW-WALC': 'EBA.GRIF-WALC.ID.H',
     'US-SW-HGMA->US-SW-SRP': 'EBA.HGMA-SRP.ID.H',
     'US-SW-PNM->US-SW-TEPC': 'EBA.PNM-TEPC.ID.H',
+    'US-SW-PNM->US-SW-SRP': 'EBA.SRP-PNM.ID.H',
     'US-SW-SRP->US-SW-TEPC': 'EBA.SRP-TEPC.ID.H',
     'US-SW-SRP->US-SW-WALC': 'EBA.SRP-WALC.ID.H',
     'US-SW-TEPC->US-SW-WALC': 'EBA.TEPC-WALC.ID.H'

--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -26,8 +26,8 @@ EXCHANGES = {"MX-NO->MX-NW": "IntercambioNTE-NOR",
              "MX-NE->MX-OC": "IntercambioNES-OCC",
              "MX-NO->MX-OC": "IntercambioNTE-OCC",
              "MX-NW->MX-OC": "IntercambioNOR-OCC",
-             "MX-NO->US": "IntercambioUSA-NTE",
-             "MX-NE->US": "IntercambioUSA-NES",
+             "MX-NO->US-TEX-ERCO": "IntercambioUSA-NTE",
+             "MX-NE->US-TEX-ERCO": "IntercambioUSA-NES",
              "BZ->MX-PN": "IntercambioPEN-BEL"
              }
 
@@ -218,16 +218,16 @@ if __name__ == '__main__':
     print(fetch_exchange("MX-NE", "MX-NO"))
     print("fetch_exchange(MX-OC, MX-OR)")
     print(fetch_exchange("MX-OC", "MX-OR"))
-    print("fetch_exchange(MX-NE, US)")
-    print(fetch_exchange("MX-NE", "US"))
+    print("fetch_exchange(MX-NE, US-TEX-ERCO)")
+    print(fetch_exchange("MX-NE", "US-TEX-ERCO"))
     print("fetch_exchange(MX-CE, MX-OC)")
     print(fetch_exchange("MX-CE", "MX-OC"))
     print("fetch_exchange(MX-PN, BZ)")
     print(fetch_exchange("MX-PN", "BZ"))
     print("fetch_exchange(MX-NO, MX-OC)")
     print(fetch_exchange("MX-NO", "MX-OC"))
-    print("fetch_exchange(MX-NO, US)")
-    print(fetch_exchange("MX-NO", "US"))
+    print("fetch_exchange(MX-NO, US-TEX-ERCO)")
+    print(fetch_exchange("MX-NO", "US-TEX-ERCO"))
     print("fetch_exchange(MX-NE, MX-OR)")
     print(fetch_exchange("MX-NE", "MX-OR"))
     print("fetch_exchange(MX-CE, MX-OR)")

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -201,7 +201,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
     elif sorted_zone_keys == 'US-MIDA-PJM->US-NY-NYIS':
         direction = 1
         relevant_exchanges = ['SCH - PJ - NY', 'SCH - PJM_HTP', 'SCH - PJM_NEPTUNE', 'SCH - PJM_VFT']
-    elif sorted_zone_keys == 'CA-ON->US-NY':
+    elif sorted_zone_keys == 'CA-ON->US-NY' or sorted_zone_keys == 'CA-ON->US-NY-NYIS':
         direction = 1
         relevant_exchanges = ['SCH - OH - NY']
     elif sorted_zone_keys == 'CA-QC->US-NY' or sorted_zone_keys == 'CA-QC->US-NY-NYIS':


### PR DESCRIPTION
Fixes #2319 .

This PR does a couple things:
- removes exchanges from old US zones to non-US zones - so the old US zones are now a virtual island (to be removed once customers have time to switch)
- adds a couple missing exchanges - US-NW-AVRN and US-SW-PNM were missing exchange configurations
  