### PR TITLE
New US BA  - Gridliance

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -3277,6 +3277,26 @@
     },
     "rotation": -44
   },
+  "US-MIDW-GLHB->US-MIDW-LGEE": {
+    "lonlat": [
+      -88.85889,
+      37.2094
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": -90
+  },
+  "US-MIDW-GLHB->US-MIDW-MISO": {
+    "lonlat": [
+      -88.85889,
+      37.2094
+    ],
+    "parsers": {
+      "exchange": "EIA.fetch_exchange"
+    },
+    "rotation": -90
+  },
   "US-MIDW-LGEE->US-MIDW-MISO": {
     "lonlat": [
       -87.3654617889999,

--- a/config/zones.json
+++ b/config/zones.json
@@ -3188,12 +3188,12 @@
     "capacity": {
       "coal": 218,
       "hydro": 658,
-	    "solar": 3,
-	    "wind": 118
+      "solar": 3,
+      "wind": 118
     },
     "contributors": [
       "https://github.com/corradio",
-	    "https://github.com/nessie2013"
+      "https://github.com/nessie2013"
     ],
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
@@ -3785,7 +3785,7 @@
     "contributors": [
       "https://github.com/corradio",
       "https://github.com/wojciej",
-	    "https://github.com/nessie2013"
+      "https://github.com/nessie2013"
     ],
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",
@@ -5775,6 +5775,18 @@
         37.83698
       ]
     ]
+  },
+  "US-MIDW-GLHB": {
+    "comment": "GridLiance",
+    "contributors": [
+      "https://github.com/systemcatch",
+      "https://github.com/robertahunt"
+    ],
+    "flag_file_name": "us.png",
+    "parsers": {
+      "production": "EIA.fetch_production_mix"
+    },
+    "timezone": "US/Central"
   },
   "US-MIDW-LGEE": {
     "comment": "Louisville Gas And Electric Company And Kentucky Utilities",

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -167,6 +167,8 @@ EXCHANGES = {
     'US-MIDW-EEI->US-MIDW-LGEE': 'EBA.EEI-LGEE.ID.H',
     'US-MIDW-EEI->US-MIDW-MISO': 'EBA.EEI-MISO.ID.H',
     'US-MIDW-EEI->US-TEN-TVA': 'EBA.EEI-TVA.ID.H',
+    'US-MIDW-GLHB->US-MIDW-LGEE': 'EBA.GLHB-LGEE.ID.H',
+    'US-MIDW-GLHB->US-MIDW-MISO': 'EBA.GLHB-MISO.ID.H',
     'US-MIDW-LGEE->US-MIDW-MISO': 'EBA.LGEE-MISO.ID.H',
     'US-MIDW-LGEE->US-TEN-TVA': 'EBA.LGEE-TVA.ID.H',
     'US-MIDW-MISO->US-SE-AEC': 'EBA.MISO-AEC.ID.H',
@@ -292,6 +294,7 @@ REGIONS = {
     'US-MIDA-PJM': 'PJM', #Pjm Interconnection, Llc
     'US-MIDW-AECI': 'AECI', #Associated Electric Cooperative, Inc.
     'US-MIDW-EEI': 'EEI', #Electric Energy, Inc.
+    'US-MIDW-GLHB': 'GLHB', #GridLiance
     'US-MIDW-LGEE': 'LGEE', #Louisville Gas And Electric Company And Kentucky Utilities
     'US-MIDW-MISO': 'MISO', #Midcontinent Independent Transmission System Operator, Inc..
     'US-NE-ISNE': 'ISNE', #Iso New England Inc.

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -1564,6 +1564,10 @@
             "countryName": "United States of America",
             "zoneName": "Electric Energy, Inc."
           },
+          "US-MIDW-GLHB": {
+            "countryName": "United States of America",
+            "zoneName": "GridLiance"
+          },
           "US-MIDW-LGEE": {
             "countryName": "United States of America",
             "zoneName": "Louisville Gas And Electric Company And Kentucky Utilities"


### PR DESCRIPTION
A new BA was added as of March 2 - 

references:
https://www.eia.gov/opendata/qb.php?category=3650184
https://www.spglobal.com/marketintelligence/en/news-insights/latest-news-headlines/gridliance-completes-purchase-of-6-transmission-lines-in-miso-57390643

They now manage the Joppa Steam Coal plant in Ohio, and they purchased some transmission lines from MISO.