### PR TITLE
Update of Spain's generating capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1445,16 +1445,16 @@
       ]
     ],
     "capacity": {
-      "biomass": 981,
-      "coal": 9683,
+      "biomass": 1076,
+      "coal": 9456,
       "gas": 26284,
       "geothermal": 0,
-      "hydro": 17087,
+      "hydro": 17085,
       "nuclear": 7117,
       "oil": 715,
-      "solar": 10122,
+      "solar": 11744,
       "unknown": 360,
-      "wind": 25223
+      "wind": 25806
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
Spain is starting its version of the german Energiewende, in which solar capacity is growing at a high rate, so although data was from november 2019, it was already outdated.

The source of the data is REE's monthly report on generating capacity of March 2020. I added plus 341 MW of a solar PV park installed at the beggining of this April. I myself will review again installed capacities when May's report is uploaded, so that summer data is updated through all three summer months.