### PR TITLE
Fix chile parser

### DIFF
--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -119,7 +119,7 @@ def fetch_production(zone_key='CL', session=None, target_datetime=None, logger=l
 
         datapoint = {
             'zoneKey': zone_key,
-            'datetime': dt,
+            'datetime': dt.to_pydatetime(),
             'production': production_data,
             'storage': {},
             'source': 'coordinador.cl'


### PR DESCRIPTION
After trying to fetch historic data for chile, I found out that the results were not being parsed by our feeder because the datetime was a pandas timestamp, not a python datetime object. This should fix that issue.