### PR TITLE
Fix datetime handling in Hawaii parser

### DIFF
--- a/parsers/US_HI.py
+++ b/parsers/US_HI.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python3
+
 import logging
 import datetime
-
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
-
-# please try to write PEP8 compliant code (use a linter). One of PEP8's
-# requirement is to limit your line length to 79 characters.
 
 
 def fetch_production(zone_key='US-HI-OA', session=None,
@@ -81,24 +76,26 @@ def fetch_production(zone_key='US-HI-OA', session=None,
     obj = res.json()
     raw_data = obj[0]
 
-    data = {
-        'zoneKey': zone_key,
-        'production': {
+    production = {
           'biomass': float(raw_data['Waste2Energy'] + raw_data['BioFuel']),
           'coal': float(raw_data['Coal']),
           'oil': float(raw_data['Fossil_Fuel']),
           'solar': float(raw_data['Solar']),
           'wind': float(raw_data['WindFarm'])
-          },
-        'storage': {},
-        'source': 'islandpulse.org',
     }
 
-    # Parse the datetime and return a python datetime object
-    data['datetime'] = arrow.get(raw_data['dateTime'], 'YYYY-MM-DDTHH:mm:ss').to(tz="Pacific/Honolulu").datetime
+    dt = arrow.get(raw_data['dateTime']).to(tz="Pacific/Honolulu").datetime
+
+    data = {
+        'zoneKey': zone_key,
+        'production': production,
+        'datetime': dt,
+        'storage': {},
+        'source': 'islandpulse.org'
+    }
 
     return data
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    print("fetch_production ->")
+    print(fetch_production())


### PR DESCRIPTION
The reason why this parser was failing was due to the wrong format string being used, arrow doesn't need a format in this case as it's supported by default. The `Z` at the end of the timestamp means UTC, I've kept the conversion to Pacific/Honolulu for now but let me know if you'd prefer it otherwise.

The error.
```shell
File "/usr/local/lib/python3.6/site-packages/arrow/parser.py", line 224, in parse "Failed to match '{}' when parsing '{}'".format(fmt, datetime_string) arrow.parser.ParserMatchError: Failed to match 'YYYY-MM-DDTHH:mm:ss' when parsing '2020-05-03T13:30:00.000Z'
```

All fixed and working now.

```shell
(EM) chris@ThinkPad:~/electricitymap$ python test_parser.py US-HI-OA
parser result:
{'zoneKey': 'US-HI-OA', 'production': {'biomass': 27.2, 'coal': 105.4, 'oil': 233.9, 'solar': 86.6, 'wind': 48.5}, 'datetime': datetime.datetime(2020, 5, 3, 10, 30, tzinfo=tzfile('/usr/share/zoneinfo/Pacific/Honolulu')), 'storage': {}, 'source': 'islandpulse.org'}
---------------------
took 0.75s
min returned datetime: 2020-05-03T20:30:00+00:00 UTC
max returned datetime: 2020-05-03T20:30:00+00:00 UTC  -- OK, <2h from now :) (now=2020-05-03T21:07:10.307290+00:00 UTC)
```


ref #2462 