### PR TITLE
Change FR parser to ENTSOE 

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1798,7 +1798,7 @@
       "generationForecast": "ENTSOE.fetch_generation_forecast",
       "productionPerModeForecast": "ENTSOE.fetch_wind_solar_forecasts",
       "price": "FR.fetch_price",
-      "production": "FR.fetch_production"
+      "production": "ENTSOE.fetch_production"
     },
     "timezone": "Europe/Paris"
   },


### PR DESCRIPTION
RTE data has been unavailable for 4 days now, and France is an important region - let's temporarily switch until RTE is fixed. See #2444 