### PR TITLE
Remove search params from Redux

### DIFF
--- a/web/src/actioncreators.js
+++ b/web/src/actioncreators.js
@@ -1,7 +1,0 @@
-export function updateApplication(key, value) {
-  return {
-    key,
-    value,
-    type: 'APPLICATION_STATE_UPDATE',
-  };
-}

--- a/web/src/components/buttontoggle.js
+++ b/web/src/components/buttontoggle.js
@@ -3,6 +3,10 @@ import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { isEmpty, noop } from 'lodash';
 
+const Wrapper = styled.div`
+  position: relative;
+`;
+
 const Button = styled.button`
   background-color: #FFFFFF;
   background-image: ${props => (props.active
@@ -23,7 +27,7 @@ const ButtonToggle = ({
   const hideTooltip = () => { setTooltipVisible(false); };
 
   return (
-    <div>
+    <Wrapper>
       <Button
         type="button"
         className="layer-button"
@@ -43,7 +47,7 @@ const ButtonToggle = ({
           </div>
         </div>
       )}
-    </div>
+    </Wrapper>
   );
 };
 

--- a/web/src/components/languageselect.js
+++ b/web/src/components/languageselect.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { map } from 'lodash';
 
 import { __ } from '../helpers/translation';
-import { useSearchParams } from '../helpers/router';
+import { useSearchParams } from '../hooks/router';
 import { languageNames } from '../../locales-config.json';
 
 import ButtonToggle from './buttontoggle';

--- a/web/src/components/layers/solarlayer.js
+++ b/web/src/components/layers/solarlayer.js
@@ -6,8 +6,8 @@ import styled from 'styled-components';
 import parse from 'color-parse';
 
 import { useWidthObserver, useHeightObserver } from '../../hooks/viewport';
+import { useSolarEnabled } from '../../hooks/router';
 import { stackBlurImageOpacity } from '../../helpers/image';
-import { useSolarEnabled } from '../../helpers/router';
 import { solarColor } from '../../helpers/scales';
 
 import { useInterpolatedSolarData } from '../../hooks/layers';

--- a/web/src/components/layers/windlayer.js
+++ b/web/src/components/layers/windlayer.js
@@ -9,7 +9,7 @@ import { CSSTransition } from 'react-transition-group';
 import styled from 'styled-components';
 
 import { useWidthObserver, useHeightObserver } from '../../hooks/viewport';
-import { useWindEnabled } from '../../helpers/router';
+import { useWindEnabled } from '../../hooks/router';
 
 import Windy from '../../helpers/windy';
 import { useInterpolatedWindData } from '../../hooks/layers';

--- a/web/src/components/onboardingmodal.js
+++ b/web/src/components/onboardingmodal.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { __ } from '../helpers/translation';
 import { saveKey } from '../helpers/storage';
 import { dispatchApplication } from '../store';
-import thirdPartyServices from '../services/thirdparty';
+import { useTrackEvent } from '../hooks/tracking';
 
 const views = [{
   headerImage: resolvePath('images/onboarding/electricymapLogoIcon.svg'),
@@ -58,6 +58,8 @@ const mapStateToProps = state => ({
 });
 
 const OnboardingModal = ({ visible }) => {
+  const trackEvent = useTrackEvent();
+
   const [currentViewIndex, setCurrentViewIndex] = useState(0);
   const isOnLastView = () => currentViewIndex === views.length - 1;
   const isOnFirstView = () => currentViewIndex === 0;
@@ -93,7 +95,7 @@ const OnboardingModal = ({ visible }) => {
   // Track event when the onboarding modal opens up
   useEffect(() => {
     if (visible) {
-      thirdPartyServices.trackWithCurrentApplicationState('onboardingModalShown');
+      trackEvent('onboardingModalShown');
     }
   }, [visible]);
 

--- a/web/src/components/zonelist.js
+++ b/web/src/components/zonelist.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Link, Redirect, useLocation } from 'react-router-dom';
+import { Link, useLocation, useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { dispatchApplication } from '../store';
@@ -80,8 +80,8 @@ const ZoneList = ({
     .filter(z => zoneMatchesQuery(z, searchQuery));
 
   const ref = React.createRef();
+  const history = useHistory();
   const location = useLocation();
-  const [enteredZone, setEnteredZone] = useState(null);
   const [selectedItemIndex, setSelectedItemIndex] = useState(null);
 
   const zonePage = zone => ({
@@ -91,7 +91,7 @@ const ZoneList = ({
 
   const enterZone = (zone) => {
     dispatchApplication('mapViewport', getCenteredZoneViewport(zone));
-    setEnteredZone(zone);
+    history.push(zonePage(zone));
   };
 
   // Keyboard navigation
@@ -135,12 +135,6 @@ const ZoneList = ({
       document.removeEventListener('keyup', keyHandler);
     };
   });
-
-  // Redirect to the zone details page if Enter key
-  // has been pressed over the zone in the list.
-  if (enteredZone) {
-    return <Redirect to={zonePage(enteredZone)} />;
-  }
 
   return (
     <div className="zone-list" ref={ref}>

--- a/web/src/cordova.js
+++ b/web/src/cordova.js
@@ -1,7 +1,7 @@
 import { select } from 'd3-selection';
 
 import thirdPartyServices from './services/thirdparty';
-import { history, navigateTo, getCurrentPage } from './helpers/router';
+import { history } from './helpers/router';
 
 export const cordovaApp = {
   // Application Constructor
@@ -16,8 +16,9 @@ export const cordovaApp = {
   },
 
   onBack(e) {
-    if (['zone', 'faq'].includes(getCurrentPage())) {
-      navigateTo({ pathname: '/map', search: history.location.search });
+    // Go to previous page if it exists, otherwise exit the app.
+    if (history.length > 1) {
+      history.goBack();
       e.preventDefault();
     } else {
       navigator.app.exitApp();

--- a/web/src/cordova.js
+++ b/web/src/cordova.js
@@ -1,7 +1,7 @@
 import { select } from 'd3-selection';
 
 import { history } from './helpers/router';
-import { dispatch } from './store';
+import { store } from './store';
 
 export const cordovaApp = {
   // Application Constructor
@@ -54,7 +54,7 @@ export const cordovaApp = {
 
   onResume() {
     // Count as app visit
-    dispatch({ type: 'TRACK_EVENT', payload: { eventName: 'Visit' } });
+    store.dispatch({ type: 'TRACK_EVENT', payload: { eventName: 'Visit' } });
     codePush.sync(null, { installMode: InstallMode.ON_NEXT_RESUME });
   },
 };

--- a/web/src/cordova.js
+++ b/web/src/cordova.js
@@ -1,7 +1,7 @@
 import { select } from 'd3-selection';
 
-import thirdPartyServices from './services/thirdparty';
 import { history } from './helpers/router';
+import { dispatch } from './store';
 
 export const cordovaApp = {
   // Application Constructor
@@ -54,7 +54,7 @@ export const cordovaApp = {
 
   onResume() {
     // Count as app visit
-    thirdPartyServices.trackWithCurrentApplicationState('Visit');
+    dispatch({ type: 'TRACK_EVENT', payload: { eventName: 'Visit' } });
     codePush.sync(null, { installMode: InstallMode.ON_NEXT_RESUME });
   },
 };

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -16,11 +16,6 @@ function getSearchParams() {
 }
 
 // TODO: Deprecate in favor of React Router useParams (requires move to React)
-export function getCurrentPage() {
-  return history.location.pathname.split('/')[1];
-}
-
-// TODO: Deprecate in favor of React Router useParams (requires move to React)
 export function getZoneId() {
   return history.location.pathname.split('/')[2];
 }
@@ -56,7 +51,6 @@ function updateStateFromURL() {
     type: 'UPDATE_STATE_FROM_URL',
     payload: {
       customDatetime: getCustomDatetime(),
-      currentPage: getCurrentPage(),
       selectedZoneName: getZoneId(),
       solarEnabled: isSolarEnabled(),
       windEnabled: isWindEnabled(),

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { createBrowserHistory, createHashHistory } from 'history';
 
@@ -11,16 +11,6 @@ import { dispatch } from '../store';
 // TODO: Replace this with React Router DOM
 // `useHistory` hook after full migration to React.
 export const history = window.isCordova ? createHashHistory() : createBrowserHistory();
-
-// TODO: Deprecate in favor of <Link /> and <Redirect />
-export function navigateTo({ pathname, search }) {
-  // Push the new URL state to browser history only
-  // if the new URL differs from the current one.
-  const url = `${pathname}${search}`;
-  if (url !== `${history.location.pathname}${history.location.search}`) {
-    history.push(url);
-  }
-}
 
 //
 // Search params

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -1,3 +1,4 @@
+import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { createBrowserHistory, createHashHistory } from 'history';
 
@@ -41,6 +42,40 @@ export function useWindEnabled() {
   return useSearchParams().get('wind') === 'true';
 }
 
+export function useSolarToggledLocation() {
+  const location = useLocation();
+  const searchParams = useSearchParams();
+  const solarEnabled = useSolarEnabled();
+
+  return useMemo(
+    () => {
+      searchParams.set('solar', !solarEnabled);
+      return {
+        pathname: location.pathname,
+        search: searchParams.toString(),
+      };
+    },
+    [location, searchParams, solarEnabled],
+  );
+}
+
+export function useWindToggledLocation() {
+  const location = useLocation();
+  const searchParams = useSearchParams();
+  const windEnabled = useWindEnabled();
+
+  return useMemo(
+    () => {
+      searchParams.set('wind', !windEnabled);
+      return {
+        pathname: location.pathname,
+        search: searchParams.toString(),
+      };
+    },
+    [location, searchParams, windEnabled],
+  );
+}
+
 // TODO: Deprecate in favor of useSearchParams (requires move to React)
 function getSearchParams() {
   return new URLSearchParams(history.location.search);
@@ -69,40 +104,6 @@ export function isSolarEnabled() {
 // TODO: Deprecate in favor of useWindEnabled (requires move to React)
 export function isWindEnabled() {
   return getSearchParams().get('wind') === 'true';
-}
-
-// TODO: Deprecate in favor of using <Link /> and <Redirect /> directly
-function updateSearchParams(searchParams) {
-  let search = searchParams.toString();
-  if (search) {
-    search = `?${search}`;
-  }
-  // Keep the pathname intact when updating search params
-  navigateTo({ pathname: history.location.pathname, search });
-}
-
-// TODO: Move this logic in the solar button once the React component is there
-// See https://github.com/tmrowco/electricitymap-contrib/issues/2345.
-export function setSolarEnabled(solarEnabled) {
-  const searchParams = getSearchParams();
-  if (solarEnabled) {
-    searchParams.set('solar', true);
-  } else {
-    searchParams.delete('solar');
-  }
-  updateSearchParams(searchParams);
-}
-
-// TODO: Move this logic in the wind button once the React component is there
-// See https://github.com/tmrowco/electricitymap-contrib/issues/2345.
-export function setWindEnabled(windEnabled) {
-  const searchParams = getSearchParams();
-  if (windEnabled) {
-    searchParams.set('wind', true);
-  } else {
-    searchParams.delete('wind');
-  }
-  updateSearchParams(searchParams);
 }
 
 // TODO: Get rid of this when a better system is put in place for switching languages.

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -1,7 +1,5 @@
 import { createBrowserHistory, createHashHistory } from 'history';
 
-import { dispatch } from '../store';
-
 // Use BrowserHistory in the web browser and HashHistory
 // in the mobile apps as we need to keep relative resource
 // paths for the mobile which are fundamentally incompatible
@@ -11,28 +9,13 @@ import { dispatch } from '../store';
 export const history = window.isCordova ? createHashHistory() : createBrowserHistory();
 
 // TODO: Deprecate in favor of useSearchParams (requires move to React)
-function getSearchParams() {
+export function getSearchParams() {
   return new URLSearchParams(history.location.search);
 }
 
 // TODO: Deprecate in favor of React Router useParams (requires move to React)
 export function getZoneId() {
   return history.location.pathname.split('/')[2];
-}
-
-// TODO: Deprecate in favor of useCustomDatetime (requires move to React)
-export function getCustomDatetime() {
-  return getSearchParams().get('datetime');
-}
-
-// TODO: Deprecate in favor of useSolarEnabled (requires move to React)
-export function isSolarEnabled() {
-  return getSearchParams().get('solar') === 'true';
-}
-
-// TODO: Deprecate in favor of useWindEnabled (requires move to React)
-export function isWindEnabled() {
-  return getSearchParams().get('wind') === 'true';
 }
 
 // TODO: Get rid of this when a better system is put in place for switching languages.
@@ -43,26 +26,3 @@ export function hideLanguageSearchParam() {
   history.replace(`?${searchParams.toString()}`);
 }
 hideLanguageSearchParam();
-
-// TODO: Remove once we don't need the copy of URL state in the Redux state anymore
-// See https://github.com/tmrowco/electricitymap-contrib/issues/2296.
-function updateStateFromURL() {
-  dispatch({
-    type: 'UPDATE_STATE_FROM_URL',
-    payload: {
-      customDatetime: getCustomDatetime(),
-      selectedZoneName: getZoneId(),
-      solarEnabled: isSolarEnabled(),
-      windEnabled: isWindEnabled(),
-    },
-  });
-}
-
-// Update Redux state with the URL search params initially and also
-// every time the URL change is triggered by a browser action to ensure
-// the URL -> Redux binding (the other direction is ensured by observing
-// the relevant state Redux entries and triggering the URL update below).
-updateStateFromURL();
-history.listen(() => {
-  updateStateFromURL();
-});

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
 import { createBrowserHistory, createHashHistory } from 'history';
 
 import { dispatch } from '../store';
@@ -11,60 +9,6 @@ import { dispatch } from '../store';
 // TODO: Replace this with React Router DOM
 // `useHistory` hook after full migration to React.
 export const history = window.isCordova ? createHashHistory() : createBrowserHistory();
-
-//
-// Search params
-//
-
-export function useSearchParams() {
-  return new URLSearchParams(useLocation().search);
-}
-
-export function useCustomDatetime() {
-  return useSearchParams().get('datetime');
-}
-
-export function useSolarEnabled() {
-  return useSearchParams().get('solar') === 'true';
-}
-
-export function useWindEnabled() {
-  return useSearchParams().get('wind') === 'true';
-}
-
-export function useSolarToggledLocation() {
-  const location = useLocation();
-  const searchParams = useSearchParams();
-  const solarEnabled = useSolarEnabled();
-
-  return useMemo(
-    () => {
-      searchParams.set('solar', !solarEnabled);
-      return {
-        pathname: location.pathname,
-        search: searchParams.toString(),
-      };
-    },
-    [location, searchParams, solarEnabled],
-  );
-}
-
-export function useWindToggledLocation() {
-  const location = useLocation();
-  const searchParams = useSearchParams();
-  const windEnabled = useWindEnabled();
-
-  return useMemo(
-    () => {
-      searchParams.set('wind', !windEnabled);
-      return {
-        pathname: location.pathname,
-        search: searchParams.toString(),
-      };
-    },
-    [location, searchParams, windEnabled],
-  );
-}
 
 // TODO: Deprecate in favor of useSearchParams (requires move to React)
 function getSearchParams() {
@@ -104,10 +48,6 @@ export function hideLanguageSearchParam() {
   history.replace(`?${searchParams.toString()}`);
 }
 hideLanguageSearchParam();
-
-//
-// Redux state sync
-//
 
 // TODO: Remove once we don't need the copy of URL state in the Redux state anymore
 // See https://github.com/tmrowco/electricitymap-contrib/issues/2296.

--- a/web/src/helpers/router.js
+++ b/web/src/helpers/router.js
@@ -8,11 +8,6 @@ import { createBrowserHistory, createHashHistory } from 'history';
 // `useHistory` hook after full migration to React.
 export const history = window.isCordova ? createHashHistory() : createBrowserHistory();
 
-// TODO: Deprecate in favor of useSearchParams (requires move to React)
-export function getSearchParams() {
-  return new URLSearchParams(history.location.search);
-}
-
 // TODO: Deprecate in favor of React Router useParams (requires move to React)
 export function getZoneId() {
   return history.location.pathname.split('/')[2];
@@ -21,7 +16,7 @@ export function getZoneId() {
 // TODO: Get rid of this when a better system is put in place for switching languages.
 // See https://github.com/tmrowco/electricitymap-contrib/issues/2382.
 export function hideLanguageSearchParam() {
-  const searchParams = getSearchParams();
+  const searchParams = new URLSearchParams(history.location.search);
   searchParams.delete('lang');
   history.replace(`?${searchParams.toString()}`);
 }

--- a/web/src/hooks/fetch.js
+++ b/web/src/hooks/fetch.js
@@ -3,9 +3,9 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { isEmpty } from 'lodash';
 
-import { useCustomDatetime, useWindEnabled, useSolarEnabled } from '../helpers/router';
 import { DATA_FETCH_INTERVAL } from '../helpers/constants';
 
+import { useCustomDatetime, useWindEnabled, useSolarEnabled } from './router';
 import { useCurrentZoneHistory } from './redux';
 
 export function useClientVersionFetch() {

--- a/web/src/hooks/layers.js
+++ b/web/src/hooks/layers.js
@@ -4,8 +4,9 @@ import { interpolate } from 'd3-interpolate';
 import { values } from 'lodash';
 import moment from 'moment';
 
-import { useCustomDatetime } from '../helpers/router';
 import { getRefTime, getTargetTime } from '../helpers/grib';
+
+import { useCustomDatetime } from './router';
 
 export function useExchangeArrowsData() {
   const isConsumption = useSelector(state => state.application.electricityMixMode === 'consumption');

--- a/web/src/hooks/redux.js
+++ b/web/src/hooks/redux.js
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { keys, sortBy } from 'lodash';
 
-import { useCustomDatetime } from '../helpers/router';
+import { useCustomDatetime } from './router';
 
 export function useCurrentZoneHistory() {
   const { zoneId } = useParams();

--- a/web/src/hooks/router.js
+++ b/web/src/hooks/router.js
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export function useSearchParams() {
+  return new URLSearchParams(useLocation().search);
+}
+
+export function useCustomDatetime() {
+  return useSearchParams().get('datetime');
+}
+
+export function useSolarEnabled() {
+  return useSearchParams().get('solar') === 'true';
+}
+
+export function useWindEnabled() {
+  return useSearchParams().get('wind') === 'true';
+}
+
+export function useSolarToggledLocation() {
+  const location = useLocation();
+  const searchParams = useSearchParams();
+  const solarEnabled = useSolarEnabled();
+
+  return useMemo(
+    () => {
+      searchParams.set('solar', !solarEnabled);
+      return {
+        pathname: location.pathname,
+        search: searchParams.toString(),
+      };
+    },
+    [location, searchParams, solarEnabled],
+  );
+}
+
+export function useWindToggledLocation() {
+  const location = useLocation();
+  const searchParams = useSearchParams();
+  const windEnabled = useWindEnabled();
+
+  return useMemo(
+    () => {
+      searchParams.set('wind', !windEnabled);
+      return {
+        pathname: location.pathname,
+        search: searchParams.toString(),
+      };
+    },
+    [location, searchParams, windEnabled],
+  );
+}

--- a/web/src/hooks/tracking.js
+++ b/web/src/hooks/tracking.js
@@ -1,14 +1,27 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 
 import thirdPartyServices from '../services/thirdparty';
 
+export const useTrackEvent = () => {
+  const dispatch = useDispatch();
+
+  return useMemo(
+    () => (eventName, context) => {
+      dispatch({ type: 'TRACK_EVENT', payload: { eventName, context } });
+    },
+    [dispatch],
+  );
+};
+
 export const usePageViewsTracker = () => {
   const { pathname, search } = useLocation();
+  const trackEvent = useTrackEvent();
 
   // Track app visit once initially.
   useEffect(() => {
-    thirdPartyServices.trackWithCurrentApplicationState('Visit');
+    trackEvent('Visit');
   }, []);
 
   // Update GA config whenever the URL changes.
@@ -20,6 +33,6 @@ export const usePageViewsTracker = () => {
 
   // Track page view whenever the pathname changes (ignore search params changes).
   useEffect(() => {
-    thirdPartyServices.trackWithCurrentApplicationState('pageview');
+    trackEvent('pageview');
   }, [pathname]);
 };

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -9,7 +9,7 @@ import {
   useSolarEnabled,
   useSolarToggledLocation,
   useWindToggledLocation,
-} from '../helpers/router';
+} from '../hooks/router';
 import { dispatchApplication } from '../store';
 
 import LanguageSelect from '../components/languageselect';

--- a/web/src/layout/layerbuttons.js
+++ b/web/src/layout/layerbuttons.js
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 import { __ } from '../helpers/translation';
 import { saveKey } from '../helpers/storage';
 import {
   useWindEnabled,
-  setWindEnabled,
   useSolarEnabled,
-  setSolarEnabled,
+  useSolarToggledLocation,
+  useWindToggledLocation,
 } from '../helpers/router';
 import { dispatchApplication } from '../store';
 
@@ -16,14 +17,10 @@ import ButtonToggle from '../components/buttontoggle';
 
 export default () => {
   const windEnabled = useWindEnabled();
-  const toggleWind = () => {
-    setWindEnabled(!windEnabled);
-  };
+  const windToggledLocation = useWindToggledLocation();
 
   const solarEnabled = useSolarEnabled();
-  const toggleSolar = () => {
-    setSolarEnabled(!solarEnabled);
-  };
+  const solarToggledLocation = useSolarToggledLocation();
 
   const brightModeEnabled = useSelector(state => state.application.brightModeEnabled);
   const toggleBrightMode = () => {
@@ -34,18 +31,20 @@ export default () => {
   return (
     <div className="layer-buttons-container">
       <LanguageSelect />
-      <ButtonToggle
-        active={windEnabled}
-        onChange={toggleWind}
-        tooltip={__(windEnabled ? 'tooltips.hideWindLayer' : 'tooltips.showWindLayer')}
-        icon="weather/wind"
-      />
-      <ButtonToggle
-        active={solarEnabled}
-        onChange={toggleSolar}
-        tooltip={__(solarEnabled ? 'tooltips.hideSolarLayer' : 'tooltips.showSolarLayer')}
-        icon="weather/sun"
-      />
+      <Link to={windToggledLocation}>
+        <ButtonToggle
+          active={windEnabled}
+          tooltip={__(windEnabled ? 'tooltips.hideWindLayer' : 'tooltips.showWindLayer')}
+          icon="weather/wind"
+        />
+      </Link>
+      <Link to={solarToggledLocation}>
+        <ButtonToggle
+          active={solarEnabled}
+          tooltip={__(solarEnabled ? 'tooltips.hideSolarLayer' : 'tooltips.showSolarLayer')}
+          icon="weather/sun"
+        />
+      </Link>
       <ButtonToggle
         active={brightModeEnabled}
         onChange={toggleBrightMode}

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -9,6 +9,7 @@ import {
   Link,
   useLocation,
   useParams,
+  useHistory,
 } from 'react-router-dom';
 import { connect, useSelector } from 'react-redux';
 import moment from 'moment';
@@ -86,11 +87,11 @@ const CountryPanel = ({
   zones,
 }) => {
   const [tooltip, setTooltip] = useState(null);
-  const [pressedBackKey, setPressedBackKey] = useState(false);
 
   const isLoadingHistories = useSelector(state => state.data.isLoadingHistories);
   const co2ColorScale = useCo2ColorScale();
 
+  const history = useHistory();
   const location = useLocation();
   const { zoneId } = useParams();
 
@@ -102,21 +103,23 @@ const CountryPanel = ({
   };
 
   // Back button keyboard navigation
-  useEffect(() => {
-    const keyHandler = (e) => {
-      if (e.key === 'Backspace' || e.key === '/') {
-        setPressedBackKey(true);
-      }
-    };
-    document.addEventListener('keyup', keyHandler);
-    return () => {
-      document.removeEventListener('keyup', keyHandler);
-    };
-  });
+  useEffect(
+    () => {
+      const keyHandler = (e) => {
+        if (e.key === 'Backspace' || e.key === '/') {
+          history.push(parentPage);
+        }
+      };
+      document.addEventListener('keyup', keyHandler);
+      return () => {
+        document.removeEventListener('keyup', keyHandler);
+      };
+    },
+    [history],
+  );
 
-  // Redirect to the parent page if the zone is invalid
-  // or if the back navigation key has been pressed.
-  if (!zones[zoneId] || pressedBackKey) {
+  // Redirect to the parent page if the zone is invalid.
+  if (!zones[zoneId]) {
     return <Redirect to={parentPage} />;
   }
 

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -131,12 +131,12 @@ const CountryPanel = ({
 
   const switchToZoneEmissions = () => {
     dispatchApplication('tableDisplayEmissions', true);
-    thirdPartyServices.track('switchToCountryEmissions');
+    thirdPartyServices.trackWithCurrentApplicationState('switchToCountryEmissions');
   };
 
   const switchToZoneProduction = () => {
     dispatchApplication('tableDisplayEmissions', false);
-    thirdPartyServices.track('switchToCountryProduction');
+    thirdPartyServices.trackWithCurrentApplicationState('switchToCountryProduction');
   };
 
   return (

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -24,13 +24,13 @@ import CountryHistoryMixGraph from '../../components/countryhistorymixgraph';
 import CountryHistoryPricesGraph from '../../components/countryhistorypricesgraph';
 import CountryTable from '../../components/countrytable';
 import LoadingPlaceholder from '../../components/loadingplaceholder';
-import thirdPartyServices from '../../services/thirdparty';
 
 import { dispatchApplication } from '../../store';
 
 // Modules
 import { useCurrentZoneData } from '../../hooks/redux';
 import { useCo2ColorScale } from '../../hooks/theme';
+import { useTrackEvent } from '../../hooks/tracking';
 import { flagUri } from '../../helpers/flags';
 import { getFullZoneName, __ } from '../../helpers/translation';
 
@@ -91,6 +91,7 @@ const CountryPanel = ({
   const isLoadingHistories = useSelector(state => state.data.isLoadingHistories);
   const co2ColorScale = useCo2ColorScale();
 
+  const trackEvent = useTrackEvent();
   const history = useHistory();
   const location = useLocation();
   const { zoneId } = useParams();
@@ -131,12 +132,12 @@ const CountryPanel = ({
 
   const switchToZoneEmissions = () => {
     dispatchApplication('tableDisplayEmissions', true);
-    thirdPartyServices.trackWithCurrentApplicationState('switchToCountryEmissions');
+    trackEvent('switchToCountryEmissions');
   };
 
   const switchToZoneProduction = () => {
     dispatchApplication('tableDisplayEmissions', false);
-    thirdPartyServices.trackWithCurrentApplicationState('switchToCountryProduction');
+    trackEvent('switchToCountryProduction');
   };
 
   return (

--- a/web/src/layout/leftpanel/index.js
+++ b/web/src/layout/leftpanel/index.js
@@ -14,7 +14,7 @@ import {
 } from 'react-router-dom';
 
 import { dispatchApplication } from '../../store';
-import { useSearchParams } from '../../helpers/router';
+import { useSearchParams } from '../../hooks/router';
 import { usePageViewsTracker } from '../../hooks/tracking';
 import { useSmallLoaderVisible } from '../../hooks/redux';
 import LastUpdatedTime from '../../components/lastupdatedtime';

--- a/web/src/layout/leftpanel/zonedetailspanel.js
+++ b/web/src/layout/leftpanel/zonedetailspanel.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { dispatch } from '../../store';
+import { dispatchApplication } from '../../store';
 import { useConditionalZoneHistoryFetch } from '../../hooks/fetch';
 import {
   useCurrentZoneHistoryDatetimes,
@@ -15,11 +15,8 @@ import TimeSlider from '../../components/timeslider';
 
 import CountryPanel from './countrypanel';
 
-const handleZoneTimeIndexChange = (selectedZoneTimeIndex) => {
-  dispatch({
-    type: 'UPDATE_SLIDER_SELECTED_ZONE_TIME',
-    payload: { selectedZoneTimeIndex },
-  });
+const handleZoneTimeIndexChange = (timeIndex) => {
+  dispatchApplication('selectedZoneTimeIndex', timeIndex);
 };
 
 const mapStateToProps = state => ({

--- a/web/src/layout/legend.js
+++ b/web/src/layout/legend.js
@@ -8,7 +8,7 @@ import { __ } from '../helpers/translation';
 
 import HorizontalColorbar from '../components/horizontalcolorbar';
 import { solarColor, windColor } from '../helpers/scales';
-import { useSolarEnabled, useWindEnabled } from '../helpers/router';
+import { useSolarEnabled, useWindEnabled } from '../hooks/router';
 import { useCo2ColorScale } from '../hooks/theme';
 
 // TODO: Move styles from styles.css to here

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -17,7 +17,7 @@ import Map from './map';
 // Modules
 import { __ } from '../helpers/translation';
 import { isNewClientVersion } from '../helpers/environment';
-import { useCustomDatetime } from '../helpers/router';
+import { useCustomDatetime } from '../hooks/router';
 import { useLoadingOverlayVisible } from '../hooks/redux';
 import {
   useClientVersionFetch,

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -3,7 +3,7 @@
 // TODO(olc): re-enable this rule
 
 import React from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
 // Layout
@@ -25,7 +25,7 @@ import {
   useConditionalWindDataPolling,
   useConditionalSolarDataPolling,
 } from '../hooks/fetch';
-import { dispatch, dispatchApplication } from '../store';
+import { dispatchApplication } from '../store';
 import OnboardingModal from '../components/onboardingmodal';
 import LoadingOverlay from '../components/loadingoverlay';
 import Toggle from '../components/toggle';
@@ -46,6 +46,7 @@ const Main = ({
   hasConnectionWarning,
   version,
 }) => {
+  const dispatch = useDispatch();
   const location = useLocation();
   const datetime = useCustomDatetime();
 

--- a/web/src/layout/map.js
+++ b/web/src/layout/map.js
@@ -1,10 +1,10 @@
 import React, { useState, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { debounce } from 'lodash';
 
 import thirdPartyServices from '../services/thirdparty';
-import { getZoneId, navigateTo } from '../helpers/router';
+import { getZoneId } from '../helpers/router';
 import { getValueAtPosition } from '../helpers/grib';
 import { calculateLengthFromDimensions } from '../helpers/math';
 import { getCenteredZoneViewport, getCenteredLocationViewport } from '../helpers/map';
@@ -34,6 +34,7 @@ export default () => {
   const windData = useInterpolatedWindData();
   const zones = useZonesWithColors();
   const location = useLocation();
+  const history = useHistory();
   // TODO: Replace with useParams().zoneId once this component gets
   // put in the right render context and has this param available.
   const zoneId = getZoneId();
@@ -72,9 +73,9 @@ export default () => {
 
       // Disable the map and redirect to zones ranking.
       dispatchApplication('webGLSupported', false);
-      navigateTo({ pathname: '/ranking', search: location.search });
+      history.push({ pathname: '/ranking', search: location.search });
     },
-    [],
+    [history],
   );
 
   const handleMouseMove = useMemo(
@@ -102,18 +103,18 @@ export default () => {
 
   const handleSeaClick = useMemo(
     () => () => {
-      navigateTo({ pathname: '/map', search: location.search });
+      history.push({ pathname: '/map', search: location.search });
     },
-    [location],
+    [history],
   );
 
   const handleZoneClick = useMemo(
     () => (id) => {
       dispatchApplication('isLeftPanelCollapsed', false);
-      navigateTo({ pathname: `/zone/${id}`, search: location.search });
+      history.push({ pathname: `/zone/${id}`, search: location.search });
       thirdPartyServices.trackWithCurrentApplicationState('countryClick');
     },
-    [location],
+    [history],
   );
 
   const handleZoneMouseEnter = useMemo(

--- a/web/src/layout/map.js
+++ b/web/src/layout/map.js
@@ -11,6 +11,7 @@ import { getCenteredZoneViewport, getCenteredLocationViewport } from '../helpers
 import { useInterpolatedSolarData, useInterpolatedWindData } from '../hooks/layers';
 import { useTheme } from '../hooks/theme';
 import { useZonesWithColors } from '../hooks/map';
+import { useTrackEvent } from '../hooks/tracking';
 import { dispatchApplication } from '../store';
 
 import ZoneMap from '../components/zonemap';
@@ -33,6 +34,7 @@ export default () => {
   const solarData = useInterpolatedSolarData();
   const windData = useInterpolatedWindData();
   const zones = useZonesWithColors();
+  const trackEvent = useTrackEvent();
   const location = useLocation();
   const history = useHistory();
   // TODO: Replace with useParams().zoneId once this component gets
@@ -110,11 +112,11 @@ export default () => {
 
   const handleZoneClick = useMemo(
     () => (id) => {
+      trackEvent('countryClick');
       dispatchApplication('isLeftPanelCollapsed', false);
       history.push({ pathname: `/zone/${id}`, search: location.search });
-      thirdPartyServices.trackWithCurrentApplicationState('countryClick');
     },
-    [history],
+    [trackEvent, history],
   );
 
   const handleZoneMouseEnter = useMemo(

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -6,8 +6,9 @@ import moment from 'moment';
 
 import thirdPartyServices from './services/thirdparty';
 import { history } from './helpers/router';
-import { store } from './store';
+import { store, sagaMiddleware } from './store';
 import { cordovaApp } from './cordova';
+import sagas from './sagas';
 
 import Main from './layout/main';
 import GlobalStyle from './globalstyle';
@@ -19,6 +20,9 @@ if (thirdPartyServices._ga) {
 
 // Set proper locale
 moment.locale(window.locale.toLowerCase());
+
+// Plug in the sagas
+sagaMiddleware.run(sagas);
 
 // Render DOM
 ReactDOM.render(

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -23,7 +23,6 @@ const initialApplicationState = {
   co2ColorbarValue: null,
   colorBlindModeEnabled: cookieGetBool('colorBlindModeEnabled', false),
   brightModeEnabled: cookieGetBool('brightModeEnabled', true),
-  customDatetime: null,
   electricityMixMode: 'consumption',
   isCordova: window.isCordova,
   isEmbedded: window.top !== window.self,
@@ -50,7 +49,6 @@ const initialApplicationState = {
   selectedZoneName: null,
   selectedZoneTimeIndex: null,
   solarColorbarValue: null,
-  solarEnabled: false,
   webGLSupported: false,
   windColorbarValue: null,
   windEnabled: false,
@@ -75,10 +73,6 @@ const applicationReducer = (state = initialApplicationState, action) => {
       }
 
       return newState;
-    }
-
-    case 'UPDATE_STATE_FROM_URL': {
-      return Object.assign({}, state, action.payload);
     }
 
     case 'UPDATE_SLIDER_SELECTED_ZONE_TIME': {

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -55,8 +55,6 @@ const initialApplicationState = {
   windColorbarValue: null,
   windEnabled: false,
 
-  // TODO(olc): refactor this state
-  currentPage: null,
   // TODO(olc): move this to countryPanel once all React components have been made
   tableDisplayEmissions: false,
 };

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -61,27 +61,18 @@ const applicationReducer = (state = initialApplicationState, action) => {
   switch (action.type) {
     case 'APPLICATION_STATE_UPDATE': {
       const { key, value } = action;
+
+      // Do nothing if the value is unchanged
       if (state[key] === value) {
         return state;
       }
 
-      const newState = Object.assign({}, state);
-      newState[key] = value;
-
-      if (key === 'electricityMixMode' && ['consumption', 'production'].indexOf(value) === -1) {
+      // Throw an error if electricity mode is of the wrong format
+      if (key === 'electricityMixMode' && !['consumption', 'production'].includes(value)) {
         throw Error(`Unknown electricityMixMode "${value}"`);
       }
 
-      return newState;
-    }
-
-    case 'UPDATE_SLIDER_SELECTED_ZONE_TIME': {
-      const { selectedZoneTimeIndex } = action.payload;
-      // Update the selection only if it has changed
-      if (selectedZoneTimeIndex !== state.selectedZoneTimeIndex) {
-        return Object.assign({}, state, { selectedZoneTimeIndex });
-      }
-      return state;
+      return { ...state, [key]: value };
     }
 
     default:

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -46,12 +46,10 @@ const initialApplicationState = {
   },
   onboardingSeen: cookieGetBool('onboardingSeen', false),
   searchQuery: null,
-  selectedZoneName: null,
   selectedZoneTimeIndex: null,
   solarColorbarValue: null,
   webGLSupported: false,
   windColorbarValue: null,
-  windEnabled: false,
 
   // TODO(olc): move this to countryPanel once all React components have been made
   tableDisplayEmissions: false,

--- a/web/src/sagas/index.js
+++ b/web/src/sagas/index.js
@@ -1,7 +1,13 @@
-import { call, put, takeLatest } from 'redux-saga/effects';
+import {
+  call,
+  put,
+  select,
+  takeLatest,
+} from 'redux-saga/effects';
 
 import thirdPartyServices from '../services/thirdparty';
 import { handleRequestError, protectedJsonRequest, textRequest } from '../helpers/api';
+import { history } from '../helpers/router';
 import {
   getGfsTargetTimeBefore,
   getGfsTargetTimeAfter,
@@ -32,7 +38,7 @@ function* fetchGridData(action) {
   const { datetime } = action.payload;
   try {
     const payload = yield call(protectedJsonRequest, datetime ? `/v3/state?datetime=${datetime}` : '/v3/state');
-    thirdPartyServices.trackWithCurrentApplicationState('pageview');
+    yield put({ type: 'TRACK_EVENT', payload: { eventName: 'pageview' } });
     yield put({ type: 'APPLICATION_STATE_UPDATE', key: 'callerLocation', value: payload.callerLocation });
     yield put({ type: 'APPLICATION_STATE_UPDATE', key: 'callerZone', value: payload.callerZone });
     yield put({ type: 'GRID_DATA_FETCH_SUCCEEDED', payload });
@@ -66,10 +72,37 @@ function* fetchWindData(action) {
   }
 }
 
+function* trackEvent(action) {
+  const appState = yield select(state => state.application);
+  const searchParams = new URLSearchParams(history.location.search);
+  const { eventName, context = {} } = action.payload;
+
+  yield call(
+    [thirdPartyServices, thirdPartyServices.trackEvent],
+    eventName,
+    {
+      // Pass whole of the application state ...
+      ...appState,
+      bundleVersion: appState.bundleHash,
+      embeddedUri: appState.isEmbedded ? document.referrer : null,
+      // ... together with the URL context ...
+      currentPage: history.location.pathname.split('/')[1],
+      selectedZoneName: history.location.pathname.split('/')[2],
+      solarEnabled: searchParams.get('solar') === 'true',
+      windEnabled: searchParams.get('wind') === 'true',
+      // ... and whatever context is explicitly provided.
+      ...context,
+    },
+  );
+}
+
 export default function* () {
+  // Data fetching
   yield takeLatest('GRID_DATA_FETCH_REQUESTED', fetchGridData);
   yield takeLatest('WIND_DATA_FETCH_REQUESTED', fetchWindData);
   yield takeLatest('SOLAR_DATA_FETCH_REQUESTED', fetchSolarData);
   yield takeLatest('ZONE_HISTORY_FETCH_REQUESTED', fetchZoneHistory);
   yield takeLatest('CLIENT_VERSION_FETCH_REQUESTED', fetchClientVersion);
+  // Analytics
+  yield takeLatest('TRACK_EVENT', trackEvent);
 }

--- a/web/src/services/thirdparty.js
+++ b/web/src/services/thirdparty.js
@@ -1,14 +1,14 @@
-/* eslint-disable */
+/* eslint-disable global-require */
+/* eslint-disable prefer-rest-params */
 // TODO: remove once refactored
 
-const store = require('../store');
-
-const { Sentry } = window;
+import { getState } from '../store';
+import { history } from '../helpers/router';
 
 class ConnectionsService {
   constructor() {
     this.connections = [];
-    if (store.getState().application.isProduction) {
+    if (getState().application.isProduction) {
       this.addConnection(require('./thirdparty/twitter'));
       this.addConnection(require('./thirdparty/facebook'));
       this._ga = this.addConnection(require('./thirdparty/ga'));
@@ -25,32 +25,35 @@ class ConnectionsService {
     this.connections.forEach((conn) => {
       try {
         conn.track(eventName, paramObj);
-      } catch(err) { console.error('External connection error: ' + err); }
+      } catch (err) { console.error(`External connection error: ${err}`); }
     });
   }
 
   trackWithCurrentApplicationState(eventName) {
-    const params = store.getState().application;
-    params.bundleVersion = params.bundleHash;
-    params.embeddedUri = params.isEmbedded ? document.referrer : null;
-    this.track(eventName, params);
+    const appState = getState().application;
+    this.track(eventName, {
+      ...appState,
+      bundleVersion: appState.bundleHash,
+      embeddedUri: appState.isEmbedded ? document.referrer : null,
+      currentPage: history.location.pathname.split('/')[1],
+    });
   }
 
   // track google analytics if is available
-  ga(){
-    if(this._ga !== undefined){
+  ga() {
+    if (this._ga !== undefined) {
       try {
         this._ga.ga(...arguments);
-      } catch(err) { console.error('Google analytics track error: ' + err); }
+      } catch (err) { console.error(`Google analytics track error: ${err}`); }
     }
   }
 
   reportToSentry(e) {
-    if (Sentry !== undefined) {
+    if (window.Sentry !== undefined) {
       try {
-        Sentry.captureException(e);
+        window.Sentry.captureException(e);
       } catch (err) {
-        console.error('Error while reporting error to Sentry: ' + err);
+        console.error(`Error while reporting error to Sentry: ${err}`);
       }
     }
   }
@@ -58,7 +61,7 @@ class ConnectionsService {
   // track errors
   trackError(e) {
     console.error(`Error Caught! ${e}`);
-    this.track('error', { ...store.getState().application, name: e.name, stack: e.stack });
+    this.track('error', { ...getState().application, name: e.name, stack: e.stack });
     this.ga('event', 'exception', { description: e, fatal: false });
     this.reportToSentry(e);
   }

--- a/web/src/services/thirdparty.js
+++ b/web/src/services/thirdparty.js
@@ -2,7 +2,8 @@
 /* eslint-disable prefer-rest-params */
 // TODO: remove once refactored
 
-import { dispatch, getState } from '../store';
+import { store } from '../store';
+import { isProduction } from '../helpers/environment';
 
 function reportToSentry(e) {
   if (window.Sentry !== undefined) {
@@ -17,7 +18,7 @@ function reportToSentry(e) {
 class ConnectionsService {
   constructor() {
     this.connections = [];
-    if (getState().application.isProduction) {
+    if (isProduction()) {
       this.addConnection(require('./thirdparty/twitter'));
       this.addConnection(require('./thirdparty/facebook'));
       this._ga = this.addConnection(require('./thirdparty/ga'));
@@ -53,7 +54,7 @@ class ConnectionsService {
   trackError(e) {
     console.error(`Error Caught! ${e}`);
     this.ga('event', 'exception', { description: e, fatal: false });
-    dispatch({
+    store.dispatch({
       type: 'TRACK_EVENT',
       payload: {
         eventName: 'error',

--- a/web/src/services/thirdparty/debugconsole.js
+++ b/web/src/services/thirdparty/debugconsole.js
@@ -1,0 +1,5 @@
+function track(event, data) {
+  console.log('TRACK', event, data);
+}
+
+module.exports = { track };

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -1,12 +1,13 @@
 import createSagaMiddleware from 'redux-saga';
 import { createStore, applyMiddleware } from 'redux';
+import { logger } from 'redux-logger';
+
 import { updateApplication } from './actioncreators';
 import reducer from './reducers';
-import sagas from './sagas';
 
-const sagaMiddleware = createSagaMiddleware();
+export const sagaMiddleware = createSagaMiddleware();
 
-const store = process.env.NODE_ENV === 'production'
+export const store = process.env.NODE_ENV === 'production'
   ? createStore(
     reducer,
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
@@ -16,33 +17,13 @@ const store = process.env.NODE_ENV === 'production'
     reducer,
     window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
     applyMiddleware(sagaMiddleware),
-    applyMiddleware(require('redux-logger').logger),
+    applyMiddleware(logger),
   );
 
-sagaMiddleware.run(sagas);
-
-// Utility to react to store changes
-const observe = (select, onChange) => {
-  let currentSelectedState;
-
-  function handleChange() {
-    const nextState = store.getState();
-    const nextSelectedState = select(nextState);
-    if (nextSelectedState !== currentSelectedState) {
-      currentSelectedState = nextSelectedState;
-      onChange(currentSelectedState, nextState);
-    }
-  }
-
-  const unsubscribe = store.subscribe(handleChange);
-  handleChange();
-  return unsubscribe;
-};
-
-const { dispatch, getState } = store;
+export const { dispatch, getState } = store;
 
 // TODO: Deprecate and use actioncreators instead
-const dispatchApplication = (key, value) => {
+export const dispatchApplication = (key, value) => {
   // Do not dispatch unnecessary events
   // TODO: warn: getState() might be out of sync
   // by the time the event gets dispatched.
@@ -50,12 +31,4 @@ const dispatchApplication = (key, value) => {
     return;
   }
   dispatch(updateApplication(key, value));
-};
-
-export {
-  dispatch,
-  dispatchApplication,
-  getState,
-  observe,
-  store,
 };

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -2,7 +2,6 @@ import createSagaMiddleware from 'redux-saga';
 import { createStore, applyMiddleware } from 'redux';
 import { logger } from 'redux-logger';
 
-import { updateApplication } from './actioncreators';
 import reducer from './reducers';
 
 export const sagaMiddleware = createSagaMiddleware();
@@ -24,11 +23,5 @@ export const { dispatch, getState } = store;
 
 // TODO: Deprecate and use actioncreators instead
 export const dispatchApplication = (key, value) => {
-  // Do not dispatch unnecessary events
-  // TODO: warn: getState() might be out of sync
-  // by the time the event gets dispatched.
-  if (getState().application[key] === value) {
-    return;
-  }
-  dispatch(updateApplication(key, value));
+  dispatch({ type: 'APPLICATION_STATE_UPDATE', key, value });
 };

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -19,9 +19,7 @@ export const store = process.env.NODE_ENV === 'production'
     applyMiddleware(logger),
   );
 
-export const { dispatch, getState } = store;
-
 // TODO: Deprecate and use actioncreators instead
 export const dispatchApplication = (key, value) => {
-  dispatch({ type: 'APPLICATION_STATE_UPDATE', key, value });
+  store.dispatch({ type: 'APPLICATION_STATE_UPDATE', key, value });
 };


### PR DESCRIPTION
Resolves #2296.

#### Major changes

* Removed all the URL state from Redux (`customDatetime`, `selectedZoneName`, `solarEnabled`, `windEnabled`, `currentPage`)
* I thought this was a good place to decouple the third party tracking logic from the Redux store logic so I added the `trackEvent` method that is now handled via sagas and always takes the freshest combination of Redux + URL state to attach to all events - see https://github.com/tmrowco/electricitymap-contrib/pull/2476/commits/3bdf01ecd5602a24b76c436054f9f2a1cc035721
* I replaced some `<Redirect />`s (which use `history.replace` under the hood) with explicit `history.push` when we want to preserve the browsing history, e.g. when using key commands - see https://github.com/tmrowco/electricitymap-contrib/pull/2476/commits/ea83d8ecf11230f4ec3048bfe73dbc08322697b4
* Tracked events are now logged via `console.log` in non-production environments
