### PR TITLE
countryCode was replaced by zoneKey ; stating so in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ A parser is a python3 script that is expected to define the method `fetch_produc
 ```python
 def fetch_production(zone_key='FR', session=None, target_datetime=None, logger=None):
     return {
-      'countryCode': 'FR',
+      'zoneKey': 'FR',
       'datetime': '2017-01-01T00:00:00Z',
       'production': {
           'biomass': 0.0,


### PR DESCRIPTION
My parser build from the example in the README failed when trying to update the local data at https://github.com/tmrowco/electricitymap-contrib/blob/ac34023ccb4cbdeef4d26374b3abc996a8b4d031/mockserver/update_state.py#L116