### PR TITLE
Make left panel wider on wide screens

### DIFF
--- a/web/src/layout/leftpanel/index.js
+++ b/web/src/layout/leftpanel/index.js
@@ -13,6 +13,7 @@ import {
   useLocation,
 } from 'react-router-dom';
 
+import { dispatchApplication } from '../../store';
 import { useSearchParams } from '../../helpers/router';
 import { usePageViewsTracker } from '../../hooks/tracking';
 import { useSmallLoaderVisible } from '../../hooks/redux';
@@ -86,6 +87,16 @@ const LeftPanel = ({ isLeftPanelCollapsed, isMobile }) => {
             <LastUpdatedTime />
           </div>
         </div>
+      </div>
+
+      <div
+        id="left-panel-collapse-button"
+        className={`small-screen-hidden ${isLeftPanelCollapsed ? 'collapsed' : ''}`}
+        onClick={() => dispatchApplication('isLeftPanelCollapsed', !isLeftPanelCollapsed)}
+        role="button"
+        tabIndex="0"
+      >
+        <i className="material-icons">arrow_drop_down</i>
       </div>
 
       {/* Render different content based on the current route */}

--- a/web/src/layout/main.js
+++ b/web/src/layout/main.js
@@ -37,14 +37,12 @@ const mapStateToProps = state => ({
   brightModeEnabled: state.application.brightModeEnabled,
   electricityMixMode: state.application.electricityMixMode,
   hasConnectionWarning: state.data.hasConnectionWarning,
-  isLeftPanelCollapsed: state.application.isLeftPanelCollapsed,
   version: state.application.version,
 });
 
 const Main = ({
   brightModeEnabled,
   electricityMixMode,
-  isLeftPanelCollapsed,
   hasConnectionWarning,
   version,
 }) => {
@@ -126,16 +124,6 @@ const Main = ({
             <div className="inner">
               {__('misc.newversion')}
             </div>
-          </div>
-
-          <div
-            id="left-panel-collapse-button"
-            className={`small-screen-hidden ${isLeftPanelCollapsed ? 'collapsed' : ''}`}
-            onClick={() => dispatchApplication('isLeftPanelCollapsed', !isLeftPanelCollapsed)}
-            role="button"
-            tabIndex="0"
-          >
-            <i className="material-icons">arrow_drop_down</i>
           </div>
 
           { /* end #inner */}

--- a/web/src/scss/components/_messaging.scss
+++ b/web/src/scss/components/_messaging.scss
@@ -25,8 +25,9 @@
 	}
 
     @include respond-to('medium-up') {
-        padding-left: 24rem; /* keep in sync with left-panel width */
         box-sizing: border-box;
+        margin: 0 15% 0 45%;
+        width: 40%;
     }
 }
 

--- a/web/src/scss/layout/_left-panel.scss
+++ b/web/src/scss/layout/_left-panel.scss
@@ -6,9 +6,10 @@
 
 /* Left-panel collapse button */
 #left-panel-collapse-button {
-    left: 24rem; /* should be same as .left-panel width */
+    left: 100%;
     top: 0.5rem;
     position: absolute;
+    cursor: pointer;
     background-color: $lighter-gray;
     width: 1.5rem;
     height: 3rem;
@@ -20,23 +21,14 @@
     border-bottom-right-radius: 4px;
     justify-content: center;
     box-shadow: 6px 2px 10px -3px rgba(0,0,0,0.10);
-    transition: transform 0.4s;
-    z-index: 2; /* in order to be above left-panel */
-
-    &:hover {
-        cursor: pointer;
-    }
+    outline: 0;
 
     i {
         transform: rotate(90deg);
     }
 
-    &.collapsed {
-        transform: translate(-24rem);
-
-        i {
-            transform: rotate(-90deg);
-        }
+    &.collapsed i {
+        transform: rotate(-90deg);
     }
 
     @include respond-to('small') {
@@ -47,7 +39,8 @@
 .left-panel {
     color: $black;
     padding: 0;
-    width: 24rem;
+    width: 28vw;
+    min-width: 24rem;
     background-color: $lighter-gray;
     position: fixed;
     box-shadow: 0 24px 15px rgba(0,0,0,0.2);
@@ -58,7 +51,7 @@
     transition: transform 0.4s, box-shadow 0.4s;
 
     &.collapsed {
-        transform: translate(-24rem);
+        transform: translate(-100%);
         box-shadow: 0 24px 15px rgba(0,0,0,0);
     }
 


### PR DESCRIPTION
Addresses second suggestion in https://github.com/tmrowco/electricitymap-contrib/issues/2007#issuecomment-625896384 - I decided for max 28% of the screen width in the end.

I also moved the collapse button inside of the left panel layout because it makes things simpler and that's really where it belongs and I shrank the flash message to make sure it never ovelaps with the left panel.

![image](https://user-images.githubusercontent.com/1216874/81592885-e992c200-93be-11ea-913e-f56da7769bcb.png)

