### PR TITLE
Tidy up zone panel question marks

### DIFF
--- a/web/src/components/countrytable.js
+++ b/web/src/components/countrytable.js
@@ -18,7 +18,11 @@ import {
 import { useCo2ColorScale } from '../hooks/theme';
 import { getTooltipPosition } from '../helpers/graph';
 import { modeOrder, modeColor, DEFAULT_FLAG_SIZE } from '../helpers/constants';
-import { getProductionCo2Intensity, getExchangeCo2Intensity } from '../helpers/zonedata';
+import {
+  getElectricityProductionValue,
+  getProductionCo2Intensity,
+  getExchangeCo2Intensity,
+} from '../helpers/zonedata';
 import { flagUri } from '../helpers/flags';
 import { __ } from '../helpers/translation';
 
@@ -124,6 +128,8 @@ const Row = ({
   index,
   isMobile,
   label,
+  scale,
+  value,
   onMouseOver,
   onMouseOut,
   width,
@@ -159,6 +165,18 @@ const Row = ({
 
       {/* Row content */}
       {children}
+
+      {/* Question mark if the value is not defined */}
+      {!isFinite(value) && (
+        <text
+          className="unknown"
+          transform={`translate(3, ${TEXT_ADJUST_Y})`}
+          style={{ pointerEvents: 'none', fill: 'darkgray' }}
+          x={LABEL_MAX_WIDTH + scale(0)}
+        >
+          ?
+        </text>
+      )}
     </g>
   );
 };
@@ -193,26 +211,6 @@ const HorizontalBar = ({
   );
 };
 
-const QuestionMarkIfNoData = ({ datapoint, scale }) => {
-  // If the mode is unknown, don't need to show the question mark
-  if (datapoint.mode === 'unknown') return null;
-
-  // If both the value and capacity fills are there, don't show the question mark 
-  const value = datapoint.isStorage ? datapoint.storage : datapoint.production;
-  if (datapoint.capacity !== undefined && value !== undefined) return null;
-
-  return (
-    <text
-      className="unknown"
-      transform={`translate(1, ${TEXT_ADJUST_Y})`}
-      style={{ pointerEvents: 'none', fill: 'darkgray' }}
-      x={LABEL_MAX_WIDTH + scale(0)}
-    >
-      ?
-    </text>
-  );
-};
-
 const CountryCarbonEmissionsTable = React.memo(({
   data,
   exchangeData,
@@ -232,15 +230,20 @@ const CountryCarbonEmissionsTable = React.memo(({
   const maxCO2eqProduction = d3Max(productionData, d => d.tCo2eqPerMin);
 
   // in tCO₂eq/min
-  const co2Scale = scaleLinear()
-    .domain([
-      -maxCO2eqExport || 0,
-      Math.max(
-        maxCO2eqProduction || 0,
-        maxCO2eqImport || 0
-      ),
-    ])
-    .range([0, width - LABEL_MAX_WIDTH - PADDING_X]);
+  const co2Scale = useMemo(
+    () => (
+      scaleLinear()
+        .domain([
+          -maxCO2eqExport || 0,
+          Math.max(
+            maxCO2eqProduction || 0,
+            maxCO2eqImport || 0
+          ),
+        ])
+        .range([0, width - LABEL_MAX_WIDTH - PADDING_X])
+    ),
+    [maxCO2eqExport, maxCO2eqProduction, maxCO2eqImport, width],
+  );
 
   const formatTick = (t) => {
     const [x1, x2] = co2Scale.domain();
@@ -262,6 +265,8 @@ const CountryCarbonEmissionsTable = React.memo(({
             index={index}
             label={__(d.mode)}
             width={width}
+            scale={co2Scale}
+            value={Math.abs(d.tCo2eqPerMin)}
             onMouseOver={ev => onProductionRowMouseOver(d.mode, data, ev)}
             onMouseOut={onProductionRowMouseOut}
             isMobile={isMobile}
@@ -270,10 +275,6 @@ const CountryCarbonEmissionsTable = React.memo(({
               className="production"
               fill={modeColor[d.mode]}
               range={[0, Math.abs(d.tCo2eqPerMin)]}
-              scale={co2Scale}
-            />
-            <QuestionMarkIfNoData
-              datapoint={d}
               scale={co2Scale}
             />
           </Row>
@@ -286,6 +287,8 @@ const CountryCarbonEmissionsTable = React.memo(({
             index={index}
             label={d.mode}
             width={width}
+            scale={co2Scale}
+            value={d.tCo2eqPerMin}
             onMouseOver={ev => onExchangeRowMouseOver(d.mode, data, ev)}
             onMouseOut={onExchangeRowMouseOut}
             isMobile={isMobile}
@@ -365,6 +368,8 @@ const CountryElectricityProductionTable = React.memo(({
             index={index}
             label={__(d.mode)}
             width={width}
+            scale={powerScale}
+            value={getElectricityProductionValue(d)}
             onMouseOver={ev => onProductionRowMouseOver(d.mode, data, ev)}
             onMouseOut={onProductionRowMouseOut}
             isMobile={isMobile}
@@ -378,11 +383,7 @@ const CountryElectricityProductionTable = React.memo(({
             <HorizontalBar
               className="production"
               fill={modeColor[d.mode]}
-              range={d.isStorage ? [0, -d.storage] : [0, d.production]}
-              scale={powerScale}
-            />
-            <QuestionMarkIfNoData
-              datapoint={d}
+              range={[0, getElectricityProductionValue(d)]}
               scale={powerScale}
             />
           </Row>
@@ -395,6 +396,8 @@ const CountryElectricityProductionTable = React.memo(({
             index={index}
             label={d.mode}
             width={width}
+            scale={powerScale}
+            value={d.exchange}
             onMouseOver={ev => onExchangeRowMouseOver(d.mode, data, ev)}
             onMouseOut={onExchangeRowMouseOut}
             isMobile={isMobile}

--- a/web/src/helpers/math.js
+++ b/web/src/helpers/math.js
@@ -1,8 +1,15 @@
 import { isFinite } from 'lodash';
 
 export function getRatioPercent(value, total) {
-  const perc = Math.round(value / total * 10000) / 100;
-  return isFinite(perc) ? `${perc}` : '?';
+  // If both the numerator and denominator are zeros,
+  // interpret the ratio as zero instead of NaN.
+  if (value === 0 && total === 0) {
+    return 0;
+  }
+  if (!isFinite(value) || !isFinite(total)) {
+    return '?';
+  }
+  return Math.round(value / total * 10000) / 100;
 }
 
 export function tonsPerHourToGramsPerMinute(value) {

--- a/web/src/helpers/zonedata.js
+++ b/web/src/helpers/zonedata.js
@@ -1,3 +1,19 @@
+import { isFinite } from 'lodash';
+
+export function getElectricityProductionValue({
+  capacity,
+  isStorage,
+  production,
+  storage,
+}) {
+  const value = isStorage ? -storage : production;
+  // If the value is not defined but the capacity
+  // is zero, assume the value is also zero.
+  if (!isFinite(value) && capacity === 0) {
+    return 0;
+  }
+  return value;
+}
 
 export function getProductionCo2Intensity(mode, zoneData) {
   const isStorage = mode.indexOf('storage') !== -1;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1216874/81715715-d17f7900-9478-11ea-9bf2-a1774abcfbf4.png)

#### Changes

* Assume electricity production is 0 when capacity is set to 0, reducing the number of question marks shown in the zones panel (see the screenshot above) - fixes #2445
* Did a similar change in the tooltip reusing the new `getElectricityProductionValue` helper
* Hide carbon intensity information from the tooltip when it doesn't apply, e.g. when we know the zone doesn't use that source of electricity
* Put the question mark inside of the `<Row />` component
