### PR TITLE
Fix broken /clientVersion endpoint

### DIFF
--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -43,22 +43,6 @@ export function protectedJsonRequest(path) {
   });
 }
 
-export function textRequest(path) {
-  const url = getEndpoint() + path;
-
-  return new Promise((resolve, reject) => {
-    request.text(url).get(null, (err, res) => {
-      if (err) {
-        reject(err);
-      } else if (!res) {
-        reject(new Error(`Empty response received for ${url}`));
-      } else {
-        resolve(res);
-      }
-    });
-  });
-}
-
 export function handleRequestError(err) {
   if (err) {
     if (err.target) {

--- a/web/src/helpers/client.js
+++ b/web/src/helpers/client.js
@@ -1,0 +1,15 @@
+import * as request from 'd3-request';
+
+export function clientVersionRequest() {
+  return new Promise((resolve, reject) => {
+    request.text('/clientVersion').get(null, (err, res) => {
+      if (err) {
+        reject(err);
+      } else if (!res) {
+        reject(new Error('Empty response received for the client version'));
+      } else {
+        resolve(res);
+      }
+    });
+  });
+}

--- a/web/src/sagas/index.js
+++ b/web/src/sagas/index.js
@@ -6,7 +6,8 @@ import {
 } from 'redux-saga/effects';
 
 import thirdPartyServices from '../services/thirdparty';
-import { handleRequestError, protectedJsonRequest, textRequest } from '../helpers/api';
+import { handleRequestError, protectedJsonRequest } from '../helpers/api';
+import { clientVersionRequest } from '../helpers/client';
 import { history } from '../helpers/router';
 import {
   getGfsTargetTimeBefore,
@@ -16,7 +17,7 @@ import {
 
 function* fetchClientVersion() {
   try {
-    const version = yield call(textRequest, '/clientVersion');
+    const version = yield call(clientVersionRequest);
     yield put({ type: 'APPLICATION_STATE_UPDATE', key: 'version', value: version });
   } catch (err) {
     handleRequestError(err);


### PR DESCRIPTION
In #2388 I accidentally made `/clientVersion` requests be made to the API endpoint while it's really the Express server which should be asked.
