### PR TITLE
Correct exchange arrows initial rendering

### DIFF
--- a/web/src/components/layers/exchangelayer.js
+++ b/web/src/components/layers/exchangelayer.js
@@ -64,7 +64,7 @@ const Arrow = React.memo(({
       k: 0.04 + (mapZoom - 1.5) * 0.1,
       r: rotation + (netFlow > 0 ? 180 : 0),
     }),
-    [lonlat, rotation, netFlow, mapZoom],
+    [project, lonlat, rotation, netFlow, mapZoom],
   );
 
   const isVisible = useMemo(

--- a/web/src/layout/map.js
+++ b/web/src/layout/map.js
@@ -58,8 +58,11 @@ export default () => {
         dispatchApplication('mapViewport', getCenteredLocationViewport(callerLocation));
       }
 
-      // Map loading is finished, lower the overlay shield.
-      dispatchApplication('isLoadingMap', false);
+      // Map loading is finished, lower the overlay shield with
+      // a bit of delay to allow the background to render first.
+      setTimeout(() => {
+        dispatchApplication('isLoadingMap', false);
+      }, 100);
 
       // Track and notify that WebGL is supported.
       dispatchApplication('webGLSupported', true);


### PR DESCRIPTION
Addresses #2532 - the bug was caused by a missing `project` function dependency in the `useMemo` method in the `Arrow` render function :facepalm: 

I noticed that the arrows would still flicker briefly as they'd be repositioned on initial rendering of the map when focused on a zone, so I also added 100ms to the loading overlay so that the initial map render would be done in the background and the overlay fadeout would look smoother.
