### PR TITLE
Updated spanish power capacity to May 2020

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1474,8 +1474,8 @@
       "hydro-storage": 3329,
       "nuclear": 7117,
       "oil": 707,
-      "solar": 11353,
-      "wind": 25806,
+      "solar": 11828,
+      "wind": 25902,
       "unknown": 360
     },
     "contributors": [


### PR DESCRIPTION
I slightly changed power production capacities from wind and solar power.

The source of the data is REE's (Red Eléctrica de España) website, where capacity data is uploaded in excel files.