### PR TITLE
Fix faulty import for exchanges config.

### DIFF
--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -5,7 +5,7 @@ import warnings
 
 import arrow
 
-from utils.config import EXCHANGES_CONFIG
+from ...utils.config import EXCHANGES_CONFIG
 
 class ValidationError(ValueError):
     pass

--- a/parsers/lib/quality.py
+++ b/parsers/lib/quality.py
@@ -5,7 +5,10 @@ import warnings
 
 import arrow
 
-from ...utils.config import EXCHANGES_CONFIG
+try:
+    from ...utils.config import EXCHANGES_CONFIG
+except ValueError:
+    from utils.config import EXCHANGES_CONFIG
 
 class ValidationError(ValueError):
     pass


### PR DESCRIPTION
[Quite URGENT] The import of `EXCHANGES_CONFIG` in `parsers/lib/quality.py` is faulty and therefore prevents the run of the feeder. 