### PR TITLE
Update installed capacity data for Ontario

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -907,17 +907,18 @@
   "CA-ON": {
     "capacity": {
       "biomass": 295,
-      "gas": 10277,
-      "hydro": 8482,
+      "gas": 11270,
+      "hydro": 9065,
       "nuclear": 13009,
-      "solar": 380,
+      "solar": 478,
       "wind": 4486,
       "coal": 0
     },
     "contributors": [
       "https://github.com/corradio",
       "https://github.com/jarek",
-      "https://github.com/scriptator"
+      "https://github.com/scriptator",
+      "https://github.com/felixvanoost"
     ],
     "flag_file_name": "ca.png",
     "parsers": {


### PR DESCRIPTION
Updates the installed generation capacity data for Ontario according to the latest IESO [Reliability Outlook](http://www.ieso.ca/-/media/Files/IESO/Document-Library/planning-forecasts/reliability-outlook/ReliabilityOutlook2020Mar.pdf?la=en) from March 2020.