### PR TITLE
Update Spain (ES) Coal Capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1468,7 +1468,7 @@
     ],
     "capacity": {
       "biomass": 1189,
-      "coal": 9456,
+      "coal": 4826,
       "gas": 30012,
       "geothermal": 0,
       "hydro": 17085,
@@ -1480,6 +1480,7 @@
       "unknown": 360
     },
     "contributors": [
+      "https://github.com/brandongalbraith",
       "https://github.com/corradio",
       "https://github.com/JosepRey",
       "https://github.com/nessie2013"


### PR DESCRIPTION
This PR reduces Spain's (ES) coal capacity based on recent news reports of coal generation closures (with verification from the facility owners).

> Seven out of the 15 coal-fired power stations that are still working in Spain will cease being operational on June 30 [2020], after their owners – the electricity companies – decided that it does not make financial sense to adapt them to European regulations. And four more are getting ready to shut down soon.

> The seven coal-fired thermal plants that will be phased out on Tuesday are Meirama in A Coruña, Narcea in Asturias, La Robla and Compostilla in León, Andorra in Teruel, Puente Nuevo in Córdoba and Velilla in Palencia.

> The four companies that own them – Naturgy, Endesa, Viesgo and Iberdrola – have confirmed to EL PAÍS that they will cease operations on June 30 [2020] to avoid violating a European environmental directive forcing such plants to adopt technology to clean up the gases they emit.

> Together, these seven plants represent 4,630 megawatts (MW), a little less than half the installed coal power generation capacity in Spain.

Source: https://web.archive.org/web/20200701184743/https://english.elpais.com/economy_and_business/2020-06-29/spain-to-close-half-its-coal-fired-power-stations.html