### PR TITLE
Remove Austria's coal capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -140,7 +140,7 @@
     ],
     "capacity": {
       "biomass": 647,
-      "coal": 246,
+      "coal": 0,
       "gas": 4015,
       "hydro": 8160,
       "hydro storage": 3120,


### PR DESCRIPTION
https://www.meinbezirk.at/graz-umgebung/c-wirtschaft/oesterreichs-letztes-kohlekraftwerk-hat-den-betrieb-eingestellt_a4043238