### PR TITLE
Responsive UI fixes

### DIFF
--- a/web/src/helpers/map.js
+++ b/web/src/helpers/map.js
@@ -1,5 +1,15 @@
 import { max, min, mean } from 'lodash';
 
+export function getCenteredLocationViewport([longitude, latitude]) {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    latitude,
+    longitude,
+    zoom: 4,
+  };
+}
+
 // If the panel is open the zoom doesn't appear perfectly centered because
 // it centers on the whole window and not just the visible map part, which
 // is something one could fix in the future.
@@ -14,13 +24,8 @@ export function getCenteredZoneViewport(zone) {
     });
   });
 
-  return {
-    latitude: mean([min(latitudes), max(latitudes)]),
-    longitude: mean([min(longitudes), max(longitudes)]),
-    zoom: 4,
-  };
-}
-
-export function getCenteredLocationViewport([longitude, latitude]) {
-  return { latitude, longitude, zoom: 4 };
+  return getCenteredLocationViewport([
+    mean([min(longitudes), max(longitudes)]),
+    mean([min(latitudes), max(latitudes)]),
+  ]);
 }

--- a/web/src/hooks/viewport.js
+++ b/web/src/hooks/viewport.js
@@ -45,3 +45,36 @@ export function useHeightObserver(ref, offset = 0) {
 
   return height;
 }
+
+function useWindowSize() {
+  const [windowSize, setWindowSize] = useState({});
+
+  // Resize hook
+  useEffect(() => {
+    const updateSize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+    // Set initial size
+    updateSize();
+    // Add window listeners
+    window.addEventListener('resize', updateSize);
+    return () => {
+      window.removeEventListener('resize', updateSize);
+    };
+  });
+
+  return windowSize;
+}
+
+export function useIsSmallScreen() {
+  const { width } = useWindowSize();
+  return width < 768;
+}
+
+export function useIsMediumUpScreen() {
+  const { width } = useWindowSize();
+  return width >= 768;
+}

--- a/web/src/hooks/viewport.js
+++ b/web/src/hooks/viewport.js
@@ -46,7 +46,7 @@ export function useHeightObserver(ref, offset = 0) {
   return height;
 }
 
-function useWindowSize() {
+export function useWindowSize() {
   const [windowSize, setWindowSize] = useState({});
 
   // Resize hook

--- a/web/src/layout/leftpanel/mobileinfotab.js
+++ b/web/src/layout/leftpanel/mobileinfotab.js
@@ -4,24 +4,24 @@
 // TODO: re-enable rules
 
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { Redirect, useLocation } from 'react-router-dom';
 
 import { __ } from '../../helpers/translation';
+import { useIsMediumUpScreen } from '../../hooks/viewport';
 import FAQ from '../../components/faq';
 import ColorBlindCheckbox from '../../components/colorblindcheckbox';
 
 const MobileInfoTab = () => {
-  const isMobile = useSelector(state => state.application.isMobile);
+  const isMediumUpScreen = useIsMediumUpScreen();
   const location = useLocation();
 
-  // If not on mobile, redirect to the /map page
-  if (!isMobile) {
+  // If not on small screen, redirect to the /map page
+  if (isMediumUpScreen) {
     return <Redirect to={{ pathname: '/map', search: location.search }} />;
   }
 
   return (
-    <div className="mobile-info-tab large-screen-hidden">
+    <div className="mobile-info-tab">
       <div className="mobile-watermark brightmode">
         <a href="http://www.tmrow.com/mission?utm_source=electricitymap.org&utm_medium=referral&utm_campaign=watermark" target="_blank">
           <img src={resolvePath('images/built-by-tomorrow.svg')} alt="" />

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -34,12 +34,14 @@ const initialApplicationState = {
   isMovingMap: false,
   isLoadingMap: true,
   isMobile:
-  (/android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i).test(navigator.userAgent),
+    (/android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i).test(navigator.userAgent),
   isProduction: isProduction(),
   isLocalhost: isLocalhost(),
   legendVisible: true,
   locale: window.locale,
   mapViewport: {
+    width: window.innerWidth,
+    height: window.innerHeight,
     latitude: 50,
     longitude: 0,
     zoom: 1.5,

--- a/web/src/scss/layout/_left-panel.scss
+++ b/web/src/scss/layout/_left-panel.scss
@@ -39,8 +39,7 @@
 .left-panel {
     color: $black;
     padding: 0;
-    width: 28vw;
-    min-width: 24rem;
+    width: calc(14vw + 16rem);
     background-color: $lighter-gray;
     position: fixed;
     box-shadow: 0 24px 15px rgba(0,0,0,0.2);


### PR DESCRIPTION
A couple of surgical fixes to the responsive aspect of the UI based on some recent issues / comments.

#### Changes

* Fix left side panel overflow on mobile - addresses https://github.com/tmrowco/electricitymap-contrib/commit/58a5d495125fecf0a73fd236d1cd906afd54067f#r40174062
* Look at screen width instead of isMobile for `/info` page redirect - the new `useIsSmallScreen` / `useIsMediumUpScreen` React hooks can be used instead of CSS screen size breakpoints when more of the styles is moved to React components #2261
* Update exchange arrows under window width resizing - fixes https://github.com/tmrowco/electricitymap-contrib/issues/2573