### PR TITLE
Update useWindowSize hook only when window size actually changes

### DIFF
--- a/web/src/hooks/viewport.js
+++ b/web/src/hooks/viewport.js
@@ -52,10 +52,15 @@ export function useWindowSize() {
   // Resize hook
   useEffect(() => {
     const updateSize = () => {
-      setWindowSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
+      if (
+        windowSize.width !== window.innerWidth
+        || windowSize.height !== window.innerHeight
+      ) {
+        setWindowSize({
+          width: window.innerWidth,
+          height: window.innerHeight,
+        });
+      }
     };
     // Set initial size
     updateSize();


### PR DESCRIPTION
After merging #2589, I noticed that the map would sometimes be stuck in a render loop:

![Screenshot from 2020-07-30 17-05-34](https://user-images.githubusercontent.com/1216874/88939528-eead3200-d286-11ea-8a5e-64322838a389.png)

The cause was in `useWindowSize` hook which would always create a new object when initialized, causing the loop: _Map_ using _useWindowSize_ updating the `{ width, height }` object causing a new render of _Map_ which initializes _useWindowSize_ again etc..

The solution was to make sure the hook updates the values only when they're actually changed.

Sorry for that :grimacing: 
