### PR TITLE
Tooltip fixes on mobile

### DIFF
--- a/web/src/components/circulargauge.js
+++ b/web/src/components/circulargauge.js
@@ -8,6 +8,7 @@ import { arc } from 'd3-shape';
 
 const CircularGauge = React.memo(({
   fontSize = '1rem',
+  onClick,
   onMouseMove,
   onMouseOut,
   onMouseOver,
@@ -23,6 +24,7 @@ const CircularGauge = React.memo(({
 
   return (
     <div
+      onClick={e => onClick && onClick(e.clientX, e.clientY)}
       onMouseOver={() => onMouseOver && onMouseOver()}
       onMouseOut={() => onMouseOut && onMouseOut()}
       onMouseMove={e => onMouseMove && onMouseMove(e.clientX, e.clientY)}

--- a/web/src/components/countryhistorycarbongraph.js
+++ b/web/src/components/countryhistorycarbongraph.js
@@ -111,6 +111,7 @@ const CountryHistoryCarbonGraph = ({
         <MapCountryTooltip
           position={tooltip.position}
           zoneData={tooltip.zoneData}
+          onClose={markerHideHandler}
         />
       )}
     </React.Fragment>

--- a/web/src/components/countryhistorycarbongraph.js
+++ b/web/src/components/countryhistorycarbongraph.js
@@ -111,7 +111,10 @@ const CountryHistoryCarbonGraph = ({
         <MapCountryTooltip
           position={tooltip.position}
           zoneData={tooltip.zoneData}
-          onClose={markerHideHandler}
+          onClose={() => {
+            setSelectedLayerIndex(null);
+            setTooltip(null);
+          }}
         />
       )}
     </React.Fragment>

--- a/web/src/components/countryhistoryemissionsgraph.js
+++ b/web/src/components/countryhistoryemissionsgraph.js
@@ -115,7 +115,10 @@ const CountryHistoryEmissionsGraph = ({
         <CountryPanelEmissionsTooltip
           position={tooltip.position}
           zoneData={tooltip.zoneData}
-          onClose={markerHideHandler}
+          onClose={() => {
+            setSelectedLayerIndex(null);
+            setTooltip(null);
+          }}
         />
       )}
     </React.Fragment>

--- a/web/src/components/countryhistoryemissionsgraph.js
+++ b/web/src/components/countryhistoryemissionsgraph.js
@@ -115,6 +115,7 @@ const CountryHistoryEmissionsGraph = ({
         <CountryPanelEmissionsTooltip
           position={tooltip.position}
           zoneData={tooltip.zoneData}
+          onClose={markerHideHandler}
         />
       )}
     </React.Fragment>

--- a/web/src/components/countryhistorymixgraph.js
+++ b/web/src/components/countryhistorymixgraph.js
@@ -201,12 +201,14 @@ const CountryHistoryMixGraph = ({
             exchangeKey={tooltip.mode}
             position={tooltip.position}
             zoneData={tooltip.zoneData}
+            onClose={markerHideHandler}
           />
         ) : (
           <CountryPanelProductionTooltip
             mode={tooltip.mode}
             position={tooltip.position}
             zoneData={tooltip.zoneData}
+            onClose={markerHideHandler}
           />
         )
       )}

--- a/web/src/components/countryhistorymixgraph.js
+++ b/web/src/components/countryhistorymixgraph.js
@@ -201,14 +201,20 @@ const CountryHistoryMixGraph = ({
             exchangeKey={tooltip.mode}
             position={tooltip.position}
             zoneData={tooltip.zoneData}
-            onClose={markerHideHandler}
+            onClose={() => {
+              setSelectedLayerIndex(null);
+              setTooltip(null);
+            }}
           />
         ) : (
           <CountryPanelProductionTooltip
             mode={tooltip.mode}
             position={tooltip.position}
             zoneData={tooltip.zoneData}
-            onClose={markerHideHandler}
+            onClose={() => {
+              setSelectedLayerIndex(null);
+              setTooltip(null);
+            }}
           />
         )
       )}

--- a/web/src/components/countryhistorypricesgraph.js
+++ b/web/src/components/countryhistorypricesgraph.js
@@ -137,7 +137,10 @@ const CountryHistoryPricesGraph = ({
         <PriceTooltip
           position={tooltip.position}
           zoneData={tooltip.zoneData}
-          onClose={markerHideHandler}
+          onClose={() => {
+            setSelectedLayerIndex(null);
+            setTooltip(null);
+          }}
         />
       )}
     </React.Fragment>

--- a/web/src/components/countryhistorypricesgraph.js
+++ b/web/src/components/countryhistorypricesgraph.js
@@ -137,6 +137,7 @@ const CountryHistoryPricesGraph = ({
         <PriceTooltip
           position={tooltip.position}
           zoneData={tooltip.zoneData}
+          onClose={markerHideHandler}
         />
       )}
     </React.Fragment>

--- a/web/src/components/countrytable.js
+++ b/web/src/components/countrytable.js
@@ -512,6 +512,7 @@ const CountryTable = ({
           mode={productionTooltip.mode}
           position={productionTooltip.position}
           zoneData={productionTooltip.zoneData}
+          onClose={() => setProductionTooltip(null)}
         />
       )}
       {exchangeTooltip && (
@@ -519,6 +520,7 @@ const CountryTable = ({
           exchangeKey={exchangeTooltip.mode}
           position={exchangeTooltip.position}
           zoneData={exchangeTooltip.zoneData}
+          onClose={() => setExchangeTooltip(null)}
         />
       )}
       <CountryTableOverlayIfNoData />

--- a/web/src/components/layers/exchangelayer.js
+++ b/web/src/components/layers/exchangelayer.js
@@ -60,6 +60,7 @@ export default React.memo(({ project }) => {
         <MapExchangeTooltip
           exchangeData={tooltip.exchangeData}
           position={tooltip.position}
+          onClose={() => setTooltip(null)}
         />
       )}
       {/* Don't render arrows when moving map - see https://github.com/tmrowco/electricitymap-contrib/issues/1590. */}

--- a/web/src/components/tooltip.js
+++ b/web/src/components/tooltip.js
@@ -1,13 +1,30 @@
 import React, { useRef } from 'react';
 import { Portal } from 'react-portal';
+import { useSelector } from 'react-redux';
+import styled from 'styled-components';
 
 import { useWidthObserver, useHeightObserver } from '../hooks/viewport';
 
 const MARGIN = 16;
 
-const Tooltip = ({ id, children, position }) => {
-  const ref = useRef(null);
+const FadedOverlay = styled.div`
+  background: rgba(0, 0, 0, 0.25);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+`;
 
+const Tooltip = ({
+  id,
+  children,
+  position,
+  onClose,
+}) => {
+  const isMobile = useSelector(state => state.application.isMobile);
+
+  const ref = useRef(null);
   const width = useWidthObserver(ref);
   const height = useHeightObserver(ref);
 
@@ -46,6 +63,11 @@ const Tooltip = ({ id, children, position }) => {
 
   return (
     <Portal>
+      {/*
+        Show the faded overlay only on mobile - close the tooltip in
+        the next rendering cycle when clicked anywhere on the overlay.
+      */}
+      {isMobile && <FadedOverlay onClick={() => setTimeout(onClose, 0)} />}
       <div id={id} className="tooltip panel" style={style} ref={ref}>
         {children}
       </div>

--- a/web/src/components/tooltips/countrypanelemissionstooltip.js
+++ b/web/src/components/tooltips/countrypanelemissionstooltip.js
@@ -5,13 +5,13 @@ import { getTotalElectricity } from '../../helpers/zonedata';
 import { tonsPerHourToGramsPerMinute } from '../../helpers/math';
 import Tooltip from '../tooltip';
 
-const CountryPanelEmissionsTooltip = ({ position, zoneData }) => {
+const CountryPanelEmissionsTooltip = ({ position, zoneData, onClose }) => {
   if (!zoneData) return null;
 
   const totalEmissions = Math.round(tonsPerHourToGramsPerMinute(getTotalElectricity(zoneData, true)) * 100) / 100;
 
   return (
-    <Tooltip id="countrypanel-emissions-tooltip" position={position}>
+    <Tooltip id="countrypanel-emissions-tooltip" position={position} onClose={onClose}>
       <b>{totalEmissions}t</b> {__('ofCO2eqPerMinute')}
     </Tooltip>
   );

--- a/web/src/components/tooltips/countrypanelexchangetooltip.js
+++ b/web/src/components/tooltips/countrypanelexchangetooltip.js
@@ -21,6 +21,7 @@ const CountryPanelExchangeTooltip = ({
   exchangeKey,
   position,
   zoneData,
+  onClose,
 }) => {
   if (!zoneData) return null;
 
@@ -49,7 +50,7 @@ const CountryPanelExchangeTooltip = ({
   headline = headline.replace('id="country-exchange-flag"', `class="flag" src="${flagUri(exchangeKey)}"`);
 
   return (
-    <Tooltip id="countrypanel-exchange-tooltip" position={position}>
+    <Tooltip id="countrypanel-exchange-tooltip" position={position} onClose={onClose}>
       <span dangerouslySetInnerHTML={{ __html: headline }} />
       <br />
       <MetricRatio

--- a/web/src/components/tooltips/countrypanelproductiontooltip.js
+++ b/web/src/components/tooltips/countrypanelproductiontooltip.js
@@ -24,6 +24,7 @@ const CountryPanelProductionTooltip = ({
   mode,
   position,
   zoneData,
+  onClose,
 }) => {
   if (!zoneData) return null;
 
@@ -64,7 +65,7 @@ const CountryPanelProductionTooltip = ({
   headline = headline.replace('id="country-flag"', `class="flag" src="${flagUri(zoneData.countryCode)}"`);
 
   return (
-    <Tooltip id="countrypanel-production-tooltip" position={position}>
+    <Tooltip id="countrypanel-production-tooltip" position={position} onClose={onClose}>
       <span dangerouslySetInnerHTML={{ __html: headline }} />
       <br />
       <MetricRatio

--- a/web/src/components/tooltips/lowcarboninfotooltip.js
+++ b/web/src/components/tooltips/lowcarboninfotooltip.js
@@ -3,8 +3,8 @@ import React from 'react';
 import { __ } from '../../helpers/translation';
 import Tooltip from '../tooltip';
 
-const LowCarbonInfoTooltip = ({ position }) => (
-  <Tooltip id="lowcarb-info-tooltip" position={position}>
+const LowCarbonInfoTooltip = ({ position, onClose }) => (
+  <Tooltip id="lowcarb-info-tooltip" position={position} onClose={onClose}>
     <b>{__('tooltips.lowcarbon')}</b>
     <br />
     <small>{__('tooltips.lowCarbDescription')}</small>

--- a/web/src/components/tooltips/mapcountrytooltip.js
+++ b/web/src/components/tooltips/mapcountrytooltip.js
@@ -16,6 +16,7 @@ const MapCountryTooltip = ({
   electricityMixMode,
   position,
   zoneData,
+  onClose,
 }) => {
   const co2ColorScale = useCo2ColorScale();
 
@@ -40,7 +41,7 @@ const MapCountryTooltip = ({
     : '?';
 
   return (
-    <Tooltip id="country-tooltip" position={position}>
+    <Tooltip id="country-tooltip" position={position} onClose={onClose}>
       <div className="zone-name-header">
         <ZoneName zone={zoneData.countryCode} />
       </div>

--- a/web/src/components/tooltips/mapexchangetooltip.js
+++ b/web/src/components/tooltips/mapexchangetooltip.js
@@ -5,7 +5,7 @@ import Tooltip from '../tooltip';
 
 import { CarbonIntensity, ZoneName } from './common';
 
-const MapExchangeTooltip = ({ exchangeData, position }) => {
+const MapExchangeTooltip = ({ exchangeData, position, onClose }) => {
   if (!exchangeData) return null;
 
   const isExporting = exchangeData.netFlow > 0;
@@ -14,7 +14,7 @@ const MapExchangeTooltip = ({ exchangeData, position }) => {
   const zoneTo = exchangeData.countryCodes[isExporting ? 1 : 0];
 
   return (
-    <Tooltip id="exchange-tooltip" position={position}>
+    <Tooltip id="exchange-tooltip" position={position} onClose={onClose}>
       {__('tooltips.crossborderexport')}:
       <br />
       <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{netFlow}</b> MW

--- a/web/src/components/tooltips/pricetooltip.js
+++ b/web/src/components/tooltips/pricetooltip.js
@@ -4,7 +4,7 @@ import { isNumber } from 'lodash';
 
 import Tooltip from '../tooltip';
 
-const PriceTooltip = ({ position, zoneData }) => {
+const PriceTooltip = ({ position, zoneData, onClose }) => {
   if (!zoneData) return null;
 
   const priceIsDefined = zoneData.price && isNumber(zoneData.price.value);
@@ -12,7 +12,7 @@ const PriceTooltip = ({ position, zoneData }) => {
   const value = priceIsDefined ? zoneData.price.value : '?';
 
   return (
-    <Tooltip id="price-tooltip" position={position}>
+    <Tooltip id="price-tooltip" position={position} onClose={onClose}>
       {value} {currency} / MWh
     </Tooltip>
   );

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -12,6 +12,7 @@ import {
   useHistory,
 } from 'react-router-dom';
 import { connect, useSelector } from 'react-redux';
+import { noop } from 'lodash';
 import moment from 'moment';
 
 // Components
@@ -189,7 +190,8 @@ const CountryPanel = ({
               <div className="country-col country-lowcarbon-wrap">
                 <div id="country-lowcarbon-gauge" className="country-gauge-wrap">
                   <CountryLowCarbonGauge
-                    onMouseMove={(x, y) => setTooltip({ position: { x, y } })}
+                    onClick={isMobile ? ((x, y) => setTooltip({ position: { x, y } })) : noop}
+                    onMouseMove={!isMobile ? ((x, y) => setTooltip({ position: { x, y } })) : noop}
                     onMouseOut={() => setTooltip(null)}
                   />
                   {tooltip && (

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -192,7 +192,12 @@ const CountryPanel = ({
                     onMouseMove={(x, y) => setTooltip({ position: { x, y } })}
                     onMouseOut={() => setTooltip(null)}
                   />
-                  {tooltip && <LowCarbonInfoTooltip position={tooltip.position} />}
+                  {tooltip && (
+                    <LowCarbonInfoTooltip
+                      position={tooltip.position}
+                      onClose={() => setTooltip(null)}
+                    />
+                  )}
                 </div>
                 <div className="country-col-headline">{__('country-panel.lowcarbon')}</div>
                 <div className="country-col-subtext" />

--- a/web/src/layout/map.js
+++ b/web/src/layout/map.js
@@ -193,6 +193,7 @@ export default () => {
         <MapCountryTooltip
           zoneData={tooltipZoneData}
           position={tooltipPosition}
+          onClose={() => setTooltipZoneData(null)}
         />
       )}
       <ZoneMap


### PR DESCRIPTION
#### Changes

* I added a faded background overlay to each tooltip on mobile (see the screenshot below) that closes the tooltip when clicked thus disabling context switches before the tooltip is closed; the desktop mode has not been affected - fixes #2582
* Fixed low carbon tooltip on mobile by adding the `onClick` trigger to it that previously wasn't there so the tooltip couldn't be activated on mobile
* Made sure the vertical bar marker in `AreaGraph` is closed together with its tooltip as a way to fix the bug of tooltips of other (non-clicked) graphs showing up on mobile together with the clicked graph's tooltip

![Screenshot from 2020-07-30 18-02-28](https://user-images.githubusercontent.com/1216874/88946065-11434900-d28f-11ea-9cf0-730914c10c52.png)
