### PR TITLE
Poland capacity update 

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -3837,7 +3837,7 @@
       ]
     ],
     "capacity": {
-      "biomass": 1493,
+      "biomass": 1508,
       "battery storage": 0,
       "coal": 29963,
       "gas": 2812,
@@ -3846,9 +3846,9 @@
       "hydro storage": 1780,
       "nuclear": 0,
       "oil": 359,
-      "solar": 2109,
+      "solar": 2261,
       "unknown": 0,
-      "wind": 5953
+      "wind": 6040
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
This time 2 updates:
* monthly - new solar capacity data from PSE
https://twitter.com/pse_pl/status/1291264471806218242

* quarterly - new wind , biomas capacity data from Energy Regulatory Office - data contain only concessiuned capacity 
https://www.ure.gov.pl/pl/oze/potencjal-krajowy-oze/5753,Moc-zainstalowana-MW.html
https://www.ure.gov.pl/download/9/11276/mocIIkw2020.pdf
