### PR TITLE
Sweden Nuclear CO2-eq override based on EPD.

### DIFF
--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -684,6 +684,12 @@
           "source": "2017 average by Tomorrow",
           "value": 46.02408724838775
         },
+        "nuclear": {
+          "_comment": "Assumes the CO2-eq for the nuclear plant not included in the EDP to be the same as the Vattenfall nuclear plants.",
+          "_url": "https://gryphon4.environdec.com/system/data/files/6/17371/S-P-00923%20EPD%20Electricity%20from%20Vattenfall%20Nordic%20Nuclear%20Power%20Plants%202019.pdf",
+          "source": "Vattenfall EPD",
+          "value": 4.1
+        },
         "unknown": {
           "source": "assumes 76% biomass, 12% oil based thermal, 7% gas, 3% solar, 2% peat",
           "value": 306
@@ -808,7 +814,7 @@
         "biomass": 0.017509,
         "battery discharge": 0,
         "battery storage": 0,
-        "coal": 0.38, 
+        "coal": 0.38,
         "gas": 0.232,
         "geothermal": 0.003081,
         "hydro": 0.158,


### PR DESCRIPTION
I found a EPD that includes the majority of the Sweden nuclear plants (2 out of 3) that has a CO2-eq of 4.1gCO2-eq/kWh and I think it's safe to assume the last nuclear plant has a similar environmental impact.

Link to EPD: [Vattenfall EPD](https://gryphon4.environdec.com/system/data/files/6/17371/S-P-00923%20EPD%20Electricity%20from%20Vattenfall%20Nordic%20Nuclear%20Power%20Plants%202019.pdf)