### PR TITLE
Update Panama installed capacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Production capacities are centralized in the [zones.json](https://github.com/tmr
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Northern Ireland: [ENTSO-E] (https://m-transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Oman: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
-- Panama: [ETESA] (https://www.cnd.com.pa/informes.php?cat=5)
+- Panama: [Secretaría de Energía de Panamá] (http://www.energia.gob.pa/mercado-energetico/?tag=84#documents-list)
 - Peru: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
 - Poland  
   - Solar: [PSE Twitter](https://twitter.com/pse_pl/status/1291264471806218242)

--- a/config/zones.json
+++ b/config/zones.json
@@ -2798,7 +2798,7 @@
     ],
     "capacity": {
       "biomass": 1104,
-      "coal": 979, 
+      "coal": 979,
       "geothermal": 0,
       "hydro": 154,
       "hydro storage": 312,
@@ -2836,7 +2836,7 @@
     "capacity": {
       "biomass": 72,
       "gas": 589,
-      "coal": 979, 
+      "coal": 979,
       "geothermal": 0,
       "hydro": 419,
       "hydro-storage": 312,
@@ -3819,12 +3819,15 @@
       ]
     ],
     "capacity": {
-      "biomass": 0,
-      "gas": 113,
-      "hydro": 1704,
+      "biomass": 8.1,
+      "coal": 420,
+      "gas": 381,
+      "hydro": 1795.523,
+      "hydro storage": 0,
       "nuclear": 0,
-      "solar": 75,
-      "unknown": 962,
+      "oil": 1018.393,
+      "solar": 197.872,
+      "unknown": 0,
       "wind": 270
     },
     "contributors": [


### PR DESCRIPTION
Also updated the source. To be exact, I used the data from the second sheet of the first [spreadsheet](http://168.77.210.79/energia/wp-content/uploads/sites/2/2020/08/2-CEE-1970-2019-GE-Generaci%C3%B3n-El%C3%A9ctrica.xls) linked on that page.

As I'm working on reporting output from fossil plants by their fuel type in #2642, it is no longer necessary to put all fossil capacity under "unknown".
