### PR TITLE
Updated Capacity of "DE" zone

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1234,6 +1234,7 @@
       "wind": 61880
     },
     "contributors": [
+      "https://github.com/corradio",
       "https://github.com/bohne13"
     ],
     "parsers": {

--- a/config/zones.json
+++ b/config/zones.json
@@ -1221,17 +1221,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 8170,
-      "coal": 43870,
-      "gas": 29850,
-      "geothermal": 38,
-      "hydro": 4800,
-      "hydro storage": 9600,
+      "biomass": 8210,
+      "coal": 43490,
+      "gas": 29930,
+      "geothermal": 42,
+      "hydro": 4780,
+      "hydro storage": 9810,
       "nuclear": 8114,
       "oil": 4360,
-      "solar": 48570,
-      "unknown": 3137,
-      "wind": 60710
+      "solar": 51990,
+      "unknown": 3700,
+      "wind": 61880
     },
     "contributors": [
       "https://github.com/corradio"

--- a/config/zones.json
+++ b/config/zones.json
@@ -1234,7 +1234,7 @@
       "wind": 61880
     },
     "contributors": [
-      "https://github.com/corradio"
+      "https://github.com/bohne13"
     ],
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",


### PR DESCRIPTION
updated capacity of "DE" zone. Data is coming from "Frauenhofer ISE" 
https://www.energy-charts.de/power_inst_de.htm?year=2020&period=annual&type=power_inst
last data update was on 1.09.20 at 22:55