### PR TITLE
Cyprus: dynamically determine the biomass portion of solar+biomass generation

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1205,7 +1205,8 @@
     },
     "contributors": [
       "https://github.com/ultibo",
-      "https://github.com/veqtrus"
+      "https://github.com/veqtrus",
+      "https://github.com/q--"
     ],
     "parsers": {
       "production": "CY.fetch_production"


### PR DESCRIPTION
Instead of a hardcoded value, use the combined solar+biomass generation
at midnight to determine which portion of said generation constitutes
biomass