### PR TITLE
Give battery storage a distinctive color

### DIFF
--- a/web/src/helpers/constants.js
+++ b/web/src/helpers/constants.js
@@ -5,7 +5,7 @@ const modeColor = {
   hydro: '#2772b2',
   'hydro storage': '#0052cc',
   battery: 'lightgray',
-  'battery storage': 'lightgray',
+  'battery storage': '#b76bcf',
   biomass: '#166a57',
   geothermal: 'yellow',
   nuclear: '#AEB800',


### PR DESCRIPTION
Currently, battery storage has the same color as "unknown".

It would be nice if it had its own color.

I went with this color because it's distinct enough from the other production type colors.

![The color #af5bca](https://color-hex.org/colors/af5bca.png)