### PR TITLE
update market link for France

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ A ⇉ B: unidirectional operation, only with power flow "from A to B"
 &nbsp;</details>
 
 ### Electricity prices (day-ahead) data sources
-- France: [RTE](http://www.rte-france.com/en/eco2mix/eco2mix-mix-energetique-en)
+- France: [RTE](https://www.rte-france.com/en/eco2mix/market-data)
 - Japan: [JEPX](http://www.jepx.org)
 - Nicaragua: [CNDC](http://www.cndc.org.ni/)
 - Singapore: [EMC](https://www.emcsg.com)


### PR DESCRIPTION
Fixes https://github.com/tmrowco/electricitymap-contrib/issues/2687

I'm not sure what the original link displayed (that's now broken), so please let me know if the new link is incorrect. The new link shows the current market data (maybe not the day ahead? unclear to me)