### PR TITLE
Detection of broken links between md

### DIFF
--- a/.github/workflows/validate-local-links-in-md.yml
+++ b/.github/workflows/validate-local-links-in-md.yml
@@ -1,0 +1,36 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on all PR where md files are modified
+# Disclaimer : this will fail one's PR for one's others broken internal link that went into master.
+# ... which shouldn't happen, for internal links.
+on:
+  pull_request:
+    branches: [ '**' ]
+    paths:
+      - '**.md'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job
+  check_broken_internal_links_in_md:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      # Install https://github.com/remarkjs/remark-validate-links
+      - name: Install remark-validate-links
+        timeout-minutes: 1
+        run: npm install remark-cli remark-validate-links
+        
+      # Invoke remarks to validate INTERNAL links in md. 
+      # --frail specifies to return a non-zero error code even on warning
+      # so the github action fails when a link is invalid
+      - name: Validate local links
+        timeout-minutes: 1
+        run: ./node_modules/.bin/remark --frail -u validate-links .
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# electricityMap [![Slack Status](https://slack.tmrow.com/badge.svg)](https://slack.tmrow.com) [![CircleCI](https://circleci.com/gh/tmrowco/electricitymap-contrib.svg?style=shield)](https://circleci.com/gh/tmrowco/electricitymap-contrib) [![Twitter Follow](https://img.shields.io/twitter/follow/electricitymap.svg?style=social&label=Follow)](https://twitter.com/electricitymap)
+# electricityMap
+
+[![Slack Status](https://slack.tmrow.com/badge.svg)](https://slack.tmrow.com) [![CircleCI](https://circleci.com/gh/tmrowco/electricitymap-contrib.svg?style=shield)](https://circleci.com/gh/tmrowco/electricitymap-contrib) [![Twitter Follow](https://img.shields.io/twitter/follow/electricitymap.svg?style=social&label=Follow)](https://twitter.com/electricitymap)
 A real-time visualisation of the Greenhouse Gas (in terms of CO<sub>2</sub> equivalent) footprint of electricity consumption built with [d3.js](https://d3js.org/) and [mapbox GL](https://github.com/mapbox/mapbox-gl-js/), maintained by [Tomorrow](https://www.tmrow.com). Try it out at [http://www.electricitymap.org](http://www.electricitymap.org), or download the app:
 
 [![Get it on Google Play](https://cloud.githubusercontent.com/assets/1655848/25219122/99b446e6-25ad-11e7-934f-9491d2eb6c9b.png)](https://play.google.com/store/apps/details?id=com.tmrow.electricitymap&utm_source=github) [![Get it on the Apple Store](https://cloud.githubusercontent.com/assets/1655848/25218927/e0ec8bdc-25ac-11e7-8df8-7ab62787303e.png)](https://itunes.apple.com/us/app/electricity-map/id1224594248&utm_source=github)
@@ -458,7 +460,7 @@ Want to help? First of all, thank you for your interest!
 
 Join us on Slack at [http://slack.tmrow.co](http://slack.tmrow.co) to see what we are working on and to get in touch with other contributors. Also, if you get stuck, you can write a message in our channel #electricitymap.
 
-For different ways to help improve electricityMap, have a look at the [overview above](#electricitymap---). Here is how to get started:
+For different ways to help improve electricityMap, have a look at the [overview above](#electricitymap). Here is how to get started:
 
 ### Steps to making a code contribution
 Follow these steps to make your contribution:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # electricityMap
 
 [![Slack Status](https://slack.tmrow.com/badge.svg)](https://slack.tmrow.com) [![CircleCI](https://circleci.com/gh/tmrowco/electricitymap-contrib.svg?style=shield)](https://circleci.com/gh/tmrowco/electricitymap-contrib) [![Twitter Follow](https://img.shields.io/twitter/follow/electricitymap.svg?style=social&label=Follow)](https://twitter.com/electricitymap)
+
 A real-time visualisation of the Greenhouse Gas (in terms of CO<sub>2</sub> equivalent) footprint of electricity consumption built with [d3.js](https://d3js.org/) and [mapbox GL](https://github.com/mapbox/mapbox-gl-js/), maintained by [Tomorrow](https://www.tmrow.com). Try it out at [http://www.electricitymap.org](http://www.electricitymap.org), or download the app:
 
 [![Get it on Google Play](https://cloud.githubusercontent.com/assets/1655848/25219122/99b446e6-25ad-11e7-934f-9491d2eb6c9b.png)](https://play.google.com/store/apps/details?id=com.tmrow.electricitymap&utm_source=github) [![Get it on the Apple Store](https://cloud.githubusercontent.com/assets/1655848/25218927/e0ec8bdc-25ac-11e7-8df8-7ab62787303e.png)](https://itunes.apple.com/us/app/electricity-map/id1224594248&utm_source=github)


### PR DESCRIPTION
After doing the work manually of fixing links, and as suggested in https://github.com/tmrowco/electricitymap-contrib/pull/2693#pullrequestreview-501867595 I'm submitting this to avoid future toil.

The modifications of the heading and links in the README are a workaround for a bug in the tool that checks broken links where images in heading are making the check fail. Bug is opened but not yet fixed: remarkjs/remark-validate-links#59