### PR TITLE
Update fr.json: Shetland & french oversea flag

### DIFF
--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -584,7 +584,7 @@
         },
         "GB-SHI": {
             "countryName": "Grande Bretagne",
-            "zoneName": "Orkney"
+            "zoneName": "Shetland"
         },
         "GB-ZET": {
             "countryName": "Grande Bretagne",
@@ -597,6 +597,7 @@
             "zoneName": "Géorgie"
         },
         "GF": {
+            "countryName": "France",
             "zoneName": "Guyane Française"
         },
         "GG": {
@@ -618,6 +619,7 @@
             "zoneName": "Guinée"
         },
         "GP": {
+            "countryName": "France",
             "zoneName": "Guadeloupe"
         },
         "GQ": {
@@ -627,7 +629,7 @@
             "zoneName": "Grèce"
         },
         "GR-IS": {
-            "countryName": "Grève",
+            "countryName": "Grèce",
             "zoneName": "Îles Égéennes"
         },
         "GS": {
@@ -974,8 +976,8 @@
             "zoneName": "Monténégro"
         },
         "MF": {
-            "countryName": "Saint Martin",
-            "zoneName": "France"
+            "countryName": "France",
+            "zoneName": "Saint-Martin"
         },
         "MG": {
             "zoneName": "Madagascar"
@@ -1002,6 +1004,7 @@
             "zoneName": "Îles Mariannes du Nord"
         },
         "MQ": {
+            "countryName": "France",
             "zoneName": "Martinique"
         },
         "MR": {
@@ -1162,6 +1165,7 @@
             "zoneName": "Pologne"
         },
         "PM": {
+            "countryName": "France",
             "zoneName": "Saint-Pierre-et-Miquelon"
         },
         "PN": {
@@ -1194,6 +1198,7 @@
             "zoneName": "Qatar"
         },
         "RE": {
+            "countryName": "France",
             "zoneName": "La Réunion"
         },
         "RO": {
@@ -1452,6 +1457,7 @@
             "zoneName": "Vanuatu"
         },
         "WF": {
+            "countryName": "France",
             "zoneName": "Wallis-et-Futuna"
         },
         "WS": {
@@ -1464,6 +1470,7 @@
             "zoneName": "Yémen"
         },
         "YT": {
+            "countryName": "France",
             "zoneName": "Mayotte"
         },
         "ZA": {


### PR DESCRIPTION
GB-SHI is Shetland not Orkney. + typo in "Grèce". Added countryName for all Overseas departments and regions of France which official flag is the french one: Guadeloupe, Martinique, Guyane française, La Réunion, Mayotte, Wallis-et-Futuna, Saint-Martin, Saint-Pierre-et-Miquelon.
GB-SHI est Shetland pas "Orkney". Ajout du countryName pour toutes les Régions-départements d'outre-mer qui ont pour drapeau le drapeau tricolore : Guadeloupe, Martinique, Guyane française, La Réunion, Mayotte, Wallis-et-Futuna, Saint-Martin, Saint-Pierre-et-Miquelon. + faute d'orthographe Grèce.