### PR TITLE
Fix contribute by adding area data link

### DIFF
--- a/web/src/components/tooltips/mapcountrytooltip.js
+++ b/web/src/components/tooltips/mapcountrytooltip.js
@@ -19,7 +19,7 @@ const TooltipContent = ({
   if (!hasParser) {
     return (
       <div className="no-parser-text">
-        <span dangerouslySetInnerHTML={{ __html: __('tooltips.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#add-a-new-region') }} />
+        <span dangerouslySetInnerHTML={{ __html: __('tooltips.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib/wiki/Getting-started') }} />
       </div>
     );
   }

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -297,7 +297,7 @@ const CountryPanel = ({
           </React.Fragment>
         ) : (
           <div className="zone-details-no-parser-message">
-            <span dangerouslySetInnerHTML={{ __html: __('country-panel.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib#add-a-new-region') }} />
+            <span dangerouslySetInnerHTML={{ __html: __('country-panel.noParserInfo', 'https://github.com/tmrowco/electricitymap-contrib/wiki/Getting-started') }} />
           </div>
         )}
 

--- a/web/src/layout/leftpanel/infotext.js
+++ b/web/src/layout/leftpanel/infotext.js
@@ -30,7 +30,7 @@ export default () => (
         dangerouslySetInnerHTML={{
           __html: __(
             'panel-initial-text.contribute',
-            'https://github.com/tmrowco/electricitymap-contrib#add-a-new-region',
+            'https://github.com/tmrowco/electricitymap-contrib/wiki/Getting-started',
           ),
         }}
       />

--- a/web/src/layout/leftpanel/mobileinfotab.js
+++ b/web/src/layout/leftpanel/mobileinfotab.js
@@ -48,7 +48,7 @@ const MobileInfoTab = () => {
       <div className="info-text">
         <ColorBlindCheckbox />
         <p>
-          {__('panel-initial-text.thisproject')} <a href="https://github.com/tmrowco/electricitymap-contrib" target="_blank">{__('panel-initial-text.opensource')}</a> ({__('panel-initial-text.see')} <a href="https://github.com/tmrowco/electricitymap-contrib#data-sources" target="_blank">{__('panel-initial-text.datasources')}</a>). <span dangerouslySetInnerHTML={{ __html: __('panel-initial-text.contribute', 'https://github.com/tmrowco/electricitymap-contrib#add-a-new-region') }} />.
+          {__('panel-initial-text.thisproject')} <a href="https://github.com/tmrowco/electricitymap-contrib" target="_blank">{__('panel-initial-text.opensource')}</a> ({__('panel-initial-text.see')} <a href="https://github.com/tmrowco/electricitymap-contrib#data-sources" target="_blank">{__('panel-initial-text.datasources')}</a>). <span dangerouslySetInnerHTML={{ __html: __('panel-initial-text.contribute', 'https://github.com/tmrowco/electricitymap-contrib/wiki/Getting-started') }} />.
         </p>
         <p>
           {__('footer.foundbugs')} <a href="https://github.com/tmrowco/electricitymap-contrib/issues/new" target="_blank">{__('footer.here')}</a>.<br />


### PR DESCRIPTION
Following issue [2767](https://github.com/tmrowco/electricitymap-contrib/issues/2767), link used (`https://github.com/tmrowco/electricitymap-contrib#add-a-new-region`) is broken so I have replaced all occurrences for this one `https://github.com/tmrowco/electricitymap-contrib/wiki/Getting-started` suggested by @FelixDQ   