### PR TITLE
Update capacities for France

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1868,17 +1868,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 1776,
-      "coal": 2968,
-      "gas": 12156,
+      "biomass": 1578,
+      "coal": 2977,
+      "gas": 12238,
       "geothermal": 16,
-      "hydro": 24086,
-      "hydro storage": 1728,
+      "hydro": 16947,
+      "hydro storage": 4656,
       "nuclear": 63130,
-      "oil": 2705,
-      "solar": 10562,
-      "wind": 16494,
-      "unknown": 218
+      "oil": 2874,
+      "solar": 9438,
+      "wind": 16592,
+      "unknown": 1316
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
![pumped hydro](https://user-images.githubusercontent.com/3521837/99888023-0f880180-2c41-11eb-96e1-56383088e4c3.png)

Using 2020 [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?name=&defaultValue=false&viewType=TABLE&areaType=BZN&atch=false&dateTime.dateTime=01.01.2020+00:00|UTC|YEAR&dateTime.endDateTime=01.01.2021+00:00|UTC|YEAR&area.values=CTY|10YFR-RTE------C!BZN|10YFR-RTE------C&productionType.values=B01&productionType.values=B02&productionType.values=B03&productionType.values=B04&productionType.values=B05&productionType.values=B06&productionType.values=B07&productionType.values=B08&productionType.values=B09&productionType.values=B10&productionType.values=B11&productionType.values=B12&productionType.values=B13&productionType.values=B14&productionType.values=B20&productionType.values=B15&productionType.values=B16&productionType.values=B17&productionType.values=B18&productionType.values=B19) data, except I left geothermal as is. Unknown includes marine+other.