### PR TITLE
Fix typo in ES pumped hydro name, update capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1538,7 +1538,7 @@
       "gas": 30012,
       "geothermal": 0,
       "hydro": 17085,
-      "hydro-storage": 3329,
+      "hydro storage": 5645,
       "nuclear": 7117,
       "oil": 707,
       "solar": 11828,


### PR DESCRIPTION
Pumped hydro capacity had a hyphen in the key so it wasn't showing up on ElectricityMap. Also updated the capacity to that from ENTSO-E.

By the way, shouldn't there be some kind of unit test to catch this?