### PR TITLE
Add link to Open Source page

### DIFF
--- a/web/src/layout/header.js
+++ b/web/src/layout/header.js
@@ -11,6 +11,10 @@ const headerLinks = [
     active: true,
   },
   {
+    label: 'Open Source',
+    href: 'https://api.electricitymap.org/open-source?utm_source=electricitymap.org&utm_medium=referral',
+  },
+  {
     label: 'Blog',
     href: 'https://www.tmrow.com/blog/tags/electricitymap?utm_source=electricitymap.org&utm_medium=referral',
   },


### PR DESCRIPTION
Adds a header link to the new [Open Source](https://api.electricitymap.org/open-source/) page.

![Screenshot from 2020-12-11 11-53-48](https://user-images.githubusercontent.com/1216874/101895253-90cf1600-3ba7-11eb-8949-0966bf848138.png)
