### PR TITLE
Fix error reporting missing data

### DIFF
--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -35,7 +35,13 @@ export function protectedJsonRequest(path) {
         if (err) {
           reject(err);
         } else if (!res || !res.data) {
-          reject(new Error(`Empty response received for ${url}`));
+          const errorToReturn = new Error(`Empty response received for ${url}`);
+          // Treat as a 404
+          errorToReturn.target = {
+            status: 404,
+            statusText: errorToReturn.message,
+          };
+          reject(errorToReturn);
         } else {
           resolve(res.data);
         }


### PR DESCRIPTION
I noticed a lot of Sentry errors as we were reporting empty data returned from the server when calling /history, see e.g. https://sentry.io/organizations/tomorrow/issues/1625179506/?project=1295430&query=is%3Aunresolved
I've made sure these errors are not reported anymore.
Tested locally.