### PR TITLE
Update on Spanish power capacity. November 2020, Peninsula only.

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1534,15 +1534,15 @@
     ],
     "capacity": {
       "biomass": 1189,
-      "coal": 4826,
-      "gas": 30012,
+      "coal": 6219,
+      "gas": 31950,
       "geothermal": 0,
       "hydro": 17085,
       "hydro storage": 5645,
       "nuclear": 7117,
       "oil": 707,
-      "solar": 11828,
-      "wind": 25902,
+      "solar": 12735,
+      "wind": 27063,
       "unknown": 360
     },
     "contributors": [


### PR DESCRIPTION
Solar power capacity increased by roughly 1000 MW, gas generation capacity (CCGTs, cogeneration and open cycle gas turbines) corrected from 30 GW to 32 GW.
Coal power capacity corrected from the 2020 estimate of 4800 MW to today's (November 2020) 6219 MW.
Wind power generation increased by roughly 1 GW, to 27 GW.

Source data: Spanish Grid Operator "Red Eléctrica de España".