### PR TITLE
Update to CO2 values for Slovenia

### DIFF
--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -704,6 +704,10 @@
         "hydro discharge": {
           "source": "2017 average by Tomorrow",
           "value": 246.34741810042195
+        },
+        "coal": {
+          "source": "Offical value for TEŠ6 coal power plant",
+          "value": 869 
         }
       },
       "SK": {


### PR DESCRIPTION
I've added a custom value for coal in Slovenia. Only full time coal power plant in Slovenia is TEŠ6. Official CO2 value for is TEŠ6 869g/KW. When TEŠ6 is out of service, old TEŠ5 power plant is turned on but that is rare and an exception. I believe that CO2 of TEŠ6 most accurately represents coal CO2 value.