### PR TITLE
Revert wind colors

### DIFF
--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true, // prevent searching eslintrc in parent directories
   "globals": {
     "ELECTRICITYMAP_PUBLIC_TOKEN": "readonly",
     "VERSION": "readonly",

--- a/web/src/helpers/scales.js
+++ b/web/src/helpers/scales.js
@@ -1,8 +1,11 @@
 import { scaleLinear, scaleQuantize } from 'd3-scale';
+import { range } from 'd3-array';
+import { interpolate } from 'd3-interpolate';
 
 // ** Wind
+const maxWind = 15;
 export const windColor = scaleLinear()
-  .domain([0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30])
+  .domain(range(10).map(i => interpolate(0, maxWind)(i / (10 - 1))))
   .range([
     'rgba(0,   255, 255, 1.0)',
     'rgba(100, 240, 255, 1.0)',


### PR DESCRIPTION
This PR reverts the wind colors to the version prior to migrating to React

Fixes https://github.com/tmrowco/electricitymap-contrib/issues/2491
cc @alixunderplatz 

![image](https://user-images.githubusercontent.com/1655848/104001979-b5b3aa80-51a0-11eb-94cd-1b5a0c405407.png)
