### PR TITLE
Mobileapp: Don't error on duplicate releases

### DIFF
--- a/mobileapp/BUILD.yaml
+++ b/mobileapp/BUILD.yaml
@@ -47,8 +47,8 @@ steps:
       - code-push release-cordova electricitymap-android android --noDuplicateReleaseError --description ${BRICK_DRONE_COMMIT_SHA:-latest}
       - code-push release-cordova electricitymap-ios ios --noDuplicateReleaseError --description ${BRICK_DRONE_COMMIT_SHA:-latest}
       # Promote
-      - code-push promote electricitymap-android Staging Production
-      - code-push promote electricitymap-ios Staging Production
+      - code-push promote electricitymap-android Staging Production --noDuplicateReleaseError
+      - code-push promote electricitymap-ios Staging Production --noDuplicateReleaseError
     secrets:
       gcloud:
         src: ~/.config/gcloud


### PR DESCRIPTION
The promotion step currently fails on CI when nothing has changed:
```
[Error] The uploaded package was not promoted because it is identical to the contents of the targeted deployment's current release.
```