### PR TITLE
Updated "DE" zones.json

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1286,17 +1286,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 8210,
+      "biomass": 8240,
       "coal": 43490,
       "gas": 29930,
-      "geothermal": 42,
-      "hydro": 4780,
+      "geothermal": 47,
+      "hydro": 4790,
       "hydro storage": 9810,
       "nuclear": 8114,
       "oil": 4360,
-      "solar": 51990,
+      "solar": 53580,
       "unknown": 3700,
-      "wind": 61880
+      "wind": 62380
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
most of the sources are updated with the source from Fraunhofer ISE (https://energy-charts.info/charts/installed_power/chart.htm?l=de&c=DE&year=2020&interval=year&stacking=grouped)

The source is already mentioned in the DATA_SOURCES.md file.

And I'm already on the list of contributors :) 

geothermal was updated with the source from entsoe.eu wich is also mentioned in the DATA_SOURCES.md