### PR TITLE
Fix node ref for wind/solar layers

### DIFF
--- a/web/src/components/layers/solarlayer.js
+++ b/web/src/components/layers/solarlayer.js
@@ -39,7 +39,9 @@ const Canvas = styled.canvas`
 `;
 
 export default ({ unproject }) => {
-  const { ref, width, height, node } = useRefWidthHeightObserver();
+  const {
+    ref, width, height, node,
+  } = useRefWidthHeightObserver();
   const solar = useInterpolatedSolarData();
   const enabled = useSolarEnabled();
 

--- a/web/src/components/layers/solarlayer.js
+++ b/web/src/components/layers/solarlayer.js
@@ -39,7 +39,7 @@ const Canvas = styled.canvas`
 `;
 
 export default ({ unproject }) => {
-  const { ref, width, height } = useRefWidthHeightObserver();
+  const { ref, width, height, node } = useRefWidthHeightObserver();
   const solar = useInterpolatedSolarData();
   const enabled = useSolarEnabled();
 
@@ -50,8 +50,8 @@ export default ({ unproject }) => {
 
   // Render the processed solar forecast image into the canvas.
   useEffect(() => {
-    if (ref.current && isVisible && solar && width && height) {
-      const ctx = ref.current.getContext('2d');
+    if (node && isVisible && solar && width && height) {
+      const ctx = node.getContext('2d');
       const image = ctx.createImageData(width, height);
 
       const [minLon, minLat] = unproject([0, 0]);
@@ -92,7 +92,7 @@ export default ({ unproject }) => {
       ctx.clearRect(0, 0, width, height);
       ctx.putImageData(image, 0, 0);
     }
-  }, [ref.current, isVisible, solar, width, height]);
+  }, [node, isVisible, solar, width, height]);
 
   return (
     <CSSTransition

--- a/web/src/components/layers/windlayer.js
+++ b/web/src/components/layers/windlayer.js
@@ -24,7 +24,9 @@ const Canvas = styled.canvas`
 `;
 
 export default ({ project, unproject }) => {
-  const { ref, width, height, node } = useRefWidthHeightObserver();
+  const {
+    ref, width, height, node,
+  } = useRefWidthHeightObserver();
   const interpolatedData = useInterpolatedWindData();
   const enabled = useWindEnabled();
 

--- a/web/src/components/layers/windlayer.js
+++ b/web/src/components/layers/windlayer.js
@@ -24,7 +24,7 @@ const Canvas = styled.canvas`
 `;
 
 export default ({ project, unproject }) => {
-  const { ref, width, height } = useRefWidthHeightObserver();
+  const { ref, width, height, node } = useRefWidthHeightObserver();
   const interpolatedData = useInterpolatedWindData();
   const enabled = useWindEnabled();
 
@@ -55,9 +55,9 @@ export default ({ project, unproject }) => {
   // hacky once Windy service is merged here and perhaps optimized via WebGL.
   // See https://github.com/tmrowco/electricitymap-contrib/issues/944.
   useEffect(() => {
-    if (!windy && isVisible && ref.current && interpolatedData) {
+    if (!windy && isVisible && node && interpolatedData) {
       const w = new Windy({
-        canvas: ref.current,
+        canvas: node,
         data: interpolatedData,
         project,
         unproject,
@@ -69,7 +69,7 @@ export default ({ project, unproject }) => {
       windy.stop();
       setWindy(null);
     }
-  }, [windy, isVisible, ref.current, interpolatedData]);
+  }, [windy, isVisible, node, interpolatedData]);
 
   return (
     <CSSTransition


### PR DESCRIPTION
Forgot that `ref.current` is not defined anymore, but that we need to use the `node` returned by the hook.