### PR TITLE
Reduces height of header and adjusts font-size

### DIFF
--- a/web/src/components/sharedheader.js
+++ b/web/src/components/sharedheader.js
@@ -9,10 +9,10 @@ const Wrapper = styled.header`
   color: black;
   display: flex;
   font-family: 'Euclid Triangle';
-  font-size: 16px;
-  height: 66px;
+  font-size: 14px;
+  height: 58px;
   justify-content: space-between;
-  min-height: 66px; /* required for old Safari */
+  min-height: 58px; /* required for old Safari */
   padding: 0 48px 0 32px;
   position: fixed;
   transition: background-color 0.5s;
@@ -58,7 +58,7 @@ const linkUnderline = css`
 const Link = styled.a`
   color: inherit;
   display: inline-block;
-  line-height: 42px;
+  line-height: 34px;
   padding: 12px 16px;
   position: relative;
   text-decoration: none;

--- a/web/src/components/sharedheader.js
+++ b/web/src/components/sharedheader.js
@@ -9,7 +9,7 @@ const Wrapper = styled.header`
   color: black;
   display: flex;
   font-family: 'Euclid Triangle';
-  font-size: 14px;
+  font-size: 15px;
   height: 58px;
   justify-content: space-between;
   min-height: 58px; /* required for old Safari */

--- a/web/src/layout/header.js
+++ b/web/src/layout/header.js
@@ -27,7 +27,7 @@ const headerLinks = [
 const Container = styled.div`
   /* This makes sure the map and the other content doesn't
   go under the SharedHeader which has a fixed position. */
-  height: 66px;
+  height: 58px;
 `;
 
 const Header = () => (


### PR DESCRIPTION
## Description

Reduces header size (from 66px to 58px).

Also decreases font-size in header (from 16px to 14px). I think 16px might actually be fine, it's not the best font for smaller text sizes :)

### Preview

Dunno if this helps much, but I did a gif with the different font-sizes 😅 

What do you think, @Kongkille?

![fontsize](https://user-images.githubusercontent.com/3296643/104325260-b9209c00-54e8-11eb-9d0a-2bf601724563.gif)


Fixes #2876 

PS. Let me know if I should do the same for the other sites (API/open-source, etc.)