### PR TITLE
Updated Portugal's installed coal capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -4011,7 +4011,7 @@
   "PT": {
     "capacity": {
       "biomass": 729,
-      "coal": 1756,
+      "coal": 500,
       "gas": 4606,
       "geothermal": 29,
       "hydro": 4359,
@@ -4023,7 +4023,8 @@
     },
     "contributors": [
       "https://github.com/corradio",
-      "https://github.com/nessie2013"
+      "https://github.com/nessie2013",
+      "https://github.com/Falconet8"
     ],
     "flag_file_name": "pt.png",
     "parsers": {


### PR DESCRIPTION
Removed 1256 MW of Coal Power due to the Sines Coal Powerplant closure tomorrow.
Source of installed capacity for the powerplant: https://portugal.edp.com/en/sines-thermoelectric-power-station
Source of the plant's closure: https://observador.pt/2021/01/13/central-de-sines-fecha-na-quinta-feira-e-desativacao-pode-levar-cinco-anos/