### PR TITLE
Coal Update for Portugal

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -4012,7 +4012,7 @@
   "PT": {
     "capacity": {
       "biomass": 729,
-      "coal": 1756,
+      "coal": 628,
       "gas": 4606,
       "geothermal": 29,
       "hydro": 4359,
@@ -4025,6 +4025,7 @@
     "contributors": [
       "https://github.com/corradio",
       "https://github.com/nessie2013"
+      "https://github.com/Falconet8"
     ],
     "flag_file_name": "pt.png",
     "parsers": {


### PR DESCRIPTION
I removed 1256 MW of Coal Power due to the closure of the Sines Coal Power Plant on the 14th of January. That day was the day their license expired and the plant exhausted all their coal on the 24th of December.
Source of the installed capacity for the power plant: https://portugal.edp.com/en/sines-thermoelectric-power-station
Source of the plant's closure: https://eco.sapo.pt/2021/01/17/o-adeus-a-uma-das-centrais-a-carvao-mais-poluentes-da-europa/

This would leave the coal section at Electricity Map with 500 MW of Capacity for Portugal but that would be wrong. According to the website of the last remaining coal power plant in Portugal (scheduled for closure later this year), the Pego Power Plant has a capacity of 628 MW. This also explains why right now there are 576 MW of power being generated from coal and not less than 500 MW.
Source of the installed capacity at Pego: https://www.tejoenergia.com/en/aboutus/