### PR TITLE
Introduce jsonlint-mod and fix CA-QC duplicate key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - checkout
       - run:
           command: |
-            sudo npm install -g jsonlint
+            sudo npm install -g jsonlint-mod
             jsonlint config/*.json web/locales/*.json
 
   test_js:

--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -1229,14 +1229,6 @@
           "biomass": 0.03
         }
       },
-      "CA-QC": {
-        "_url": "https://www.cer-rec.gc.ca/en/data-analysis/energy-markets/provincial-territorial-energy-profiles/provincial-territorial-energy-profiles-quebec.html",
-        "powerOriginRatios": {
-          "hydro": 0.95,
-          "wind": 0.04,
-          "unknown": 0.01
-        }
-      },
       "CA-ON": {
         "_source": "Tomorrow",
         "powerOriginRatios": {


### PR DESCRIPTION
Use [jsonlint-mod](https://github.com/circlecell/jsonlint-mod) as suggested by @veqtrus. We use it to check for duplicated keys. 

It found one issue in `co2eq_parameters.json`, which seems to be a regression introduced when bringing back fallback mixes #2862.

Ref: https://github.com/tmrowco/electricitymap-contrib/issues/2963