### PR TITLE
Fix url for PE parser

### DIFF
--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -61,7 +61,7 @@ def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=g
         raise NotImplementedError('This parser is not yet able to parse past dates')
     
     r = session or requests.session()
-    url = 'http://www.coes.org.pe/Portal/portalinformacion/Generacion'
+    url = 'https://www.coes.org.pe/Portal/portalinformacion/generacion'
 
     current_date = arrow.now(tz=tz)
 


### PR DESCRIPTION
The old URL (withotu https) would redirect to another HTML page