### PR TITLE
Fix Japan consumptionForecast parsers

### DIFF
--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -13,6 +13,8 @@ import pandas as pd
 import numpy as np
 
 from . import occtonet
+
+
 def fetch_production(zone_key='JP-KY', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
     """Requests the last known production mix (in MW) of a given zone
@@ -151,6 +153,8 @@ def fetch_production(zone_key='JP-KY', session=None, target_datetime=None,
         return data
     else:
         return []
+
+
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -20,17 +20,18 @@ from parsers import occtonet
 # JP-CG  : Chūgoku
 
 sources = {
-        'JP-HKD':'denkiyoho.hepco.co.jp',
-        'JP-TH':'setsuden.nw.tohoku-epco.co.jp',
-        'JP-TK':'www.tepco.co.jp',
-        'JP-CB':'denki-yoho.chuden.jp',
-        'JP-HR':'www.rikuden.co.jp/denki-yoho',
-        'JP-KN':'www.kepco.co.jp',
-        'JP-SK':'www.yonden.co.jp',
-        'JP-CG':'www.energia.co.jp',
-        'JP-KY':'www.kyuden.co.jp/power_usages/pc.html',
-        'JP-ON':'www.okiden.co.jp/denki/'
+        'JP-HKD': 'denkiyoho.hepco.co.jp',
+        'JP-TH': 'setsuden.nw.tohoku-epco.co.jp',
+        'JP-TK': 'www.tepco.co.jp',
+        'JP-CB': 'denki-yoho.chuden.jp',
+        'JP-HR': 'www.rikuden.co.jp/denki-yoho',
+        'JP-KN': 'www.kepco.co.jp',
+        'JP-SK': 'www.yonden.co.jp',
+        'JP-CG': 'www.energia.co.jp',
+        'JP-KY': 'www.kyuden.co.jp/power_usages/pc.html',
+        'JP-ON': 'www.okiden.co.jp/denki/'
         }
+
 
 def fetch_production(zone_key='JP-TK', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
@@ -64,23 +65,24 @@ def fetch_production(zone_key='JP-TK', session=None, target_datetime=None,
         datalist.append(data)
     return datalist
 
+
 def fetch_production_df(zone_key='JP-TK', session=None, target_datetime=None,
-                      logger=logging.getLogger(__name__)):
+                        logger=logging.getLogger(__name__)):
     """
     Calculates production from consumption and imports for a given area
     All production is mapped to unknown
     """
     exch_map = {
-        'JP-HKD':['JP-TH'],
-        'JP-TH':['JP-TK', 'JP-HKD'],
-        'JP-TK':['JP-TH', 'JP-CB'],
-        'JP-CB':['JP-TK', 'JP-HR', 'JP-KN'],
-        'JP-HR':['JP-CB', 'JP-KN'],
-        'JP-KN':['JP-CB', 'JP-HR', 'JP-SK', 'JP-CG'],
-        'JP-SK':['JP-KN', 'JP-CG'],
-        'JP-CG':['JP-KN', 'JP-SK', 'JP-KY'],
-        'JP-ON':[],
-        'JP-KY':['JP-CG']
+        'JP-HKD': ['JP-TH'],
+        'JP-TH': ['JP-TK', 'JP-HKD'],
+        'JP-TK': ['JP-TH', 'JP-CB'],
+        'JP-CB': ['JP-TK', 'JP-HR', 'JP-KN'],
+        'JP-HR': ['JP-CB', 'JP-KN'],
+        'JP-KN': ['JP-CB', 'JP-HR', 'JP-SK', 'JP-CG'],
+        'JP-SK': ['JP-KN', 'JP-CG'],
+        'JP-CG': ['JP-KN', 'JP-SK', 'JP-KY'],
+        'JP-ON': [],
+        'JP-KY': ['JP-CG']
         }
     df = fetch_consumption_df(zone_key, target_datetime)
     df['imports'] = 0
@@ -135,7 +137,7 @@ def fetch_consumption_df(zone_key='JP-TK', target_datetime=None,
         df = pd.read_csv(consumption_url[zone_key], skiprows=startrow,
                          encoding='shift-jis')
     except pd.errors.EmptyDataError as e:
-        logger.error("Data not available yet")
+        logger.exception("Data not available yet")
         raise e
 
     if zone_key in ['JP-TH']:
@@ -155,6 +157,7 @@ def fetch_consumption_df(zone_key='JP-TK', target_datetime=None,
         df = df[['datetime', 'cons']]
     return df
 
+
 def fetch_consumption_forecast(zone_key='JP-KY', session=None, target_datetime=None,
                                logger=logging.getLogger(__name__)):
     """
@@ -162,7 +165,7 @@ def fetch_consumption_forecast(zone_key='JP-KY', session=None, target_datetime=N
     Returns a list of dictionaries.
     """
     # Currently past dates not implemented for areas with no date in their demand csv files
-    if target_datetime and (zone_key in ['JP-TK', 'JP-TH', 'JP-CB', 'JP-KN', 'JP-SK']):
+    if target_datetime and zone_key == 'JP-HKD':
         raise NotImplementedError(
             "Past dates not yet implemented for selected region")
     datestamp = arrow.get(target_datetime).to('Asia/Tokyo').strftime('%Y%m%d')
@@ -218,6 +221,7 @@ def fetch_consumption_forecast(zone_key='JP-KY', session=None, target_datetime=N
         })
     return data
 
+
 def fetch_price(zone_key='JP-TK', session=None, target_datetime=None,
                 logger=logging.getLogger(__name__)):
     if target_datetime is None:
@@ -251,7 +255,7 @@ def fetch_price(zone_key='JP-TK', session=None, target_datetime=None,
             'zoneKey': zone_key,
             'currency': 'JPY',
             'datetime': row[1]['datetime'].datetime,
-            'price': round(int(1000*row[1][zone_key]),-1),# Convert from JPY/kWh to JPY/MWh
+            'price': round(int(1000*row[1][zone_key]),-1),  # Convert from JPY/kWh to JPY/MWh
             'source': 'jepx.org'
         })
 
@@ -263,11 +267,11 @@ def parse_dt(row):
     Parses timestamps from date and time
     """
     if 'AM' in row['Time'] or 'PM' in row['Time']:
-        timestamp= arrow.get(' '.join([row['Date'], row['Time']]).replace('/', '-'),
-                     'YYYY-M-D H:mm A').replace(tzinfo='Asia/Tokyo').datetime
+        timestamp = arrow.get(' '.join([row['Date'], row['Time']]).replace('/', '-'),
+                              'YYYY-M-D H:mm A').replace(tzinfo='Asia/Tokyo').datetime
     else:
-        timestamp= arrow.get(' '.join([row['Date'], row['Time']]).replace('/', '-'),
-                     'YYYY-M-D H:mm').replace(tzinfo='Asia/Tokyo').datetime
+        timestamp = arrow.get(' '.join([row['Date'], row['Time']]).replace('/', '-'),
+                              'YYYY-M-D H:mm').replace(tzinfo='Asia/Tokyo').datetime
     return timestamp
 
 

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -4,7 +4,7 @@
 import arrow
 import dateutil
 import requests
-from .lib.validation import validate
+# from .lib.validation import validate
 from logging import getLogger
 
 tz = 'America/Lima'

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -4,7 +4,7 @@
 import arrow
 import dateutil
 import requests
-# from .lib.validation import validate
+from .lib.validation import validate
 from logging import getLogger
 
 tz = 'America/Lima'

--- a/parsers/occtonet.py
+++ b/parsers/occtonet.py
@@ -76,8 +76,6 @@ def fetch_exchange(zone_key1='JP-TH', zone_key2='JP-TK', session=None,
     """
     #get target date in time zone Asia/Tokyo
     query_date = arrow.get(target_datetime).to('Asia/Tokyo').strftime('%Y/%m/%d')
-    #get d-1 in tz Asia/Tokyo
-    query_date_1 = arrow.get(target_datetime).shift(days=-1).to('Asia/Tokyo').strftime('%Y/%m/%d')
 
     sortedZoneKeys = '->'.join(sorted([zone_key1, zone_key2]))
     exch_id = exchange_mapping[sortedZoneKeys]
@@ -86,30 +84,20 @@ def fetch_exchange(zone_key1='JP-TH', zone_key2='JP-TK', session=None,
     Cookies = get_cookies(r)
     # Get headers for querying exchange
     Headers = get_headers(r, exch_id[0], query_date, Cookies)
-    Headers_1 = get_headers(r, exch_id[0], query_date_1, Cookies)
     # Add request tokens to headers
     Headers = get_request_token(r, Headers, Cookies)
-    Headers_1 = get_request_token(r, Headers_1, Cookies)
     # Query data
-    data = get_exchange(r, Headers, Cookies)
-    data_1 = get_exchange(r, Headers_1, Cookies)
-    # Concatenate d-1 and current day
-    df = pd.concat([data_1,data])
+    df = get_exchange(r, Headers, Cookies)
+
     # CB-HR -exceptions
     if sortedZoneKeys == 'JP-CB->JP-HR':
 
         df = df.set_index(['Date', 'Time'])
 
         Headers = get_headers(r, exch_id[1], query_date, Cookies)
-        Headers_1 = get_headers(r, exch_id[1], query_date_1, Cookies)
-
         Headers = get_request_token(r, Headers, Cookies)
-        Headers_1 = get_request_token(r, Headers_1, Cookies)
 
-        data = get_exchange(r, Headers, Cookies)
-        data_1 = get_exchange(r, Headers_1, Cookies)
-
-        df2 = pd.concat([data_1,data])
+        df2 = get_exchange(r, Headers, Cookies)
         df2 = df2.set_index(['Date', 'Time'])
 
         df = df + df2
@@ -136,8 +124,9 @@ def fetch_exchange(zone_key1='JP-TH', zone_key2='JP-TK', session=None,
         result['datetime'] = result['datetime'].to_pydatetime()
     return results
 
+
 def fetch_exchange_forecast(zone_key1='JP-TH', zone_key2='JP-TK', session=None,
-                   target_datetime=None, logger=logging.getLogger(__name__)):
+                            target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Gets exchange forecast between two specified zones.
     Returns a list of dictionaries.
@@ -189,10 +178,12 @@ def fetch_exchange_forecast(zone_key1='JP-TH', zone_key2='JP-TK', session=None,
         result['datetime'] = result['datetime'].to_pydatetime()
     return results
 
+
 def get_cookies(session=None):
     s = session or requests.session()
     s.get('http://occtonet.occto.or.jp/public/dfw/RP11/OCCTO/SD/LOGIN_login')
     return s.cookies
+
 
 def get_headers(session, exch_id, date, cookies):
     payload = {
@@ -231,6 +222,7 @@ def get_headers(session, exch_id, date, cookies):
         payload['updDaytime'] = headers['root']['bizRoot']['header']['updDaytime']['value']
     return payload
 
+
 def get_request_token(session, payload, cookies):
     s = session
     payload['fwExtention.actionSubType']='ok'
@@ -246,6 +238,7 @@ def get_request_token(session, payload, cookies):
         payload['requestToken'] = headers['root']['bizRoot']['header']['requestToken']['value']
     return payload
 
+
 def get_exchange(session, payload, cookies):
     s = session
     payload['fwExtention.actionSubType']='download'
@@ -259,6 +252,7 @@ def get_exchange(session, payload, cookies):
     df = df.dropna()
     return df
 
+
 def get_exchange_fcst(session, payload, cookies):
     s = session
     payload['fwExtention.actionSubType']='download'
@@ -271,146 +265,9 @@ def get_exchange_fcst(session, payload, cookies):
     df = df.dropna()
     return df
 
+
 def parse_dt(row):
     return arrow.get(' '.join([row['Date'], row['Time']]).replace('/', '-')).replace(tzinfo='Asia/Tokyo').datetime
-
-def zone_headers(zone, date):
-    """
-    Get query headers for querying intra-zone flows
-    """
-    area_map={
-    'JP-HKD':1,
-    'JP-TH':2,
-    'JP-TK':3,
-    'JP-CB':4,
-    'JP-HR':5,
-    'JP-KN':6,
-    'JP-CG':7,
-    'JP-SK':8,
-    'JP-KY':9,
-    'JP-ON':10
-    }
-    payload = {
-            'ajaxToken':'',
-            'areaCdAreaSumNon':'{:02d}'.format(area_map[zone]),
-            'daPtn':'00',
-            'daPtn1':'187',
-            'daPtn2':'275',
-            'daPtn3':'220',
-            'daPtn4':'187',
-            'daPtn5':'132',
-            'downloadKey':'',
-            'fwExtention.actionSubType':'headerInput',
-            'fwExtention.actionType':'reference',
-            'fwExtention.formId':'CB01S020P',
-            'fwExtention.jsonString':'',
-            'fwExtention.pagingTargetTable':'',
-            'fwExtention.pathInfo':'CB01S020C',
-            'fwExtention.prgbrh':'0',
-            'msgArea':'',
-            'requestToken':'',
-            'requestTokenBk':'',
-            'searchReqHdn':'',
-            'table1.currentPage':'',
-            'table1.dispRowNum':'200',
-            'table1.endIndex':'',
-            'table1.nextPageStartIndex':'',
-            'table1.pagingMode':'editable',
-            'table1.rows[0].rowParams.originRowIndex':'0',
-            'table1.rows[0].rowParams.rowAddUpdate':'',
-            'table1.rows[0].rowParams.rowDelete':'',
-            'table1.rows[0].rowParams.rowNum':'',
-            'table1.rows[0].rowParams.selected':'',
-            'table1.startIndex':'',
-            'table1.tableIdToken':'',
-            'table1.totalPage':'',
-            'tgtAreaHdn':'',
-            'tgtDaHdn':'',
-            'tgtNngp': date,
-            'tgtNngpHdn':'',
-            'transitionContextKey':'DEFAULT',
-            'updDaytime':''
-          }
-
-    with requests.Session() as s:
-
-
-        r = s.get('http://occtonet.occto.or.jp/public/dfw/RP11/OCCTO/SD/LOGIN_login')
-
-    r2 = s.post('http://occtonet.occto.or.jp/public/dfw/RP11/OCCTO/SD/CB01S020C?fwExtention.pathInfo=CB01S020C&fwExtention.prgbrh=0',
-                   cookies=s.cookies, data=payload)
-    r2.encoding = 'utf-8'
-    headers=r2.text
-    headers = eval(headers.replace('false', 'False').replace('null', 'None'))
-    return headers
-
-def solve_flows(headers):
-    """
-    Solves flow equations for each node inside a zone for a given day,
-    allowing possibly to add large isolated thermal generators, pump storages etc. to eMap
-    Japanese regions in the future
-
-    Expects a dictionary argument obtained by function zone_headers(zone, date)
-    Returns net generation for each node at 30 minute intervals in a Pandas DataFrame
-    """
-    dict1 = headers['root']['bizRoot']['table']['table1']['table1']['rows']
-    # For each transmission line:
-    for entry in dict1:
-        # Collect flows at each timestamp
-        for i in range(1,49):
-            column = 'colonLbl'+'{:02d}'.format((i*30)//60)+'{:02d}'.format((i*30)%60)
-            try:
-                entry[column] = entry[column]['value']
-            except TypeError:
-                pass
-        # Collect line names
-        if str(type(entry['flowHukuSeiHuku']))=="<class 'dict'>":
-            entry['flowHukuSeiHuku'] = entry['flowHukuSeiHuku']['value']
-        # Remove unneeded keys from dictionary for parsing it into DataFrame
-        for key in ['daKv','rowParams.originRowIndex', 'rowParams.rowAddUpdate',
-                   'rowParams.rowDelete', 'rowParams.rowNum', 'rowParams.selected',
-                   'sdlNm']:
-            try:
-                del entry[key]
-            except KeyError:
-                pass
-    # Format to DataFrame, with timestamps as rows
-    df = pd.DataFrame(dict1).T
-    df.columns = df.iloc[-1]
-    df=df.drop(df.index[-1])
-
-    df2 = pd.DataFrame()
-    #Sum flows for each node
-    for i in range(len(df.columns)):
-        col = df.columns[i]
-        src = col.split(' → ')[0]
-        tgt = col.split(' → ')[-1]
-
-        if src in df2.columns:
-            df2[src] = df2[src]+pd.to_numeric(df.iloc[:,i])
-        else:
-            df2[src] = pd.to_numeric(df.iloc[:,i])
-
-        if tgt in df2.columns:
-            df2[tgt] = df2[tgt]-pd.to_numeric(df.iloc[:,i])
-        else:
-            df2[tgt] = -1*pd.to_numeric(df.iloc[:,i])
-    timestamps = []
-    # convert timestamps
-    date = headers['root']['bizRoot']['header']['tgtNngp']['value']
-    for ts in list(df2.index.values):
-        time = headers['root']['bizRoot']['header'][ts]['label']
-        timestamps.append(
-            arrow.get('{0} {1}'.format(date, time).replace(
-            '/', '-')).replace(tzinfo='Asia/Tokyo').datetime
-        )
-    df2 = df2.reset_index()
-    df2['timestamps']=pd.Series(timestamps)
-    df2=df2.set_index('timestamps')
-    df2=df2.drop('index', axis=1)
-    df2=df2.dropna()
-    return df2
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I noticed the urls used for the consumption forecast Japan parsers were not updated which led to many 404.

Also made the exchange parsers faster with only 1 day's worth of data (1 query instead of 2) which reduces the time from ~11 secs to 5 secs.
I noticed the exchanges/imports are used in the `fetch_consumption` logic for the japan parsers. I have not seen that pattern anywhere else in parsers. 

The Japanese parsers fetches the consumption then substracts the exchanges. Is electricity-map backend smart enough to do that computation if we were to only provide fetch_consumption and fetch_exchange?