### PR TITLE
Updates text-color of the carbon intensity "square" based on contrast to background

### DIFF
--- a/web/src/components/carbonintensitysquare.js
+++ b/web/src/components/carbonintensitysquare.js
@@ -18,9 +18,8 @@ const getTextColor = (rgbColor) => {
   return contrastRatio > 128 ? 'black' : 'white';
 };
 
-
 const Value = styled.span`
-font-weight: bold;
+  font-weight: bold;
 `;
 
 const Box = styled.div`
@@ -42,9 +41,7 @@ const CarbonIntensitySquare = ({ value, withSubtext }) => {
 
   return (
     <div className="country-col">
-      <Box
-        color={co2ColorScale(value)}
-      >
+      <Box color={co2ColorScale(value)}>
         <div>
           <Value>{Math.round(value) || '?'}</Value>g
         </div>

--- a/web/src/components/carbonintensitysquare.js
+++ b/web/src/components/carbonintensitysquare.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { useCo2ColorScale } from '../hooks/theme';
+import { __ } from '../helpers/translation';
+
+const Value = styled.span`
+font-weight: bold;
+`;
+
+const Box = styled.div`
+  background-color: ${props => props.color};
+  color: #fff;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  height: 4rem;
+  width: 4rem;
+  margin: 0 auto;
+  border-radius: 1rem;
+  font-size: 1rem;
+`;
+
+const CarbonIntensitySquare = ({ value, withSubtext }) => {
+  const co2ColorScale = useCo2ColorScale();
+
+  return (
+    <div className="country-col">
+      <Box
+        color={co2ColorScale(value)}
+      >
+        <div>
+          <Value>{Math.round(value) || '?'}</Value>g
+        </div>
+      </Box>
+      <div className="country-col-headline">{__('country-panel.carbonintensity')}</div>
+      {withSubtext && <div className="country-col-subtext">(gCO₂eq/kWh)</div>}
+    </div>
+  );
+};
+
+export default CarbonIntensitySquare;

--- a/web/src/components/carbonintensitysquare.js
+++ b/web/src/components/carbonintensitysquare.js
@@ -4,13 +4,28 @@ import styled from 'styled-components';
 import { useCo2ColorScale } from '../hooks/theme';
 import { __ } from '../helpers/translation';
 
+/**
+ * This function finds the optimal text color based on YIQ contrast.
+ * Based on https://medium.com/@druchtie/contrast-calculator-with-yiq-5be69e55535c
+ * @param {string} rgbColor a string with the background color (e.g. "rgb(0,5,4)")
+ */
+const getTextColor = (rgbColor) => {
+  const colors = rgbColor.replace(/[^\d,.]/g, '').split(',');
+  const r = parseInt(colors[0], 10);
+  const g = parseInt(colors[1], 10);
+  const b = parseInt(colors[2], 10);
+  const contrastRatio = (r * 299 + g * 587 + b * 114) / 1000;
+  return contrastRatio > 128 ? 'black' : 'white';
+};
+
+
 const Value = styled.span`
 font-weight: bold;
 `;
 
 const Box = styled.div`
   background-color: ${props => props.color};
-  color: #fff;
+  color: ${props => getTextColor(props.color)};
   display: flex;
   align-items: center;
   flex-direction: column;

--- a/web/src/components/tooltips/mapcountrytooltip.js
+++ b/web/src/components/tooltips/mapcountrytooltip.js
@@ -12,7 +12,7 @@ const mapStateToProps = state => ({
   electricityMixMode: state.application.electricityMixMode,
 });
 
-const TooltipContent = ({
+const TooltipContent = React.memo(({
   isDataDelayed, hasParser, co2intensity, fossilFuelPercentage, renewablePercentage,
 }) => {
   if (!hasParser) {
@@ -56,7 +56,7 @@ const TooltipContent = ({
       </div>
     </div>
   );
-};
+});
 
 const MapCountryTooltip = ({
   electricityMixMode,

--- a/web/src/components/tooltips/mapcountrytooltip.js
+++ b/web/src/components/tooltips/mapcountrytooltip.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { __ } from '../../helpers/translation';
-import { useCo2ColorScale } from '../../hooks/theme';
 
 import CircularGauge from '../circulargauge';
+import CarbonIntensitySquare from '../carbonintensitysquare';
 import Tooltip from '../tooltip';
 import { ZoneName } from './common';
 
@@ -15,7 +15,6 @@ const mapStateToProps = state => ({
 const TooltipContent = ({
   isDataDelayed, hasParser, co2intensity, fossilFuelPercentage, renewablePercentage,
 }) => {
-  const co2ColorScale = useCo2ColorScale();
   if (!hasParser) {
     return (
       <div className="no-parser-text">
@@ -40,21 +39,7 @@ const TooltipContent = ({
   return (
     <div className="zone-details">
       <div className="country-table-header-inner">
-        <div className="country-col country-emission-intensity-wrap">
-          <div
-            id="country-emission-rect"
-            className="country-col-box emission-rect emission-rect-overview"
-            style={{ backgroundColor: co2ColorScale(co2intensity) }}
-          >
-            <div>
-              <span className="country-emission-intensity">
-                {Math.round(co2intensity) || '?'}
-              </span>
-              g
-            </div>
-          </div>
-          <div className="country-col-headline">{__('country-panel.carbonintensity')}</div>
-        </div>
+        <CarbonIntensitySquare value={co2intensity} />
         <div className="country-col country-lowcarbon-wrap">
           <div id="tooltip-country-lowcarbon-gauge" className="country-gauge-wrap">
             <CircularGauge percentage={fossilFuelPercentage} />

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -17,6 +17,7 @@ import moment from 'moment';
 
 // Components
 import LowCarbonInfoTooltip from '../../components/tooltips/lowcarboninfotooltip';
+import CarbonIntensitySquare from '../../components/carbonintensitysquare';
 import CircularGauge from '../../components/circulargauge';
 import ContributorList from '../../components/contributorlist';
 import CountryHistoryCarbonGraph from '../../components/countryhistorycarbongraph';
@@ -30,7 +31,6 @@ import { dispatchApplication } from '../../store';
 
 // Modules
 import { useCurrentZoneData } from '../../hooks/redux';
-import { useCo2ColorScale } from '../../hooks/theme';
 import { useTrackEvent } from '../../hooks/tracking';
 import { flagUri } from '../../helpers/flags';
 import { getFullZoneName, __ } from '../../helpers/translation';
@@ -90,7 +90,6 @@ const CountryPanel = ({
   const [tooltip, setTooltip] = useState(null);
 
   const isLoadingHistories = useSelector(state => state.data.isLoadingHistories);
-  const co2ColorScale = useCo2ColorScale();
 
   const trackEvent = useTrackEvent();
   const history = useHistory();
@@ -171,22 +170,7 @@ const CountryPanel = ({
         {hasParser && (
           <React.Fragment>
             <div className="country-table-header-inner">
-              <div className="country-col country-emission-intensity-wrap">
-                <div
-                  id="country-emission-rect"
-                  className="country-col-box emission-rect emission-rect-overview"
-                  style={{ backgroundColor: co2ColorScale(co2Intensity) }}
-                >
-                  <div>
-                    <span className="country-emission-intensity">
-                      {Math.round(co2Intensity) || '?'}
-                    </span>
-                    g
-                  </div>
-                </div>
-                <div className="country-col-headline">{__('country-panel.carbonintensity')}</div>
-                <div className="country-col-subtext">(gCO₂eq/kWh)</div>
-              </div>
+              <CarbonIntensitySquare value={co2Intensity} withSubtext />
               <div className="country-col country-lowcarbon-wrap">
                 <div id="country-lowcarbon-gauge" className="country-gauge-wrap">
                   <CountryLowCarbonGauge

--- a/web/src/scss/content/map/_map.scss
+++ b/web/src/scss/content/map/_map.scss
@@ -65,7 +65,6 @@
     }
 }
 
-.country-emission-intensity,
 .country-spot-price,
 .emission-intensity,
 .fossil-fuel-percentage,
@@ -73,16 +72,6 @@
     font-weight: bold;
 }
 
-.emission-rect-overview {
-    width: 4rem;
-    height: 4rem;
-    display: inline-flex;
-    font-size: 1rem;
-    border-radius: 1rem;
-    color: #fff;
-    flex-direction: column;
-    justify-content: center;
-}
 
 .emission-rect {
     display: inline-block;


### PR DESCRIPTION
## Issues

Fixes #1886 (thanks for the code and suggestions!)

Might also partially help with #2304

### Description

The text is now changing color based on the background-color - so if it's light, we change text color to black.

While at it, I also noticed that `<TooltipContent />` was being re-rendered on every mouse-move event, which makes no sense if it's within the same zone. The component has been memoized here :)

### Preview

![Kapture 2021-02-08 at 13 52 41](https://user-images.githubusercontent.com/3296643/107224463-bea1d100-6a17-11eb-8089-fb9c42fa508f.gif)


This has been fixed now: 👇 
![Screenshot 2021-02-08 at 14 02 57](https://user-images.githubusercontent.com/3296643/107224422-b47fd280-6a17-11eb-9f31-5e7f4bfc992d.png)
