### PR TITLE
Document how to generate bounding boxes for zones

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -34,3 +34,10 @@ TopoJSON format, which is a more compressed format than geoJSON. It only stores 
 on a grid. All together, this allows to convert a ~`24MB` file to a ~`1MB` one.
 
 The final file is named `world.json` and is the one sent to the client.
+
+## `generate-zone-bounding-boxes.js`
+
+You can create bounding boxes for new or existing zones in `config/zones.json`:
+1) Run: `docker-compose run --rm web ./topogen.sh`
+2) Update the zone you want to update in `config/zones.json` with `"bounding_box": null`
+3) Run: `node generate-zone-bounding-boxes.js`

--- a/web/generate-geometries.js
+++ b/web/generate-geometries.js
@@ -923,7 +923,11 @@ const zoneFeatures = getZoneFeatures(zoneDefinitions, backendGeos)
 
 // Write unsimplified list of geojson, without state merges
 // including overlapping US zones
-fs.writeFileSync('public/dist/zonegeometries.json', zoneFeatures.map(JSON.stringify).join('\n'));
+const zonegeometriesFolder = 'public/dist'
+if (!fs.existsSync(zonegeometriesFolder)){
+  fs.mkdirSync(zonegeometriesFolder);
+}
+fs.writeFileSync(`${zonegeometriesFolder}/zonegeometries.json`, zoneFeatures.map(JSON.stringify).join('\n'));
 
 // Convert to TopoJSON
 const topojson = require('topojson');


### PR DESCRIPTION
- Document how to generate bounding boxes for zones using `generate-zone-bounding-boxes.js`.
- Update `generate-geometries.js` to ensure `public/dist` folder exists
