### PR TITLE
Make it possible to generate geometries for smaller zones

### DIFF
--- a/web/generate-geometries.js
+++ b/web/generate-geometries.js
@@ -949,7 +949,6 @@ topo = topojson.filter(topo, topojson.filterWeight(topo, 0.009));
 topoMoreDetails = topojson.topology(zonesMoreDetails);
 topoMoreDetails = topojson.presimplify(topoMoreDetails);
 topoMoreDetails = topojson.simplify(topoMoreDetails, 0.001);
-topoMoreDetails = topojson.filter(topoMoreDetails, topojson.filterWeight(topo, 0.001));
 
 // Merge topoMoreDetails into topo
 mergeTopoJsonSingleZone(topo, topoMoreDetails);

--- a/web/generate-geometries.js
+++ b/web/generate-geometries.js
@@ -943,14 +943,16 @@ let topo = topojson.topology(webZones);
 // Simplify all countries
 topo = topojson.presimplify(topo);
 topo = topojson.simplify(topo, 0.01);
+topo = topojson.filter(topo, topojson.filterWeight(topo, 0.009));
 
 // Simplify to 0.001 zonesMoreDetails zones
 topoMoreDetails = topojson.topology(zonesMoreDetails);
 topoMoreDetails = topojson.presimplify(topoMoreDetails);
 topoMoreDetails = topojson.simplify(topoMoreDetails, 0.001);
+topoMoreDetails = topojson.filter(topoMoreDetails, topojson.filterWeight(topo, 0.001));
+
 // Merge topoMoreDetails into topo
 mergeTopoJsonSingleZone(topo, topoMoreDetails);
 
-topo = topojson.filter(topo, topojson.filterWeight(topo, 0.009));
 topo = topojson.quantize(topo, 1e5);
 fs.writeFileSync('src/world.json', JSON.stringify(topo));


### PR DESCRIPTION
## Description

As discovered by @ajoga in #2977, we currently can't generate geometries for very small areas.

This PR ensures that we only applies the `topojson.filter` function for areas without `moreDetails: true`.

The increase to file size of `world.json` is extremely small:

```
Before: 560.009 bytes (561 KB on disk)
After:  560.077 bytes (561 KB on disk)
```