### PR TITLE
capacity update Spain January 2021

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -307,7 +307,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Spain:
   - Biomass: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
   - Gas, Oil: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?)
-  - Other: [REE](https://www.ree.es/es/datos/publicaciones/series-estadisticas-nacionales)
+  - Other: [REE](https://www.ree.es/es/datos/publicaciones/boletines-mensuales)
 - Spain (Canary Islands)
   - Hydro storage: [goronadelviento.es](http://www.goronadelviento.es/)
   - Wind, Solar: [REE](http://www.ree.es/sites/default/files/11_PUBLICACIONES/Documentos/Renovables-2016-v3.pdf)

--- a/config/zones.json
+++ b/config/zones.json
@@ -1603,17 +1603,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 1189,
-      "coal": 4826,
-      "gas": 30012,
+      "biomass": 1190,
+      "coal": 5144,
+      "gas": 30181,
       "geothermal": 0,
-      "hydro": 17085,
+      "hydro": 17083,
       "hydro storage": 5645,
       "nuclear": 7117,
       "oil": 707,
-      "solar": 11828,
-      "wind": 25902,
-      "unknown": 360
+      "solar": 13581,
+      "wind": 26811,
+      "unknown": 438
     },
     "contributors": [
       "https://github.com/brandongalbraith",

--- a/config/zones.json
+++ b/config/zones.json
@@ -1619,7 +1619,8 @@
       "https://github.com/brandongalbraith",
       "https://github.com/corradio",
       "https://github.com/JosepRey",
-      "https://github.com/nessie2013"
+      "https://github.com/nessie2013",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "es.png",
     "parsers": {


### PR DESCRIPTION
I updated Spains generation capacity according to the newest report from the spanish grid operator. 

Source: https://www.ree.es/es/datos/publicaciones/boletines-mensuales/boletin-mensual-enero-2021
I used the file named "produccion" page "Data 1".

If this PR  gets approved PR #2873 could be closed since he used an older report.