### PR TITLE
Changed US-MIDW-MISO parser to use EIA instead

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -342,7 +342,6 @@ For many European countries, data is available from [ENTSO-E](https://transparen
     - CEC: [CEC](https://ww2.energy.ca.gov/almanac/electricity_data/electric_generation_capacity.html)
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
-  - MISO: [MISO](https://www.misoenergy.org/about/media-center/corporate-fact-sheet/)
   - NYISO: [NYISO Gold Book](https://home.nyiso.com/wp-content/uploads/2017/12/2017_Gold-Book.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2019.ashx?la=en)
   - SPP: [SPP](https://www.spp.org/about-us/fast-facts/)

--- a/config/zones.json
+++ b/config/zones.json
@@ -6218,6 +6218,9 @@
       "consumptionForecast": "EIA.fetch_consumption_forecast",
       "productionPerModeForecast": "US_MISO.fetch_wind_forecast"
     },
+    "delays": {
+      "production": 30
+    },
     "timezone": "US/Central",
     "bounding_box": [
       [

--- a/config/zones.json
+++ b/config/zones.json
@@ -6213,7 +6213,7 @@
     ],
     "flag_file_name": "us.png",
     "parsers": {
-      "production": "US_MISO.fetch_production",
+      "production": "EIA.fetch_production_mix",
       "consumption": "EIA.fetch_consumption",
       "consumptionForecast": "EIA.fetch_consumption_forecast",
       "productionPerModeForecast": "US_MISO.fetch_wind_forecast"


### PR DESCRIPTION
Resolves #2725 

The current data source is coming in very spotty. We investigated the opportunity of estimating the unknown breakdown, but it turned out to be rather difficult, and we don't want to make too many assumptions.

It's a bit unfortunate because EIA isn't real-time (It's delayed up to 30 hours afaik), so it won't always show up on the map. It would be shown when the historical view has been implemented https://github.com/tmrowco/electricitymap-contrib/pull/2393

I backed up the old data, so we can potentially switch back if we find a fix.


