### PR TITLE
Fix drag

### DIFF
--- a/web/src/scss/_base.scss
+++ b/web/src/scss/_base.scss
@@ -21,6 +21,7 @@ body {
     padding: 0 !important;
     font-family: $primary-font;
     transition: background-color 800ms;
+    overflow: hidden; /* Disable dragging that can occur on mobile */
 }
 
 body {


### PR DESCRIPTION
This PR fixes a bug where the user, when dragging the input slider, or when dragging the screen horizontally (e.g. the header), would cause a shift of the whole interface (see video below).
https://user-images.githubusercontent.com/1655848/109930141-94b29600-7cc7-11eb-980e-6a29e647e2cc.mov

This CSS fix resolves the issue. I've tested that all dragging of both map, inputs as well as scrolls work on mobile.

