### PR TITLE
Update GB capacity 

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -2019,17 +2019,17 @@
       ]
     ],
     "capacity": {
-      "biomass": 4237,
-      "coal": 6780,
-      "gas": 38274,
+      "biomass": 4528,
+      "coal": 5241,
+      "gas": 39822,
       "geothermal": 0,
-      "hydro": 1882,
-      "hydro storage": 4052,
-      "nuclear": 8209,
+      "hydro": 1919,
+      "hydro storage": 4309,
+      "nuclear": 8256,
       "oil": 0,
-      "solar": 13276,
-      "unknown": 6155,
-      "wind": 23200
+      "solar": 13378,
+      "unknown": 4708,
+      "wind": 25097
     },
     "contributors": [
       "https://github.com/corradio",


### PR DESCRIPTION
Source is ENTSO-E like before

For some reason [PRIS](https://pris.iaea.org/PRIS/CountryStatistics/CountryDetails.aspx?current=GB) reports more nuclear than ENTSO-E. I went with the ENTSO-E value.