### PR TITLE
update BG generation capacities

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -185,7 +185,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Bolivia: [CNDC](http://www.cndc.bo/agentes/generacion.php)
 - Bosnia and Herzegovina: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Brazil: [ONS](http://www.ons.org.br/Paginas/resultados-da-operacao/historico-da-operacao/capacidade_instalada.aspx)
-- Bulgaria: [wikipedia.org](https://en.wikipedia.org/wiki/Energy_in_Bulgaria)
+- Bulgaria: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Canada (British Columbia, Manitoba, New Brunswick, Newfoundland and Labrador, Nova Scotia, Prince Edward Island):
   [wikipedia.org](https://en.wikipedia.org/wiki/List_of_generating_stations_in_Canada)
 - Canada (Ontario): [IESO](http://www.ieso.ca/en/Power-Data/Supply-Overview/Transmission-Connected-Generation)

--- a/config/zones.json
+++ b/config/zones.json
@@ -637,15 +637,15 @@
       ]
     ],
     "capacity": {
-      "biomass": 81,
-      "coal": 4900,
-      "gas": 779,
+      "biomass": 80,
+      "coal": 4365,
+      "gas": 1361,
       "geothermal": 0,
-      "hydro": 3204,
+      "hydro": 3211,
       "nuclear": 2000,
       "oil": 0.3,
-      "solar": 1043,
-      "wind": 701
+      "solar": 1087,
+      "wind": 700
     },
     "contributors": [
       "https://github.com/yurukov",


### PR DESCRIPTION
Updated the generation capacities in Bulgaria according to Entsoe.

If I go through all the Entsoe countries and update their capacities do you guys prefere one PR for all of them or shall I create a new PR for every country? Which is the easiest for you?