### PR TITLE
Ignore flaky code push errors

### DIFF
--- a/mobileapp/BUILD.yaml
+++ b/mobileapp/BUILD.yaml
@@ -44,11 +44,11 @@ steps:
       - cordova prepare
       # Release to staging
       - code-push login --accessKey ${BRICK_CODE_PUSH_ACCESS_KEY:-unknown}
-      - code-push release-cordova electricitymap-android android --noDuplicateReleaseError --description ${BRICK_DRONE_COMMIT_SHA:-latest}
-      - code-push release-cordova electricitymap-ios ios --noDuplicateReleaseError --description ${BRICK_DRONE_COMMIT_SHA:-latest}
+      - code-push release-cordova electricitymap-android android --noDuplicateReleaseError --description ${BRICK_DRONE_COMMIT_SHA:-latest} || echo 'WARNING ignoring code push failure (Android)'
+      - code-push release-cordova electricitymap-ios ios --noDuplicateReleaseError --description ${BRICK_DRONE_COMMIT_SHA:-latest} || echo 'WARNING ignoring code push failure (iOS)'
       # Promote
-      - code-push promote electricitymap-android Staging Production --noDuplicateReleaseError
-      - code-push promote electricitymap-ios Staging Production --noDuplicateReleaseError
+      - code-push promote electricitymap-android Staging Production --noDuplicateReleaseError || echo 'WARNING ignoring code push promote failure (Android)'
+      - code-push promote electricitymap-ios Staging Production --noDuplicateReleaseError || echo 'WARNING ignoring code push promote failure (iOS)'
     secrets:
       gcloud:
         src: ~/.config/gcloud


### PR DESCRIPTION
The code push job is flaky and blocks our deployment pipeline... We might be able to stabilize this by upgrading to https://github.com/microsoft/appcenter-cli (note that the current version of the code push CLI is 3 years old).

Silently failing is not nice, but for now we should monitor that code is being shipped to the Android and iOS apps.

Ref: https://github.com/tmrowco/electricitymap/issues/394