### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ packages = [
 include = ["config/*.json"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+#python = "^3.6"
+python = '>= 3.6, < 3.8'
 
 arrow = {version="0.16.0", optional=true}
 beautifulsoup4 = {version="4.6.0", optional=true}


### PR DESCRIPTION
Change pyproject.toml to include python version 3.6 and 3.7 as acceptable, based on a suggestion by Kenneth Skovhus.