### PR TITLE
Fix real-time update of %

### DIFF
--- a/web/src/reducers/dataReducer.js
+++ b/web/src/reducers/dataReducer.js
@@ -86,6 +86,10 @@ module.exports = (state = initialDataState, action) => {
       Object.keys(newGrid.zones).forEach((key) => {
         const zone = Object.assign({}, newGrid.zones[key]);
         zone.co2intensity = undefined;
+        zone.fossilFuelRatio = undefined;
+        zone.fossilFuelRatioProduction = undefined;
+        zone.renewableRatio = undefined;
+        zone.renewableRatioProduction = undefined;
         zone.exchange = {};
         zone.production = {};
         zone.productionCo2Intensities = {};


### PR DESCRIPTION
I realised that the renewable and fossil fuel % weren't set to '?' on the left panel when data went from being present to being missing.
This is because we forgot to reset those variables in the reducer that handles the data layer (GridState)