### PR TITLE
update capacities Brazil

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -729,11 +729,11 @@
       ]
     ],
     "capacity": {
-      "hydro": 63797,
+      "hydro": 58142,
       "nuclear": 1990,
-      "solar": 910,
+      "solar": 923,
       "wind": 28,
-      "unknown": 19365
+      "unknown": 19446
     },
     "contributors": [
       "https://github.com/alexanmtz",
@@ -759,10 +759,10 @@
       ]
     ],
     "capacity": {
-      "hydro": 22251,
-      "solar": 5,
+      "hydro": 22261,
+      "solar": 3,
       "wind": 426,
-      "unknown": 3654
+      "unknown": 3641
     },
     "contributors": [
       "https://github.com/alexanmtz",
@@ -788,10 +788,10 @@
       ]
     ],
     "capacity": {
-      "hydro": 11023,
-      "solar": 1525,
-      "wind": 12801,
-      "unknown": 7227
+      "hydro": 11021,
+      "solar": 2128,
+      "wind": 14278,
+      "unknown": 8243
     },
     "contributors": [
       "https://github.com/alexanmtz",
@@ -817,10 +817,10 @@
       ]
     ],
     "capacity": {
-      "hydro": 17045,
-      "solar": 4,
+      "hydro": 17166,
+      "solar": 8,
       "wind": 2018,
-      "unknown": 4220
+      "unknown": 4227
     },
     "contributors": [
       "https://github.com/alexanmtz",


### PR DESCRIPTION
I updated the capacities in Brazil according to the source in data_sources.md (http://www.ons.org.br/Paginas/resultados-da-operacao/historico-da-operacao/capacidade_instalada.aspx).