### PR TITLE
Update NL.py

### DIFF
--- a/parsers/NL.py
+++ b/parsers/NL.py
@@ -12,7 +12,7 @@ import requests
 
 
 def fetch_production(zone_key='NL', session=None, target_datetime=None,
-                     logger=logging.getLogger(__name__), energieopwek_nl=True):
+                     logger=logging.getLogger(__name__), energieopwek_nl=False):
     if target_datetime is None:
         target_datetime = arrow.utcnow()
     else:


### PR DESCRIPTION
Setting energieopwek_nl to False in order to use the ENTSOE data instead of the energieopwek-data (which has not been available for quite some time). The issue was discussed at https://github.com/tmrowco/electricitymap-contrib/issues/3015