### PR TITLE
Pylance - PEP8 and code cleanup in Parsers [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ web/node_modules
 Thumbs.db
 mobileapp/*.zip
 dist
+.vscode
 
 ## Pycharm IDE
 .idea

--- a/config/zones.json
+++ b/config/zones.json
@@ -2494,7 +2494,7 @@
         34.2585
       ]
     ],
-    "capacity": {
+    "capacity": { #TODO: update capacities
       "coal": 4840,
       "gas": 9213,
       "solar": 378,
@@ -2505,7 +2505,8 @@
       "https://github.com/jarek"
     ],
     "parsers": {
-      "production": "IL.fetch_production"
+      "production": "IL.fetch_production",
+      "consumption": #TODO: add function
     },
     "timezone": "Asia/Jerusalem"
   },

--- a/config/zones.json
+++ b/config/zones.json
@@ -2505,8 +2505,7 @@
       "https://github.com/jarek"
     ],
     "parsers": {
-      "production": "IL.fetch_production",
-      "consumption": "IL.fetch_consumption"
+      "production": "IL.fetch_production"
     },
     "timezone": "Asia/Jerusalem"
   },

--- a/config/zones.json
+++ b/config/zones.json
@@ -2494,7 +2494,7 @@
         34.2585
       ]
     ],
-    "capacity": { #TODO: update capacities
+    "capacity": {
       "coal": 4840,
       "gas": 9213,
       "solar": 378,
@@ -2506,7 +2506,7 @@
     ],
     "parsers": {
       "production": "IL.fetch_production",
-      "consumption": #TODO: add function
+      "consumption": "IL.fetch_consumption"
     },
     "timezone": "Asia/Jerusalem"
   },

--- a/mockserver/public/v3/state
+++ b/mockserver/public/v3/state
@@ -1803,6 +1803,22 @@
                     "hydro": 0
                 }
             },
+            "IL": {
+                "countryCode": "IL",
+                "datetime": 2021-04-11T21:00:00+02:00,
+                "production": {
+                    "biomass": 0.0,
+                    "coal": 0.0,
+                    "gas": 0.0,
+                    "oil": 0.0,
+                    "solar": 0.0,
+                    "wind": 0.0,
+                    "geothermal": 0.0,
+                    "unknown": 12358
+                },
+                "source": "iec.co.il",
+                "price": "50.66"
+            },
             "IN-AP": {
                 "co2intensity": 11.1133509122906,
                 "countryCode": "IN-AP",

--- a/mockserver/public/v3/state
+++ b/mockserver/public/v3/state
@@ -1804,6 +1804,9 @@
                 }
             },
             "IL": {
+                "capacity": {
+                    "unknown": 17700.0
+                },
                 "countryCode": "IL",
                 "datetime": "2021-04-11T19:00:00+02:00",
                 "production": {

--- a/mockserver/public/v3/state
+++ b/mockserver/public/v3/state
@@ -1805,7 +1805,7 @@
             },
             "IL": {
                 "countryCode": "IL",
-                "datetime": 2021-04-11T21:00:00+02:00,
+                "datetime": "2021-04-11T19:00:00+02:00",
                 "production": {
                     "biomass": 0.0,
                     "coal": 0.0,
@@ -1814,10 +1814,10 @@
                     "solar": 0.0,
                     "wind": 0.0,
                     "geothermal": 0.0,
-                    "unknown": 12358
+                    "unknown": 12358.0
                 },
                 "source": "iec.co.il",
-                "price": "50.66"
+                "price": 50.66
             },
             "IN-AP": {
                 "co2intensity": 11.1133509122906,

--- a/parsers/AM.py
+++ b/parsers/AM.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 import re
@@ -109,18 +108,8 @@ def fetch_production(zone_key='AM', session=None, target_datetime=None, logger=N
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries.
     """
     sorted_keys = '->'.join(sorted([zone_key1, zone_key2]))
 

--- a/parsers/AM.py
+++ b/parsers/AM.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
 
-import arrow
 import re
 import requests
 from datetime import datetime

--- a/parsers/AM.py
+++ b/parsers/AM.py
@@ -2,10 +2,12 @@
 # coding=utf-8
 
 import re
-import requests
 from datetime import datetime
-from dateutil import parser as dparser, tz
+
+import requests
 from bs4 import BeautifulSoup
+from dateutil import parser as dparser
+from dateutil import tz
 
 #URL of the power system summary: http://epso.am/poweren.htm
 #URL of the detailled SCADA-page: http://epso.am/scada.htm

--- a/parsers/AR.py
+++ b/parsers/AR.py
@@ -1,17 +1,14 @@
-#!/usr/bin/env python3
 
 import itertools
+import logging
 import re
 import string
-import logging
+
 import arrow
 import requests
 from bs4 import BeautifulSoup
 
-try:
-    unicode  # Python 2
-except NameError:
-    unicode = str  # Python 3
+unicode = str
 
 # This parser gets hourly electricity generation data from portalweb.cammesa.com/Memnet1/default.aspx
 # for Argentina.  Currently wind and solar power are small contributors and not monitored but this is

--- a/parsers/AR.py
+++ b/parsers/AR.py
@@ -603,8 +603,8 @@ tie_mapping = {'CL-SEN': "position:absolute; top:349; left:585",
                }
 
 
-def webparser(req):
-    """Takes content from webpage and returns all text as a list of strings"""
+def webparser(req) -> list:
+    """Takes content from webpage."""
 
     soup = BeautifulSoup(req.content, 'html.parser')
     figs = soup.find_all("div", class_="r11")
@@ -615,20 +615,8 @@ def webparser(req):
 
 def fetch_price(zone_key='AR', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
-    Requests the last known power price of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'currency': EUR,
-      'datetime': '2017-01-01T00:00:00Z',
-      'price': 0.0,
-      'source': 'mysource.com'
-    }
-      """
+    Requests the last known power price of a given country.
+    """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
     s = session or requests.Session()
@@ -664,7 +652,8 @@ def fetch_price(zone_key='AR', session=None, target_datetime=None, logger=loggin
 
 def get_datetime(session=None):
     """
-    Generation data is updated hourly.  Makes request then finds most recent hour available.
+    Generation data is updated hourly.
+    Makes request then finds most recent hour available.
     Returns an arrow datetime object using UTC-3 for timezone and zero for minutes and seconds.
     """
 
@@ -680,8 +669,8 @@ def get_datetime(session=None):
     return {'datetime': datetime}
 
 
-def dataformat(junk):
-    """Takes string data with only digits and returns it as a float."""
+def dataformat(junk) -> float:
+    """Takes string data with only digits."""
 
     formatted = []
     for item in junk:
@@ -692,9 +681,9 @@ def dataformat(junk):
     return formatted
 
 
-def generation_finder(data, gen_type):
-    """Finds all generation matching requested type in a list.
-    Sums together and returns a float.
+def generation_finder(data, gen_type) -> float:
+    """
+    Finds all generation matching requested type in a list.
     """
 
     find_generation = [i + 2 for i, x in enumerate(data) if x == gen_type]
@@ -703,10 +692,9 @@ def generation_finder(data, gen_type):
     return float(generation_total)
 
 
-def get_thermal(session, logger):
+def get_thermal(session, logger) -> dict:
     """
-    Requests thermal generation data then parses and sorts by type.  Nuclear is included.
-    Returns a dictionary.
+    Requests thermal generation data then parses and sorts by type.
     """
 
     # Need to persist session in order to get ControlID and ReportSession so we can send second request
@@ -775,10 +763,11 @@ def get_thermal(session, logger):
             'biomass': biomass_generation}
 
 
-def get_hydro_and_renewables(session, logger):
-    """Requests hydro generation data then parses into a usable format.
+def get_hydro_and_renewables(session, logger) -> dict:
+    """
+    Requests hydro generation data then parses into a usable format.
     There's sometimes solar and wind plants included in the data.
-    Returns a dictionary."""
+    """
 
     s = session or requests.Session()
     r = s.get(hurl)
@@ -834,33 +823,7 @@ def get_hydro_and_renewables(session, logger):
 
 def fetch_production(zone_key='AR', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
-    Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    target_datetime: if we want to parser for a specific time and not latest
-    logger: where to log useful information
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    Requests the last known production mix (in MW) for a given country.
     """
     if target_datetime is not None:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -895,9 +858,8 @@ def fetch_production(zone_key='AR', session=None, target_datetime=None, logger=l
 
 def direction_finder(direction, exchange):
     """
-    Uses the 'src' attribute of an "img" tag to find the
-    direction of flow. In the data source small arrow images
-    are used to show flow direction.
+    Uses the 'src' attribute of an "img" tag to find the direction of flow.
+    In the data source small arrow images are used to show flow direction.
     """
 
     if direction == "/uflujpot.nsf/f90.gif":
@@ -910,10 +872,9 @@ def direction_finder(direction, exchange):
         raise ValueError('Flow direction for {} cannot be determined, got {}'.format(exchange, direction))
 
 
-def tie_finder(exchange_url, exchange, session):
+def tie_finder(exchange_url, exchange, session) -> float:
     """
     Finds tie data using div tag style attribute.
-    Returns a float.
     """
 
     req = session.get(exchange_url)
@@ -930,25 +891,8 @@ def tie_finder(exchange_url, exchange, session):
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-
-    Arguments:
-    zone_key1, zone_key2: specifies which exchange to get
-    session: requests session passed in order to re-use an existing session,
-      not used here due to difficulty providing it to pandas
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones.
     """
 
     # Only hourly data is available.

--- a/parsers/AW.py
+++ b/parsers/AW.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+
+import datetime
 
 import arrow
 import requests
-import datetime
 
 
 def fetch_production(zone_key='AW', session=None, target_datetime=None, logger=None):

--- a/parsers/AX.py
+++ b/parsers/AX.py
@@ -1,11 +1,7 @@
-#!/usr/bin/env python3
-# The arrow library is used to handle datetimes
-import arrow
-# The request library is used to fetch content through HTTP
-import requests
 
-# Numpy and PIL are used to process the image
+import arrow
 import numpy as np
+import requests
 from PIL import Image
 
 

--- a/parsers/AX.py
+++ b/parsers/AX.py
@@ -262,34 +262,8 @@ def _fetch_data(session=None):
 
 
 def fetch_production(zone_key='AX', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -334,20 +308,8 @@ def fetch_consumption(zone_key='AX', session=None, target_datetime=None, logger=
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/BD.py
+++ b/parsers/BD.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python3
-
 """Parser for Bangladesh."""
 
-import arrow
-from datetime import datetime
 import logging
-import pandas as pd
+from datetime import datetime
 
+import arrow
+import pandas as pd
 
 GENERATION_MAPPING = {'Gas (Public)': 'gas_public',
                       'Gas (Private)': 'gas_private',

--- a/parsers/BD.py
+++ b/parsers/BD.py
@@ -73,9 +73,10 @@ def new_format_converter(df, logger):
     return df
 
 
-def production_processer(df, target_datetime, old_format=False):
-    """Takes dataframe and extracts all production data and timestamps.
-    Returns a list of 2 element tuples in form (dict, arrow object)."""
+def production_processer(df, target_datetime, old_format=False) -> list:
+    """
+    Takes dataframe and extracts all production data and timestamps.
+    """
 
     if old_format:
         MAPPING = OLD_GENERATION_MAPPING
@@ -95,9 +96,10 @@ def production_processer(df, target_datetime, old_format=False):
     return processed_data
 
 
-def exchange_processer(df, target_datetime, old_format=False):
-    """Takes dataframe and extracts all exchange data and timestamps.
-    Returns a list of 2 element tuples in form (dict, arrow object)."""
+def exchange_processer(df, target_datetime, old_format=False) -> list:
+    """
+    Takes dataframe and extracts all exchange data and timestamps.
+    """
 
     # Positive means import from India hence sign reversal needed for EM.
     processed_data = []
@@ -110,10 +112,10 @@ def exchange_processer(df, target_datetime, old_format=False):
     return processed_data
 
 
-def excel_handler(shifted_target_datetime, logger):
-    """Decides which url to request based on supplied arrow object.
+def excel_handler(shifted_target_datetime, logger) -> tuple:
+    """
+    Decides which url to request based on supplied arrow object.
     Converts returned excel data into dataframe, format of data varies by date.
-    Returns a tuple containing (dataframe, bool).
     """
 
     # NOTE file named 11-01-2019 actually covers 10-01-2019, pattern repeats!
@@ -167,32 +169,7 @@ def excel_handler(shifted_target_datetime, logger):
 
 def fetch_production(zone_key = 'BD', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
-    Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional) -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    Requests the last known production mix (in MW) of a given country.
     """
 
     if not target_datetime:
@@ -221,20 +198,8 @@ def fetch_production(zone_key = 'BD', session=None, target_datetime=None, logger
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=logging.getLogger(__name__)):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones.
     """
     if not target_datetime:
         raise NotImplementedError("""This parser is only able to get historical

--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 import arrow
-from bs4 import BeautifulSoup
 import requests
+from bs4 import BeautifulSoup
 
 TYPE_MAPPING = {                        # Real values around midnight
     u'АЕЦ': 'nuclear',                  # 2000

--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -28,34 +28,8 @@ def time_string_converter(ts):
 
 
 def fetch_production(zone_key='BG', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -9,7 +9,9 @@ tz_bo = 'America/La_Paz'
 
 
 def extract_xsrf_token(html):
-  """Extracts XSRF token from the source code of the generation graph page"""
+  """
+  Extracts XSRF token from the source code of the generation graph page.
+  """
   return re.search(r'var ttoken = "([a-f0-9]+)";', html).group(1)
 
 
@@ -37,31 +39,7 @@ def template_forecast_response(zone_key, datetime, source):
 
 def fetch_production(zone_key='BO', session=None, target_datetime=None, logger=None):
     """
-    Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime is not None:
         now = arrow.get(target_datetime)

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -1,11 +1,9 @@
-#!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes
-import arrow
 import json
-# The request library is used to fetch content through HTTP
-import requests
 import re
+
+import arrow
+import requests
 
 tz_bo = 'America/La_Paz'
 

--- a/parsers/BR.py
+++ b/parsers/BR.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 from collections import defaultdict
 
@@ -6,7 +5,6 @@ import arrow
 import requests
 
 from .lib.validation import validate
-
 
 url = 'http://tr.ons.org.br/Content/GetBalancoEnergetico/null'
 

--- a/parsers/BR.py
+++ b/parsers/BR.py
@@ -62,10 +62,9 @@ def get_data(session, logger):
     return json_data
 
 
-def production_processor(json_data, zone_key):
+def production_processor(json_data, zone_key) -> tuple:
     """
     Extracts data timestamp and sums regional data into totals by key.
-    Maps keys to type and returns a tuple.
     """
 
     dt = arrow.get(json_data['Data'])
@@ -91,32 +90,7 @@ def production_processor(json_data, zone_key):
 
 def fetch_production(zone_key, session=None, target_datetime=None, logger=None):
     """
-    Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -141,20 +115,8 @@ def fetch_production(zone_key, session=None, target_datetime=None, logger=None):
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two regions
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two regions.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -180,19 +142,6 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 def fetch_region_exchange(region1, region2, session=None, target_datetime=None, logger=None):
     """
     Requests the last known power exchange (in MW) between two Brazilian regions.
-    Arguments:
-    region1           -- the first region
-    region2           -- the second region; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python3
 
-import arrow
-from bs4 import BeautifulSoup
 import datetime
 import re
-import requests
+
+import arrow
 import pandas as pd
+import requests
+from bs4 import BeautifulSoup
 from pytz import timezone
 
 ab_timezone = 'Canada/Mountain'

--- a/parsers/CA_AB.py
+++ b/parsers/CA_AB.py
@@ -22,34 +22,8 @@ def convert_time_str(ts):
 
 
 def fetch_production(zone_key='CA-AB', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -94,21 +68,8 @@ def fetch_production(zone_key='CA-AB', session=None, target_datetime=None, logge
 
 
 def fetch_price(zone_key='CA-AB', session=None, target_datetime=None, logger=None):
-    """Requests the last known power price of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'currency': EUR,
-      'datetime': '2017-01-01T00:00:00Z',
-      'price': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power price of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -138,20 +99,8 @@ def fetch_price(zone_key='CA-AB', session=None, target_datetime=None, logger=Non
 
 
 def fetch_exchange(zone_key1='CA-AB', zone_key2='CA-BC', session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -9,20 +9,8 @@ timezone = 'Canada/Pacific'
 
 
 def fetch_exchange(zone_key1=None, zone_key2=None, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/CA_BC.py
+++ b/parsers/CA_BC.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
 
 # More info:

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -1,14 +1,7 @@
-#!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes consistently with other parsers
 import arrow
-
-# The request library is used to fetch content through HTTP
 import requests
-
-# BeautifulSoup is used to parse HTML to get information
 from bs4 import BeautifulSoup
-
 
 timezone = 'Canada/Atlantic'
 

--- a/parsers/CA_NB.py
+++ b/parsers/CA_NB.py
@@ -34,36 +34,8 @@ def _get_new_brunswick_flows(requests_obj):
 
 
 def fetch_production(zone_key='CA-NB', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key       -- ignored here, only information for CA-NB is returned
-    session (optional) -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
-    """
+    Requests the last known production mix (in MW) of a given country.
     In this case, we are calculating the amount of electricity generated
     in New Brunswick, versus imported and exported elsewhere.
     """
@@ -97,21 +69,8 @@ def fetch_production(zone_key='CA-NB', session=None, target_datetime=None, logge
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two regions
-
-    Arguments:
-    zone_key1           -- the first country code (use format like "CA-QC" for sub-country regions)
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two regions.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -126,34 +126,8 @@ def _get_ns_info(requests_obj, logger):
 
 
 def fetch_production(zone_key='CA-NS', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     if target_datetime:
         raise NotImplementedError('This parser is unable to give information more than 24 hours in the past')
@@ -166,7 +140,8 @@ def fetch_production(zone_key='CA-NS', session=None, target_datetime=None, logge
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two regions.
+    """
+    Requests the last known power exchange (in MW) between two regions.
 
     Note: As of early 2017, Nova Scotia only has an exchange with New Brunswick (CA-NB).
     (An exchange with Newfoundland, "Maritime Link", is scheduled to open in "late 2017").

--- a/parsers/CA_NS.py
+++ b/parsers/CA_NS.py
@@ -1,8 +1,5 @@
-#!/usr/bin/env python3
 
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
 
 
@@ -194,8 +191,8 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    from pprint import pprint
     import logging
+    from pprint import pprint
     test_logger = logging.getLogger()
 
     print('fetch_production() ->')

--- a/parsers/CA_ON.py
+++ b/parsers/CA_ON.py
@@ -1,17 +1,11 @@
-#!/usr/bin/env python3
 
-from datetime import timedelta, timezone
 import logging
 import xml.etree.ElementTree as ET
+from datetime import timedelta, timezone
 
-# The arrow library is used to handle datetimes
 import arrow
-
-# The request library is used to fetch content through HTTP
-import requests
-
-# pandas processes tabular data
 import pandas as pd
+import requests
 
 """
 Some notes about timestamps:

--- a/parsers/CA_ON.py
+++ b/parsers/CA_ON.py
@@ -92,37 +92,8 @@ def _parse_ieso_hour(output, target_dt):
 
 def fetch_production(zone_key='CA-ON', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given region
-
-    Arguments:
-    zone_key (optional): ignored here, only information for CA-ON is returned
-    session (optional): request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'CA-ON',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given region.
     """
 
     dt, xml = _fetch_ieso_xml(target_datetime, session, logger, PRODUCTION_URL)
@@ -186,24 +157,8 @@ def fetch_production(zone_key='CA-ON', session=None, target_datetime=None,
 
 def fetch_price(zone_key='CA-ON', session=None, target_datetime=None,
                 logger=logging.getLogger(__name__)):
-    """Requests the last known power price per MWh of a given region
-
-    Arguments:
-    zone_key: ignored here, only information for CA-ON is returned
-    session: requests session passed in order to re-use an existing session,
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'currency': EUR,
-      'datetime': '2017-01-01T00:00:00Z',
-      'price': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power price per MWh of a given region.
     """
 
     # "HOEP" below is "Hourly Ontario Energy Price".
@@ -236,24 +191,8 @@ def fetch_price(zone_key='CA-ON', session=None, target_datetime=None,
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None,
                    logger=logging.getLogger(__name__)):
-    """Requests the last known power exchange (in MW) between two regions
-
-    Arguments:
-    zone_key1: the first region code
-    zone_key2: the second region code; order of the two codes in params doesn't matter
-    session: requests session passed in order to re-use an existing session,
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    [{
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }]
+    """
+    Requests the last known power exchange (in MW) between two regions.
     """
 
     sorted_zone_keys = '->'.join(sorted([zone_key1, zone_key2]))

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -1,13 +1,8 @@
-#!/usr/bin/env python3
 
 import json
 
-# The arrow library is used to handle datetimes consistently with other parsers
 import arrow
-
-# The request library is used to fetch content through HTTP
 import requests
-
 
 timezone = 'Canada/Atlantic'
 

--- a/parsers/CA_PE.py
+++ b/parsers/CA_PE.py
@@ -52,34 +52,8 @@ def _get_pei_info(requests_obj):
 
 
 def fetch_production(zone_key='CA-PE', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key       -- ignored here, only information for CA-PE is returned
-    session (optional) -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -115,21 +89,8 @@ def fetch_production(zone_key='CA-PE', session=None, target_datetime=None, logge
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two regions
-
-    Arguments:
-    zone_key1           -- the first country code (use format like "CA-QC" for sub-country regions)
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two regions.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/CA_YT.py
+++ b/parsers/CA_YT.py
@@ -7,11 +7,8 @@ timezone = 'America/Whitehorse'
 
 
 def fetch_production(zone_key='CA-YT', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given region
-
-    Arguments:
-    zone_key       -- ignored here, only information for CA-YT is returned
-    session (optional) -- request session passed in order to re-use an existing session
+    """
+    Requests the last known production mix (in MW) of a given region.
     """
 
     """

--- a/parsers/CA_YT.py
+++ b/parsers/CA_YT.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python3
 
 import arrow
-from bs4 import BeautifulSoup
 import requests
-
+from bs4 import BeautifulSoup
 
 timezone = 'America/Whitehorse'
 

--- a/parsers/CH.py
+++ b/parsers/CH.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
+
+import logging
 
 import arrow
+import requests
 
 from . import ENTSOE
-import logging
-import requests
 
 
 def fetch_swiss_exchanges(session, target_datetime, logger):

--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -32,10 +32,9 @@ def get_data_live(session, logger):
     return json_total, json_ren
 
 
-def production_processor_live(json_tot, json_ren):
+def production_processor_live(json_tot, json_ren) -> list:
     """
     Extracts generation data and timestamp into dictionary.
-    Returns a list of dictionaries for all of the available "live" data, usually that day.
     """
 
     gen_total = json_tot['data'][0]['values']
@@ -76,9 +75,9 @@ def production_processor_live(json_tot, json_ren):
     return mapped_totals
 
 
-def production_processor_historical(raw_data):
-    """Takes raw json data and groups by datetime while mapping generation to type.
-    Returns a list of dictionaries.
+def production_processor_historical(raw_data) -> list:
+    """
+    Takes raw json data and groups by datetime while mapping generation to type.
     """
 
     clean_datapoints = []
@@ -118,34 +117,8 @@ def production_processor_historical(raw_data):
 
 
 def fetch_production(zone_key='CL', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day, a string in the form YYYYMMDD
-    logger (optional) -- handles logging when parser is run
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given zone.
     """
 
     if target_datetime is None:

--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python3
-
 """Parser for the electricity grid of Chile"""
 
-import arrow
 import logging
-import requests
 from collections import defaultdict
 from operator import itemgetter
+
+import arrow
+import requests
+
 from .lib.validation import validate
 
 # Historical API

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -206,23 +206,8 @@ def fetch_production(zone_key='CR', session=None,
 
 
 def fetch_exchange(zone_key1='CR', zone_key2='NI', session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two regions
-
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two regions.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 import datetime as dt

--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -98,57 +98,8 @@ class CyprusParser:
 def fetch_production(zone_key='CY', session=None,
         target_datetime: datetime.datetime = None,
         logger: logging.Logger = logging.getLogger(__name__)) -> list:
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-
-        {
-            'zoneKey': 'FR',
-            'datetime': '2017-01-01T00:00:00Z',
-            'production': {
-                'biomass': 0.0,
-                'coal': 0.0,
-                'gas': 0.0,
-                'hydro': 0.0,
-                'nuclear': None,
-                'oil': 0.0,
-                'solar': 0.0,
-                'wind': 0.0,
-                'geothermal': 0.0,
-                'unknown': 0.0
-            },
-            'capacity': {
-                'hydro': 500
-            },
-            'storage': {
-                'hydro': -10.0,
-            },
-            'source': 'mysource.com'
-        }
+    """
+    Requests the last known production mix (in MW) of a given country.
     """
     assert zone_key == 'CY'
 
@@ -157,8 +108,7 @@ def fetch_production(zone_key='CY', session=None,
 
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     target_datetime = None
     if len(sys.argv) == 4:

--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python3
-import logging
+
 import datetime
+import logging
 import sys
 
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
-# BeautifulSoup is used to parse HTML
 from bs4 import BeautifulSoup
+
 
 class CyprusParser:
     CAPACITY_KEYS = {

--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -1,12 +1,14 @@
-import logging
-import pandas as pd
-import arrow  # the arrow library is used to handle datetimes
-import requests  # the request library is used to fetch content through HTTP
-import pytz
-import time
-import json
-from .lib.exceptions import ParserException
 
+import json
+import logging
+import time
+
+import arrow
+import pandas as pd
+import pytz
+import requests
+
+from .lib.exceptions import ParserException
 
 ids = {
     'real_time': '06380963-b7c6-46b7-aec5-173d15e4648b',

--- a/parsers/DK.py
+++ b/parsers/DK.py
@@ -19,12 +19,11 @@ ids = {
 def fetch_production(zone_key='DK-DK1', session=None,target_datetime=None,
                      logger: logging.Logger = logging.getLogger(__name__)):
     """
-    Queries "Electricity balance Non-Validated" from energinet api
-    for Danish bidding zones
+    Queries "Electricity balance Non-Validated" from energinet api for Danish bidding zones.
 
     NOTE: Missing historical wind/solar data @ 2017-08-01
-
     """
+    
     r = session or requests.session()
     
     if zone_key not in ['DK-DK1', 'DK-DK2']:

--- a/parsers/DK_BHM.py
+++ b/parsers/DK_BHM.py
@@ -1,7 +1,5 @@
-#!/usr/bin/env python3
-# The arrow library is used to handle datetimes
+
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
 
 PRODUCTION_MAPPING = {

--- a/parsers/DK_BHM.py
+++ b/parsers/DK_BHM.py
@@ -18,34 +18,8 @@ def _fetch_data(session=None):
 
 
 def fetch_production(zone_key='DK-BHM', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -67,20 +41,8 @@ def fetch_production(zone_key='DK-BHM', session=None, target_datetime=None, logg
 
 def fetch_exchange(zone_key1='DK-BHM', zone_key2='SE', session=None, target_datetime=None,
                    logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries.
     """
 
     obj = _fetch_data(session)

--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -84,11 +84,10 @@ thermal_plants = {
                  }
 
 
-def get_data(session=None):
+def get_data(session=None) -> list:
     """
     Makes a request to source url.
     Finds main table and creates a list of all table elements in string format.
-    Returns a list.
     """
 
     data = []
@@ -117,11 +116,10 @@ def floater(item):
         return item
 
 
-def chunker(big_lst):
+def chunker(big_lst) -> dict:
     """
     Breaks a big list into a list of lists.  Removes any list with no data then turns remaining
     lists into key: value pairs with first element from the list being the key.
-    Returns a dictionary.
     """
 
     chunks = [big_lst[x:x + 27] for x in range(0, len(big_lst), 27)]
@@ -138,10 +136,9 @@ def chunker(big_lst):
     return chunked_list
 
 
-def data_formatter(data):
+def data_formatter(data) -> dict:
     """
     Takes data and finds relevant sections.  Formats and breaks data into usable parts.
-    Returns a nested dictionary.
     """
 
     find_thermal_index = data.index(u'GRUPO: T\xe9rmica')
@@ -180,11 +177,10 @@ def data_parser(formatted_data):
     return dft
 
 
-def thermal_production(df, logger):
+def thermal_production(df, logger) -> dict:
     """
     Takes DataFrame and finds thermal generation for each hour.
     Removes any non generating plants then maps plants to type.
-    Sums type instances and returns a dictionary.
     """
 
     therms = []
@@ -225,10 +221,9 @@ def thermal_production(df, logger):
     return therms
 
 
-def total_production(df):
+def total_production(df) -> dict:
     """
     Takes DataFrame and finds generation totals for each hour.
-    Returns a dictionary.
     """
 
     vals = []
@@ -255,10 +250,9 @@ def total_production(df):
     return vals
 
 
-def merge_production(thermal, total):
+def merge_production(thermal, total) -> defaultdict:
     """
     Takes thermal generation and total generation and merges them using 'datetime' key.
-    Returns a defaultdict.
     """
 
     d = defaultdict(dict)
@@ -283,31 +277,7 @@ def merge_production(thermal, total):
 
 def fetch_production(zone_key='DO', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
-    Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    Requests the last known production mix (in MW) of a given country.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/DO.py
+++ b/parsers/DO.py
@@ -1,15 +1,14 @@
-#!/usr/bin/env python3
+
+import logging
+from collections import defaultdict
+from math import isnan
+from operator import itemgetter
 
 import arrow
-from bs4 import BeautifulSoup
-from collections import defaultdict
-import logging
-from math import isnan
 import numpy as np
-from operator import itemgetter
 import pandas as pd
 import requests
-
+from bs4 import BeautifulSoup
 
 # This parser gets hourly electricity generation data from oc.org.do for the Dominican Republic.
 # The data is in MWh but since it is updated hourly we can view it as MW.

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -11,9 +11,9 @@ import datetime
 
 import requests
 from dateutil import parser, tz
+from eiapy import Series
 
 from .ENTSOE import merge_production_outputs
-from .lib.utils import get_token
 from .lib.validation import validate
 
 #Reverse exchanges need to be multiplied by -1, since they are reported in the opposite direction
@@ -478,7 +478,6 @@ def _fetch_series(zone_key, series_id, session=None, target_datetime=None,
 
     # local import to avoid the exception that happens if EIAPY token is not set
     # even if this module is unused
-    from eiapy import Series
     series = Series(series_id=series_id, session=s)
 
     if target_datetime:

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -1,4 +1,5 @@
-"""Parser for U.S. Energy Information Administration, https://www.eia.gov/ .
+"""
+Parser for U.S. Energy Information Administration, https://www.eia.gov/ .
 
 Aggregates and standardizes data from most of the US ISOs,
 and exposes them via a unified API.

--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Parser for U.S. Energy Information Administration, https://www.eia.gov/ .
 
 Aggregates and standardizes data from most of the US ISOs,

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 """
@@ -12,16 +11,16 @@ https://www.elexon.co.uk/wp-content/uploads/2017/06/
 bmrs_api_data_push_user_guide_v1.1.pdf
 """
 
-import os
-import arrow
-import logging
-import requests
 import datetime as dt
-import pandas as pd
+import logging
 from io import StringIO
 
-from .lib.validation import validate
+import arrow
+import pandas as pd
+import requests
+
 from .lib.utils import get_token
+from .lib.validation import validate
 
 ELEXON_ENDPOINT = 'https://api.bmreports.com/BMRS/{}/v1'
 

--- a/parsers/ELEXON.py
+++ b/parsers/ELEXON.py
@@ -314,8 +314,7 @@ def fetch_production(zone_key='GB', session=None, target_datetime=None,
 
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')
     print(fetch_production())

--- a/parsers/ENTE.py
+++ b/parsers/ENTE.py
@@ -39,7 +39,7 @@ def fetch_production(zone_key='HN', session=None, target_datetime=None, logger=N
 
     return data
 
-def extract_exchange(raw_data, exchange):
+def extract_exchange(raw_data, exchange) -> float:
     """
     Extracts flow value and direction for a given exchange.
     Returns a float or None.
@@ -61,17 +61,9 @@ def extract_exchange(raw_data, exchange):
     return interconnection
 
 
-def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
+def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None) -> dict:
     """
     Gets an exchange pair from the SIEPAC system.
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'CR->PA',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/ENTE.py
+++ b/parsers/ENTE.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 import arrow
 import requests

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 """
@@ -13,18 +12,18 @@ Generation Forecast
 Consumption Forecast
 """
 import itertools
-import numpy as np
-from bs4 import BeautifulSoup
+import logging
+import re
 from collections import defaultdict
 
 import arrow
-import logging, os, re
-import requests
-
+import numpy as np
 import pandas as pd
+import requests
+from bs4 import BeautifulSoup
 
+from .lib.utils import get_token, sum_production_dicts
 from .lib.validation import validate
-from .lib.utils import sum_production_dicts, get_token
 
 ENTSOE_ENDPOINT = 'https://transparency.entsoe.eu/api'
 ENTSOE_PARAMETER_DESC = {

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -468,9 +468,7 @@ def query_production_per_units(psr_type, domain, session, target_datetime=None):
         check_response(response, query_production_per_units.__name__)
 
 
-def query_exchange(in_domain, out_domain, session, target_datetime=None):
-    """Returns a string object if the query succeeds."""
-
+def query_exchange(in_domain, out_domain, session, target_datetime=None) -> str:
     params = {
         'documentType': 'A11',
         'in_Domain': in_domain,
@@ -483,10 +481,9 @@ def query_exchange(in_domain, out_domain, session, target_datetime=None):
         check_response(response, query_exchange.__name__)
 
 
-def query_exchange_forecast(in_domain, out_domain, session, target_datetime=None):
+def query_exchange_forecast(in_domain, out_domain, session, target_datetime=None) -> str:
     """
     Gets exchange forecast for 48 hours ahead and previous 24 hours.
-    Returns a string object if the query succeeds.
     """
 
     params = {
@@ -501,9 +498,7 @@ def query_exchange_forecast(in_domain, out_domain, session, target_datetime=None
         check_response(response, query_exchange_forecast.__name__)
 
 
-def query_price(domain, session, target_datetime=None):
-    """Returns a string object if the query succeeds."""
-
+def query_price(domain, session, target_datetime=None) -> str:
     params = {
         'documentType': 'A44',
         'in_Domain': domain,
@@ -516,10 +511,9 @@ def query_price(domain, session, target_datetime=None):
         check_response(response, query_price.__name__)
 
 
-def query_generation_forecast(in_domain, session, target_datetime=None):
+def query_generation_forecast(in_domain, session, target_datetime=None) -> str:
     """
     Gets generation forecast for 48 hours ahead and previous 24 hours.
-    Returns a string object if the query succeeds.
     """
 
     # Note: this does not give a breakdown of the production
@@ -535,10 +529,9 @@ def query_generation_forecast(in_domain, session, target_datetime=None):
         check_response(response, query_generation_forecast.__name__)
 
 
-def query_consumption_forecast(in_domain, session, target_datetime=None):
+def query_consumption_forecast(in_domain, session, target_datetime=None) -> str:
     """
     Gets consumption forecast for 48 hours ahead and previous 24 hours.
-    Returns a string object if the query succeeds.
     """
 
     params = {
@@ -553,10 +546,9 @@ def query_consumption_forecast(in_domain, session, target_datetime=None):
         check_response(response, query_generation_forecast.__name__)
 
 
-def query_wind_solar_production_forecast(in_domain, session, target_datetime=None):
+def query_wind_solar_production_forecast(in_domain, session, target_datetime=None) -> str:
     """
     Gets consumption forecast for 48 hours ahead and previous 24 hours.
-    Returns a string object if the query succeeds.
     """
 
     params = {
@@ -583,9 +575,7 @@ def datetime_from_position(start, position, resolution):
     raise NotImplementedError('Could not recognise resolution %s' % resolution)
 
 
-def parse_scalar(xml_text, only_inBiddingZone_Domain=False, only_outBiddingZone_Domain=False):
-    """Returns a tuple containing two lists."""
-
+def parse_scalar(xml_text, only_inBiddingZone_Domain=False, only_outBiddingZone_Domain=False) -> tuple:
     if not xml_text:
         return None
     soup = BeautifulSoup(xml_text, 'html.parser')
@@ -610,9 +600,7 @@ def parse_scalar(xml_text, only_inBiddingZone_Domain=False, only_outBiddingZone_
     return values, datetimes
 
 
-def parse_production(xml_text):
-    """Returns a tuple containing two lists."""
-
+def parse_production(xml_text) -> tuple:
     if not xml_text:
         return None
     soup = BeautifulSoup(xml_text, 'html.parser')
@@ -677,8 +665,7 @@ def parse_self_consumption(xml_text):
     return res
 
 
-def parse_production_per_units(xml_text):
-    """Returns a dict indexed by the (datetime, unit_key) key"""
+def parse_production_per_units(xml_text) -> dict:
     values = {}
 
     if not xml_text:
@@ -716,9 +703,7 @@ def parse_production_per_units(xml_text):
     return values.values()
 
 
-def parse_exchange(xml_text, is_import, quantities=None, datetimes=None):
-    """Returns a tuple containing two lists."""
-
+def parse_exchange(xml_text, is_import, quantities=None, datetimes=None) -> tuple:
     if not xml_text:
         return None
     quantities = quantities or []
@@ -749,9 +734,7 @@ def parse_exchange(xml_text, is_import, quantities=None, datetimes=None):
     return quantities, datetimes
 
 
-def parse_price(xml_text):
-    """Returns a tuple containing three lists."""
-
+def parse_price(xml_text) -> tuple:
     if not xml_text:
         return None
     soup = BeautifulSoup(xml_text, 'html.parser')
@@ -861,11 +844,10 @@ def fetch_consumption(zone_key, session=None, target_datetime=None,
 
 
 def fetch_production(zone_key, session=None, target_datetime=None,
-                     logger=logging.getLogger(__name__)):
+                     logger=logging.getLogger(__name__)) -> list:
     """
-    Gets values and corresponding datetimes for all production types in the
-    specified zone. Removes any values that are in the future or don't have
-    a datetime associated with them.
+    Gets values and corresponding datetimes for all production types in the specified zone.
+    Removes any values that are in the future or don't have a datetime associated with them.
     Returns a list of dictionaries that have been validated.
     """
     if not session:
@@ -980,10 +962,9 @@ def fetch_production_aggregate(zone_key, session=None, target_datetime=None,
 
 
 def fetch_production_per_units(zone_key, session=None, target_datetime=None,
-                               logger=logging.getLogger(__name__)):
+                               logger=logging.getLogger(__name__)) -> list:
     """
-    Returns a list of all production units and production values as a list
-    of dictionaries
+    Returns a list of all production units and production values.
     """
     if not session:
         session = requests.session()
@@ -1012,11 +993,10 @@ def fetch_production_per_units(zone_key, session=None, target_datetime=None,
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None,
-                   logger=logging.getLogger(__name__)):
+                   logger=logging.getLogger(__name__)) -> list:
     """
     Gets exchange status between two specified zones.
     Removes any datapoints that are in the future.
-    Returns a list of dictionaries.
     """
     if not session:
         session = requests.session()
@@ -1063,10 +1043,9 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None,
 
 
 def fetch_exchange_forecast(zone_key1, zone_key2, session=None, target_datetime=None,
-                            logger=logging.getLogger(__name__)):
+                            logger=logging.getLogger(__name__)) -> list:
     """
     Gets exchange forecast between two specified zones.
-    Returns a list of dictionaries.
     """
     if not session:
         session = requests.session()
@@ -1113,10 +1092,9 @@ def fetch_exchange_forecast(zone_key1, zone_key2, session=None, target_datetime=
 
 
 def fetch_price(zone_key, session=None, target_datetime=None,
-                logger=logging.getLogger(__name__)):
+                logger=logging.getLogger(__name__)) -> list:
     """
     Gets day-ahead price for specified zone.
-    Returns a list of dictionaries.
     """
     # Note: This is day-ahead prices
     if not session:
@@ -1143,10 +1121,9 @@ def fetch_price(zone_key, session=None, target_datetime=None,
 
 
 def fetch_generation_forecast(zone_key, session=None, target_datetime=None,
-                              logger=logging.getLogger(__name__)):
+                              logger=logging.getLogger(__name__)) -> list:
     """
     Gets generation forecast for specified zone.
-    Returns a list of dictionaries.
     """
     if not session:
         session = requests.session()
@@ -1169,10 +1146,9 @@ def fetch_generation_forecast(zone_key, session=None, target_datetime=None,
 
 
 def fetch_consumption_forecast(zone_key, session=None, target_datetime=None,
-                               logger=logging.getLogger(__name__)):
+                               logger=logging.getLogger(__name__)) -> list:
     """
     Gets consumption forecast for specified zone.
-    Returns a list of dictionaries.
     """
     if not session:
         session = requests.session()
@@ -1195,12 +1171,10 @@ def fetch_consumption_forecast(zone_key, session=None, target_datetime=None,
 
 
 def fetch_wind_solar_forecasts(zone_key, session=None, target_datetime=None,
-                               logger=logging.getLogger(__name__)):
+                               logger=logging.getLogger(__name__)) -> list:
     """
-    Gets values and corresponding datetimes for all production types in the
-    specified zone. Removes any values that are in the future or don't have
-    a datetime associated with them.
-    Returns a list of dictionaries that have been validated.
+    Gets values and corresponding datetimes for all production types in the specified zone.
+    Removes any values that are in the future or don't have a datetime associated with them.
     """
     if not session:
         session = requests.session()

--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python3
 
 from urllib.parse import urlencode
 
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
 
 from .lib.exceptions import ParserException

--- a/parsers/ESIOS.py
+++ b/parsers/ESIOS.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from os import environ
 from urllib.parse import urlencode
 
 # The arrow library is used to handle datetimes

--- a/parsers/ES_CN.py
+++ b/parsers/ES_CN.py
@@ -1,16 +1,13 @@
-#!/usr/bin/env python3
 
 import logging
 
-# The arrow library is used to handle datetimes
 from arrow import get
-# The request library is used to fetch content through HTTP
-from requests import Session
-from ree import (ElHierro, GranCanaria, Gomera, LanzaroteFuerteventura,
+from ree import (ElHierro, Gomera, GranCanaria, LanzaroteFuerteventura,
                  LaPalma, Tenerife)
+from requests import Session
+
 from .lib.exceptions import ParserException
 from .lib.validation import validate
-
 
 # Minimum valid zone demand. This is used to eliminate some cases
 # where generation for one or more modes is obviously missing.

--- a/parsers/ES_IB.py
+++ b/parsers/ES_IB.py
@@ -1,17 +1,12 @@
-#!/usr/bin/env python3
 
 import logging
+
 from arrow import get
+from ree import BalearicIslands, Formentera, Ibiza, Mallorca, Menorca
 from requests import Session
-from ree import (Formentera, Ibiza,
-                 Mallorca, Menorca,
-                 BalearicIslands)
-# package "ree" is used to parse data from www.ree.es // maintained on github by @hectorespert
 
 from .lib.exceptions import ParserException
 from .lib.validation import validate, validate_production_diffs
-
-## Guess we'll need to figure these out later?! Adapted from ES-CN:
 
 # Minimum valid zone demand. This is used to eliminate some cases
 # where generation for one or more modes is obviously missing.

--- a/parsers/FO.py
+++ b/parsers/FO.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
-import arrow
-from .lib.validation import validate
 from logging import getLogger
+
+import arrow
 import requests
+
+from .lib.validation import validate
 
 MAP_GENERATION = {
     'Vand': 'hydro',

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -3,7 +3,6 @@
 import arrow
 import json
 import logging
-import os
 import math
 
 import pandas as pd

--- a/parsers/FR.py
+++ b/parsers/FR.py
@@ -1,16 +1,15 @@
-#!/usr/bin/env python3
 
-import arrow
 import json
 import logging
 import math
-
-import pandas as pd
-import requests
 import xml.etree.ElementTree as ET
 
-from .lib.validation import validate, validate_production_diffs
+import arrow
+import pandas as pd
+import requests
+
 from .lib.utils import get_token
+from .lib.validation import validate, validate_production_diffs
 
 API_ENDPOINT = 'https://opendata.reseaux-energies.fr/api/records/1.0/search/'
 

--- a/parsers/FR_O.py
+++ b/parsers/FR_O.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
-import arrow
 import json
 import logging
+
+import arrow
 import requests
 
 # APIs

--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python3
 
+import logging
 from datetime import datetime
 from io import StringIO
 
-import logging
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup

--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -116,10 +116,9 @@ def create_exchange_df(text_data):
     return df_exchange
 
 
-def production_processor(df):
+def production_processor(df) -> list:
     """
     Creates quarter hour datapoints for thermal production.
-    Returns a list.
     """
 
     datapoints = []
@@ -138,10 +137,9 @@ def production_processor(df):
     return datapoints
 
 
-def moyle_processor(df):
+def moyle_processor(df) -> list:
     """
     Creates quarter hour datapoints for GB exchange.
-    Returns a list.
     """
 
     datapoints = []
@@ -157,10 +155,9 @@ def moyle_processor(df):
     return datapoints
 
 
-def IE_processor(df):
+def IE_processor(df) -> list:
     """
     Creates quarter hour datapoints for IE exchange.
-    Returns a list.
     """
 
     datapoints = []
@@ -181,31 +178,6 @@ def fetch_production(zone_key='GB-NIR', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
-        Arguments:
-        zone_key (optional) -- used in case a parser is able to fetch multiple countries
-        session (optional)      -- request session passed in order to re-use an existing session
-        Return:
-        A dictionary in the form:
-        {
-          'zoneKey': 'FR',
-          'datetime': '2017-01-01T00:00:00Z',
-          'production': {
-              'biomass': 0.0,
-              'coal': 0.0,
-              'gas': 0.0,
-              'hydro': 0.0,
-              'nuclear': null,
-              'oil': 0.0,
-              'solar': 0.0,
-              'wind': 0.0,
-              'geothermal': 0.0,
-              'unknown': 0.0
-          },
-          'storage': {
-              'hydro': -10.0,
-          },
-          'source': 'mysource.com'
-        }
     """
 
     production_data = get_data(production_url, target_datetime)
@@ -234,18 +206,8 @@ def fetch_production(zone_key='GB-NIR', session=None, target_datetime=None,
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries
     """
 
     exchange_data = get_data(exchange_url, target_datetime)

--- a/parsers/GB_NIR.py
+++ b/parsers/GB_NIR.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 
-from collections import defaultdict
 from datetime import datetime
 from io import StringIO
-from operator import itemgetter
 
 import logging
 import pandas as pd

--- a/parsers/GB_ORK.py
+++ b/parsers/GB_ORK.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python3
-
 """Parser for the Orkney Islands"""
+
+import logging
 
 import arrow
 import dateutil
-import logging
 import requests
 from bs4 import BeautifulSoup
 

--- a/parsers/GB_ORK.py
+++ b/parsers/GB_ORK.py
@@ -73,31 +73,6 @@ def fetch_production(zone_key='GB-ORK', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
-        Arguments:
-        zone_key (optional) -- used in case a parser is able to fetch multiple countries
-        session (optional)  -- request session passed in order to re-use an existing session
-        Return:
-        A dictionary in the form:
-        {
-          'zoneKey': 'FR',
-          'datetime': '2017-01-01T00:00:00Z',
-          'production': {
-              'biomass': 0.0,
-              'coal': 0.0,
-              'gas': 0.0,
-              'hydro': 0.0,
-              'nuclear': null,
-              'oil': 0.0,
-              'solar': 0.0,
-              'wind': 0.0,
-              'geothermal': 0.0,
-              'unknown': 0.0
-          },
-          'storage': {
-              'hydro': -10.0,
-          },
-          'source': 'mysource.com'
-        }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -124,23 +99,8 @@ def fetch_production(zone_key='GB-ORK', session=None, target_datetime=None,
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=logging.getLogger(__name__)):
-    """Requests the last known power exchange (in MW) between two zones
-
-    Arguments:
-    zone_key1, zone_key2: specifies which exchange to get
-    session (optional): request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'CA-QC->US-NEISO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     sorted_zone_keys = '->'.join(sorted([zone_key1, zone_key2]))
     raw_data = get_json_data(session)

--- a/parsers/GCCIA.py
+++ b/parsers/GCCIA.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 # This parser returns Gulf Cooperation Council countries (United Arab Emirates, Bahrain, Saudi Arabia, Oman, Qatar, and Kuwait) electricity demand (only consumption, production data is not available)
@@ -9,10 +8,11 @@
 # Kuwait shares of Electricity production in 2017: 65.6% oil, 34.4% gas (source: IEA; https://www.iea.org/statistics/?country=KUWAIT&indicator=ElecGenByFuel)
 # TODO get this data for the other countries as well
 
-import arrow
-import requests
 import re
 from sys import stderr
+
+import arrow
+import requests
 
 COUNTRY_CODE_MAPPING = {
   'AE': 'uae',

--- a/parsers/GE.py
+++ b/parsers/GE.py
@@ -1,9 +1,11 @@
-import logging
+
 import datetime
-import pandas as pd
+import logging
 
 import arrow
+import pandas as pd
 import requests
+
 
 def fetch_production(zone_key='GE', session=None, target_datetime: datetime.datetime=None,
                      logger: logging.Logger=None):
@@ -194,4 +196,3 @@ if __name__ == '__main__':
     print(fetch_exchange('GE', 'RU'))
     print('fetch_exchange(GE, TR) ->')
     print(fetch_exchange('GE', 'TR'))
-    

--- a/parsers/GE.py
+++ b/parsers/GE.py
@@ -9,42 +9,8 @@ import requests
 
 def fetch_production(zone_key='GE', session=None, target_datetime: datetime.datetime=None,
                      logger: logging.Logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. If past data is not available, raise a NotImplementedError. Beware that the
-      provided target_datetime is UTC.
-    logger: an instance of a `logging.Logger`. Information logged will be publicly available so that
-      correct execution of the logger can be checked. All Exceptions will automatically be logged,
-      so when something's wrong, simply raise an Exception (with an explicit text). Use
-      `logger.warning` or `logger.info` for information that can useful to check if the parser is
-      working correctly.
-      
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     r = session or requests.session()
     
@@ -116,28 +82,8 @@ def fetch_production(zone_key='GE', session=None, target_datetime: datetime.date
 
 def fetch_exchange(zone_key1='GE', zone_key2='TR', session=None, target_datetime=None,
                    logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. If past data is not available, raise a NotImplementedError. Beware that the
-      provided target_datetime is UTC.
-    logger: an instance of a `logging.Logger`. Information logged will be publicly available so that
-      correct execution of the logger can be checked. All Exceptions will automatically be logged,
-      so when something's wrong, simply raise an Exception (with an explicit text). Use
-      `logger.warning` or `logger.info` for information that can useful to check if the parser is
-      working correctly.
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries
     """
     
     exch_map = {'AM->GE':'armeniaSum', 'AZ->GE':'azerbaijanSum',

--- a/parsers/GT.py
+++ b/parsers/GT.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
-import requests
-# The pandas library is used to manipulate real time data
 import pandas as pd
+import requests
 
 tz_gt = 'America/Guatemala'
 

--- a/parsers/HOPS.py
+++ b/parsers/HOPS.py
@@ -10,12 +10,11 @@ import requests
 URL = "https://www.hops.hr/Home/PowerExchange"
 
 
-def fetch_solar_production(feed_date, session=None, logger=logging.getLogger(__name__)):
+def fetch_solar_production(feed_date, session=None, logger=logging.getLogger(__name__)) -> float:
     """
     Calls extra resource at https://files.hrote.hr/files/EKO_BG/FORECAST/SOLAR/FTP/TEST_DRIVE/<dd.m.yyyy>.json
     to get Solar power production in MW.
     :param feed_date: date_time string from the original HOPS feed
-    :return: Float
     """
     r = session or requests.session()
 

--- a/parsers/HOPS.py
+++ b/parsers/HOPS.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python3
-
 """Parser for power production in Croatia"""
 
-import arrow
-import requests
 import logging
-import pandas as pd
-
 from datetime import datetime
+
+import arrow
+import pandas as pd
+import requests
 
 URL = "https://www.hops.hr/Home/PowerExchange"
 

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -13,6 +13,7 @@ import arrow
 import requests
 from bs4 import BeautifulSoup
 
+IEC_URL = "iec.co.il"
 IEC_PRODUCTION = (
     "https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx"
 )
@@ -30,7 +31,7 @@ def flatten_list(_2d_list):
             flat_list.append(element)
     return flat_list
 
-def fetch_production(zone_key="IL", session=None, logger=None):
+def fetch():
     first = requests.get(IEC_PRODUCTION)
     first.cookies
     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
@@ -47,21 +48,36 @@ def fetch_production(zone_key="IL", session=None, logger=None):
         cleaned_list = flatten_list(cleaned_list)
 
         int_list = [int(item) for item in cleaned_list]
+    return int_list
 
-        data = {
-            "zoneKey": zone_key,
-            "datetime": arrow.now("Asia/Jerusalem").datetime,
-            "production": int_list[0] + int_list[1],
-            "consumption": int_list[0],
-            "source": "iec.co.il",
-            "price": PRICE,
-        }
+def fetch_production(zone_key="IL", session=None, logger=None):
+    int_list = fetch()
+    data = {
+        "zoneKey": zone_key,
+        "datetime": arrow.now("Asia/Jerusalem").datetime,
+        "production": int_list[0] + int_list[1],
+        "source": IEC_URL,
+        "price": PRICE,
+    }
 
-        return data
+    return data
 
+def fetch_consumption(zone_key='IL', session=None, target_datetime=None, logger=None):
+    int_list = fetch()
+
+    data = {
+        'zoneKey': zone_key,
+        'datetime': arrow.now("Asia/Jerusalem").datetime,
+        'consumption': int_list[0],
+        'source': IEC_URL
+    }
+
+    return data
 
 if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print("fetch_production() ->")
     print(fetch_production())
+    print("fetch_consumption() ->")
+    print(fetch_consumption())

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -31,7 +31,8 @@ def fetch_production(zone_key='IL', session=None, logger=None):
         'zoneKey': zone_key,
         'datetime': arrow.now('Asia/Jerusalem').datetime,
         'production': production,
-        'source': 'iec.co.il'
+        'source': 'iec.co.il',
+        'price': '50.66' # Price is determined yearly
     }
 
     return datapoint

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -22,10 +22,8 @@ PRICE = "50.66"  # Price is determined yearly
 
 def flatten_list(_2d_list):
     flat_list = []
-    # Iterate through the outer list
     for element in _2d_list:
         if type(element) is list:
-            # If the element is of type list, iterate through the sublist
             for item in element:
                 flat_list.append(item)
         else:

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 # This parser returns Israel's electricity system load (assumed to be equal to electricity production)

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -33,6 +33,7 @@ def flatten_list(_2d_list):
 def fetch_production(zone_key="IL", session=None, logger=None):
     first = requests.get(IEC_PRODUCTION)
     first.cookies
+<<<<<<< HEAD
     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
         soup = BeautifulSoup(second.content, "lxml")
 
@@ -63,6 +64,24 @@ def fetch_production(zone_key="IL", session=None, logger=None):
         },
         "source": IEC_URL,
         "price": PRICE,
+=======
+    second = requests.get(IEC_PRODUCTION, cookies=first.cookies)
+
+    soup = BeautifulSoup(second.content, 'lxml')
+
+    span = soup.find("span", attrs={"class": "statusVal"})
+    value = re.findall("\d+", span.text.replace(",", ""))
+    load = int(value[0])
+    production = {}
+    production['unknown'] = load
+    
+    datapoint = {
+        'zoneKey': zone_key,
+        'datetime': arrow.now('Asia/Jerusalem').datetime,
+        'production': production,
+        'source': 'iec.co.il',
+        'price': '50.66' # Price is determined yearly
+>>>>>>> 0a521ef9 (Add price)
     }
 
     return data

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -31,7 +31,26 @@ def flatten_list(_2d_list):
             flat_list.append(element)
     return flat_list
 
-def fetch():
+# def fetch():
+#     first = requests.get(IEC_PRODUCTION)
+#     first.cookies
+#     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
+#         soup = BeautifulSoup(second.content, "lxml")
+
+#         values:list = soup.find_all("span", class_='statusVal')
+#         del values[1]
+
+#         cleaned_list = []
+#         for value in values:
+#             value = re.findall("\d+", value.text.replace(",", ""))
+#             cleaned_list.append(value)
+
+#         cleaned_list = flatten_list(cleaned_list)
+
+#         int_list = [int(item) for item in cleaned_list]
+#     return int_list
+
+def fetch_production(zone_key="IL", session=None, logger=None):
     first = requests.get(IEC_PRODUCTION)
     first.cookies
     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
@@ -48,36 +67,44 @@ def fetch():
         cleaned_list = flatten_list(cleaned_list)
 
         int_list = [int(item) for item in cleaned_list]
-    return int_list
 
-def fetch_production(zone_key="IL", session=None, logger=None):
-    int_list = fetch()
     data = {
         "zoneKey": zone_key,
         "datetime": arrow.now("Asia/Jerusalem").datetime,
-        "production": int_list[0] + int_list[1],
+        'production': {
+            'biomass': 0.0,
+            'coal':  0.0,
+            'gas':  0.0,
+            'oil': 0.0,
+            'solar':  0.0,
+            'wind':  0.0,
+            'geothermal': 0.0,
+            'unknown': int_list[0] + int_list[1]
+            },
         "source": IEC_URL,
         "price": PRICE,
     }
 
     return data
 
-def fetch_consumption(zone_key='IL', session=None, target_datetime=None, logger=None):
-    int_list = fetch()
+# def fetch_consumption(zone_key='IL', session=None, target_datetime=None, logger=None):
+#     int_list = fetch()
 
-    data = {
-        'zoneKey': zone_key,
-        'datetime': arrow.now("Asia/Jerusalem").datetime,
-        'consumption': int_list[0],
-        'source': IEC_URL
-    }
+#     load = int_list[0]
+#     consumption = {}
+#     consumption['unknown'] = load
 
-    return data
+#     data = {
+#         'zoneKey': zone_key,
+#         'datetime': arrow.now("Asia/Jerusalem").datetime,
+#         'consumption': consumption,
+#         'source': IEC_URL
+#     }
+
+#     return data
 
 if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print("fetch_production() ->")
     print(fetch_production())
-    print("fetch_consumption() ->")
-    print(fetch_consumption())

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -12,11 +12,12 @@ import requests
 import re
 from bs4 import BeautifulSoup
 
+IEC_PRODUCTION = 'https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx'
 
 def fetch_production(zone_key='IL', session=None, logger=None):
-    first = requests.get('https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx')
+    first = requests.get(IEC_PRODUCTION)
     first.cookies
-    second = requests.get('https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx', cookies=first.cookies)
+    second = requests.get(IEC_PRODUCTION, cookies=first.cookies)
 
     soup = BeautifulSoup(second.content, 'lxml')
 

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -7,12 +7,14 @@
 # Shares of Electricity production in 2018: 65.6% oil, 34.4% gas (source: IEA; https://www.iea.org/data-and-statistics?country=ISRAEL&fuel=Electricity%20and%20heat&indicator=Electricity%20generation%20by%20source)
 
 
+import re
+
 import arrow
 import requests
-import re
 from bs4 import BeautifulSoup
 
 IEC_PRODUCTION = 'https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx'
+PRICE = '50.66' # Price is determined yearly
 
 def fetch_production(zone_key='IL', session=None, logger=None):
     first = requests.get(IEC_PRODUCTION)
@@ -32,7 +34,7 @@ def fetch_production(zone_key='IL', session=None, logger=None):
         'datetime': arrow.now('Asia/Jerusalem').datetime,
         'production': production,
         'source': 'iec.co.il',
-        'price': '50.66' # Price is determined yearly
+        'price': PRICE
     }
 
     return datapoint

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -19,6 +19,7 @@ IEC_PRODUCTION = (
 )
 PRICE = "50.66"  # Price is determined yearly
 
+
 def flatten_list(_2d_list):
     flat_list = []
     # Iterate through the outer list
@@ -31,24 +32,6 @@ def flatten_list(_2d_list):
             flat_list.append(element)
     return flat_list
 
-# def fetch():
-#     first = requests.get(IEC_PRODUCTION)
-#     first.cookies
-#     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
-#         soup = BeautifulSoup(second.content, "lxml")
-
-#         values:list = soup.find_all("span", class_='statusVal')
-#         del values[1]
-
-#         cleaned_list = []
-#         for value in values:
-#             value = re.findall("\d+", value.text.replace(",", ""))
-#             cleaned_list.append(value)
-
-#         cleaned_list = flatten_list(cleaned_list)
-
-#         int_list = [int(item) for item in cleaned_list]
-#     return int_list
 
 def fetch_production(zone_key="IL", session=None, logger=None):
     first = requests.get(IEC_PRODUCTION)
@@ -56,7 +39,7 @@ def fetch_production(zone_key="IL", session=None, logger=None):
     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
         soup = BeautifulSoup(second.content, "lxml")
 
-        values:list = soup.find_all("span", class_="statusVal")
+        values: list = soup.find_all("span", class_="statusVal")
         del values[1]
 
         cleaned_list = []
@@ -72,20 +55,21 @@ def fetch_production(zone_key="IL", session=None, logger=None):
         "zoneKey": zone_key,
         "datetime": arrow.now("Asia/Jerusalem").datetime,
         "production": {
-            'biomass': 0.0,
-            'coal':  0.0,
-            'gas':  0.0,
-            'oil': 0.0,
-            'solar':  0.0,
-            'wind':  0.0,
-            'geothermal': 0.0,
-            'unknown': int_list[0] + int_list[1]
-            },
+            "biomass": 0.0,
+            "coal": 0.0,
+            "gas": 0.0,
+            "oil": 0.0,
+            "solar": 0.0,
+            "wind": 0.0,
+            "geothermal": 0.0,
+            "unknown": int_list[0] + int_list[1],
+        },
         "source": IEC_URL,
         "price": PRICE,
     }
 
     return data
+
 
 # def fetch_consumption(zone_key='IL', session=None, target_datetime=None, logger=None):
 #     int_list = fetch()

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -13,35 +13,38 @@ import arrow
 import requests
 from bs4 import BeautifulSoup
 
-IEC_PRODUCTION = 'https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx'
-PRICE = '50.66' # Price is determined yearly
+IEC_PRODUCTION = (
+    "https://www.iec.co.il/_layouts/iec/applicationpages/lackmanagment.aspx"
+)
+PRICE = "50.66"  # Price is determined yearly
 
-def fetch_production(zone_key='IL', session=None, logger=None):
+
+def fetch_production(zone_key="IL", session=None, logger=None):
     first = requests.get(IEC_PRODUCTION)
     first.cookies
     second = requests.get(IEC_PRODUCTION, cookies=first.cookies)
 
-    soup = BeautifulSoup(second.content, 'lxml')
+    soup = BeautifulSoup(second.content, "lxml")
 
     span = soup.find("span", attrs={"class": "statusVal"})
     value = re.findall("\d+", span.text.replace(",", ""))
     load = int(value[0])
     production = {}
-    production['unknown'] = load
-    
+    production["unknown"] = load
+
     datapoint = {
-        'zoneKey': zone_key,
-        'datetime': arrow.now('Asia/Jerusalem').datetime,
-        'production': production,
-        'source': 'iec.co.il',
-        'price': PRICE
+        "zoneKey": zone_key,
+        "datetime": arrow.now("Asia/Jerusalem").datetime,
+        "production": production,
+        "source": "iec.co.il",
+        "price": PRICE,
     }
 
     return datapoint
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
-    
-    print('fetch_production() ->')
+
+    print("fetch_production() ->")
     print(fetch_production())

--- a/parsers/IL.py
+++ b/parsers/IL.py
@@ -56,7 +56,7 @@ def fetch_production(zone_key="IL", session=None, logger=None):
     with requests.get(IEC_PRODUCTION, cookies=first.cookies) as second:
         soup = BeautifulSoup(second.content, "lxml")
 
-        values:list = soup.find_all("span", class_='statusVal')
+        values:list = soup.find_all("span", class_="statusVal")
         del values[1]
 
         cleaned_list = []
@@ -71,7 +71,7 @@ def fetch_production(zone_key="IL", session=None, logger=None):
     data = {
         "zoneKey": zone_key,
         "datetime": arrow.now("Asia/Jerusalem").datetime,
-        'production': {
+        "production": {
             'biomass': 0.0,
             'coal':  0.0,
             'gas':  0.0,

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -15,10 +15,9 @@ GENERATION_MAPPING = {'THERMAL GENERATION': 'coal',
 GENERATION_URL = 'http://meritindia.in/Dashboard/BindAllIndiaMap'
 
 
-def get_data(session):
+def get_data(session) -> dict:
     """
     Requests html then extracts generation data.
-    Returns a dictionary.
     """
 
     s = session or requests.Session()
@@ -42,31 +41,6 @@ def get_data(session):
 def fetch_production(zone_key = 'IN', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     if target_datetime is not None:

--- a/parsers/IN.py
+++ b/parsers/IN.py
@@ -1,9 +1,8 @@
-#!usr/bin/env python3
-
 """Parser for all of India"""
 
-import arrow
 import logging
+
+import arrow
 import requests
 from bs4 import BeautifulSoup
 

--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -5,7 +5,7 @@ from .lib import IN, web, zonekey
 
 
 def fetch_production(zone_key='IN-AP', session=None, target_datetime=None, logger=None):
-    """Fetch Andhra Pradesh  production"""
+    """Fetch Andhra Pradesh production"""
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
 

--- a/parsers/IN_AP.py
+++ b/parsers/IN_AP.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
 
 from requests import Session
-from .lib import zonekey, IN, web
+
+from .lib import IN, web, zonekey
 
 
 def fetch_production(zone_key='IN-AP', session=None, target_datetime=None, logger=None):

--- a/parsers/IN_CT.py
+++ b/parsers/IN_CT.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python3
 
 from requests import Session
-from .lib import web
-from .lib import zonekey
-from .lib import IN
+
+from .lib import IN, web, zonekey
 
 
 def fetch_consumption(zone_key='IN-CT', session=None, target_datetime=None, logger=None):

--- a/parsers/IN_CT.py
+++ b/parsers/IN_CT.py
@@ -27,10 +27,11 @@ def fetch_consumption(zone_key='IN-CT', session=None, target_datetime=None, logg
 
 
 def fetch_production(zone_key='IN-CT', session=None, target_datetime=None, logger=None):
+    """Fetch Chhattisgarh production."""
+
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
 
-    """Fetch Chhattisgarh production"""
     zonekey.assert_zone_key(zone_key, 'IN-CT')
 
     html = web.get_response_soup(zone_key, 'http://117.239.199.203/csptcl/GEN.aspx', session)

--- a/parsers/IN_DL.py
+++ b/parsers/IN_DL.py
@@ -1,9 +1,7 @@
-#!/usr/bin/env python3
 
 from requests import Session
-from .lib import web
-from .lib import zonekey
-from .lib import IN
+
+from .lib import IN, web, zonekey
 
 plants = {
     "CCGT-Bawana": "Gas",

--- a/parsers/IN_GJ.py
+++ b/parsers/IN_GJ.py
@@ -135,34 +135,6 @@ def fetch_production(zone_key='IN-GJ', session=None, target_datetime=None,
                      logger=getLogger('IN-GJ')):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key: specifies which zone to get
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     session = session or requests.session()
     if target_datetime:

--- a/parsers/IN_GJ.py
+++ b/parsers/IN_GJ.py
@@ -6,7 +6,7 @@ from operator import itemgetter
 import arrow
 import requests
 import itertools
-from .lib import zonekey, web, IN
+from .lib import zonekey, web
 from .lib.validation import validate
 from logging import getLogger
 

--- a/parsers/IN_GJ.py
+++ b/parsers/IN_GJ.py
@@ -1,14 +1,15 @@
-#!/usr/bin/env python3
 
-import re
 import collections
+import itertools
+import re
+from logging import getLogger
 from operator import itemgetter
+
 import arrow
 import requests
-import itertools
-from .lib import zonekey, web
+
+from .lib import web, zonekey
 from .lib.validation import validate
-from logging import getLogger
 
 SLDCGUJ_URL = 'http://www.sldcguj.com/RealTimeData/PrintPage.php?page=realtimedemand.php'
 

--- a/parsers/IN_HP.py
+++ b/parsers/IN_HP.py
@@ -88,8 +88,10 @@ def fetch_production(zone_key=ZONE_KEY, session=None,
 
 
 def get_state_gen(soup, logger: logging.Logger):
-    """Gets the total generation by type from state powerplants (MW).
-    Data is from the table titled GENERATION OF HP(Z)"""
+    """
+    Gets the total generation by type from state powerplants (MW).
+    Data is from the table titled GENERATION OF HP(Z)
+    """
     table_name = 'GENERATION OF HP(Z)'
     gen = {GenType.HYDRO.value: 0.0, GenType.UNKNOWN.value: 0.0}
     # Read all rows except the last (Total).
@@ -106,9 +108,11 @@ def get_state_gen(soup, logger: logging.Logger):
 
 
 def get_isgs_gen(soup, logger: logging.Logger):
-    """Gets the total generation by type from ISGS powerplants (MW).
+    """
+    Gets the total generation by type from ISGS powerplants (MW).
     ISGS means Inter-State Generating Station: one owned by multiple states.
-    Data is from the table titled (B1)ISGS(HPSLDC WEB PORTAL)"""
+    Data is from the table titled (B1)ISGS(HPSLDC WEB PORTAL)
+    """
     table_name = '(B1)ISGS(HPSLDC WEB PORTAL)'
     gen = {GenType.HYDRO.value: 0.0, GenType.UNKNOWN.value: 0.0}
     # Read all rows except the first (headers) and last two (OTHERISGS and Total).
@@ -142,9 +146,11 @@ def get_table_rows(soup, container_class, table_name):
 
 
 def combine_gen(gen1, gen2):
-    """Combines two dictionaries of generation data.
+    """
+    Combines two dictionaries of generation data.
     Currently only does Hydro and Unknown as there are
-    no other types in the data source."""
+    no other types in the data source.
+    """
     return {
         GenType.HYDRO.value: round(gen1[GenType.HYDRO.value] + gen2[GenType.HYDRO.value], 2),
         GenType.UNKNOWN.value: round(gen1[GenType.UNKNOWN.value] +

--- a/parsers/IN_HP.py
+++ b/parsers/IN_HP.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Parser for Himachal Pradesh (Indian State)."""
 
 import datetime
@@ -9,7 +7,6 @@ from enum import Enum
 import arrow
 import requests
 from bs4 import BeautifulSoup
-
 
 DATA_URL = 'https://hpsldc.com/intra-state-power-transaction/'
 ZONE_KEY = 'IN-HP'

--- a/parsers/IN_KA.py
+++ b/parsers/IN_KA.py
@@ -1,10 +1,8 @@
-#!/usr/bin/env python3
 
 from requests import Session
+
+from .lib import IN, web, zonekey
 from .lib.exceptions import ParserException
-from .lib import web
-from .lib import zonekey
-from .lib import IN
 
 
 def fetch_consumption(zone_key='IN-KA', session=None, target_datetime=None, logger=None):

--- a/parsers/IN_MH.py
+++ b/parsers/IN_MH.py
@@ -1,10 +1,12 @@
-from PIL import Image, ImageOps
-import pytesseract
-import cv2
-from imageio import imread
-import numpy as np
-import arrow
+
 import logging
+
+import arrow
+import cv2
+import numpy as np
+import pytesseract
+from imageio import imread
+from PIL import Image, ImageOps
 
 url = 'https://mahasldc.in/wp-content/reports/sldc/mvrreport3.jpg'
 

--- a/parsers/IN_PB.py
+++ b/parsers/IN_PB.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python3
+
+from collections import defaultdict
 
 import arrow
 import requests
-from collections import defaultdict
-
 
 GENERATION_URL = "http://www.pstcl.org:9091/scadadata/pbGenData2"
 

--- a/parsers/IN_PB.py
+++ b/parsers/IN_PB.py
@@ -26,33 +26,6 @@ def calculate_average_timestamp(timestamps):
 def fetch_production(zone_key='IN-PB', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('The IN-PB production parser is not yet able to parse past dates')
@@ -90,19 +63,6 @@ def fetch_production(zone_key='IN-PB', session=None, target_datetime=None, logge
 def fetch_consumption(zone_key='IN-PB', session=None, target_datetime=None, logger=None):
     """
     Requests the last known consumption (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': 2832.5,
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('The IN-PB consumption parser is not yet able to parse past dates')

--- a/parsers/IN_UP.py
+++ b/parsers/IN_UP.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python3
+
 import json
 from ast import literal_eval
+
 import arrow
 from requests import Session
 

--- a/parsers/IN_UT.py
+++ b/parsers/IN_UT.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python3
 
-import arrow
 import logging
 
-from .lib import web
+import arrow
 
+from .lib import web
 
 ENDPOINT = 'http://uksldc.in/real-time-data.php'
 

--- a/parsers/IQ.py
+++ b/parsers/IQ.py
@@ -46,34 +46,8 @@ def fetch_production(
     target_datetime=None,
     logger=logging.getLogger(__name__),
 ):
-    """Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day, a string in the form YYYYMMDD
-    logger (optional) -- handles logging when parser is run
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given zone
     """
     if target_datetime is not None:
         raise NotImplementedError("This parser is not yet able to parse past dates")

--- a/parsers/IQ.py
+++ b/parsers/IQ.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python3
-
 """Parser for the electricity grid of Iraq"""
 
-import arrow
 import logging
-from dateutil.tz import tz
-import requests
 
+import arrow
+import requests
+from dateutil.tz import tz
 
 LIVE_PRODUCTION_API_URL = "https://www.gdoco.org/vueips.php"
 DATA_SOURCE = "www.gdoco.org"

--- a/parsers/IS.py
+++ b/parsers/IS.py
@@ -1,15 +1,9 @@
-#!python3
-import logging
+
 import datetime
+import logging
 
-# The arrow library is used to handle datetimes
 import arrow
-
-# The request library is used to fetch content through HTTP
 import requests
-
-# please try to write PEP8 compliant code (use a linter). One of PEP8's
-# requirement is to limit your line length to 79 characters.
 
 
 def fetch_production(

--- a/parsers/IS.py
+++ b/parsers/IS.py
@@ -12,53 +12,8 @@ def fetch_production(
     target_datetime: datetime.datetime = None,
     logger: logging.Logger = logging.getLogger(__name__),
 ):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'zoneKey': 'IS',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     r = session or requests.session()
     if target_datetime is None:
@@ -92,8 +47,7 @@ def fetch_production(
 
 
 if __name__ == "__main__":
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print("fetch_production() ->")
     print(fetch_production())

--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -12,53 +12,8 @@ from . import occtonet
 
 def fetch_production(zone_key='JP-KY', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given zone
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given zone
     """
     if target_datetime:
         raise NotImplementedError(

--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python3
 # coding=utf-8
-import logging
-# The arrow library is used to handle datetimes
-import arrow
-# The request library is used to fetch content through HTTP
-import requests
 
+import logging
 import re
+
+import arrow
+import requests
 from bs4 import BeautifulSoup
 
 from . import occtonet

--- a/parsers/JP-KY.py
+++ b/parsers/JP-KY.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
 import logging
-import datetime
 # The arrow library is used to handle datetimes
 import arrow
 # The request library is used to fetch content through HTTP
@@ -9,8 +8,6 @@ import requests
 
 import re
 from bs4 import BeautifulSoup
-import pandas as pd
-import numpy as np
 
 from . import occtonet
 

--- a/parsers/JP.py
+++ b/parsers/JP.py
@@ -1,10 +1,11 @@
-#!/usr/bin/env python3
 # coding=utf-8
-import logging
-# The arrow library is used to handle datetimes
-import arrow
+
 import datetime as dt
+import logging
+
+import arrow
 import pandas as pd
+
 from parsers import occtonet
 
 # Abbreviations

--- a/parsers/JP_ISEP.py
+++ b/parsers/JP_ISEP.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
-import re
-import logging
-import requests
+
 import datetime
+import logging
+import re
 
 import pandas as pd
+import requests
 
 url = 'https://isep-energychart.com/en/graphics/electricityproduction/?region={region}&period_year={year}&period_month={month}&period_day={day}&period_length=1day&display_format=residual_demand'
 timezone = 'Japan'

--- a/parsers/JP_ISEP.py
+++ b/parsers/JP_ISEP.py
@@ -73,53 +73,8 @@ def process_data(df):
 def fetch_production(zone_key='JP', session=None,
                      target_datetime: datetime.datetime = None,
                      logger: logging.Logger = logging.getLogger(__name__)):
-    """Requests the historic production mix (in MW) of japan
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the historic production mix (in MW) of japan
     """
     if target_datetime is None:
         # This data is only available with approx 4 month delay
@@ -164,39 +119,8 @@ def fetch_production(zone_key='JP', session=None,
 def fetch_consumption(zone_key='JP', session=None,
                      target_datetime: datetime.datetime = None,
                      logger: logging.Logger = logging.getLogger(__name__)):
-    """Requests the historic consumption mix (in MW) of japan
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'consumption': 10.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the historic consumption mix (in MW) of japan
     """
     if target_datetime is None:
         # This data is only available with approx 4 month delay
@@ -228,8 +152,7 @@ def fetch_consumption(zone_key='JP', session=None,
 
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')
     print(fetch_production(target_datetime=pd.Timestamp('2019-01-01')))

--- a/parsers/JP_ISEP.py
+++ b/parsers/JP_ISEP.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-import os
 import re
-import json
 import logging
 import requests
 import datetime

--- a/parsers/JP_KN.py
+++ b/parsers/JP_KN.py
@@ -1,23 +1,17 @@
-#!/usr/bin/env python3
-import logging
+
 import datetime
+import logging
+import re
+from io import BytesIO
+from urllib.request import Request, urlopen
 
-
+import arrow
+import requests
+from bs4 import BeautifulSoup
 from PIL import Image
 from pytesseract import image_to_string
-from bs4 import BeautifulSoup
-from urllib.request import urlopen, Request
-from io import BytesIO
-import re
 
-# The arrow library is used to handle datetimes
-import arrow
-# The request library is used to fetch content through HTTP
-import requests
 from .JP import fetch_production as JP_fetch_production
-
-# please try to write PEP8 compliant code (use a linter). One of PEP8's
-# requirement is to limit your line length to 79 characters.
 
 
 def fetch_production(zone_key='JP-KN', session=None,

--- a/parsers/JP_KN.py
+++ b/parsers/JP_KN.py
@@ -136,8 +136,7 @@ def get_nuclear_production():
 
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')
     print(fetch_production())

--- a/parsers/KR.py
+++ b/parsers/KR.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
+
+import re
+from logging import getLogger
 
 import arrow
-import re
 import requests
 from bs4 import BeautifulSoup
-from logging import getLogger
 
 LOAD_URL = 'http://kpx.or.kr/eng/index.do'
 

--- a/parsers/KR.py
+++ b/parsers/KR.py
@@ -76,8 +76,7 @@ def check_hydro_capacity(plant_name, value, logger):
         return True
 
 
-def fetch_hydro(session, logger):
-    """Returns 2 element tuple in form (float, arrow object)."""
+def fetch_hydro(session, logger) -> tuple:
     req = session.get(HYDRO_URL, verify=False)
     soup = BeautifulSoup(req.content, 'html.parser')
     table = soup.find("div", {"class": "dep02Sec"})
@@ -113,8 +112,7 @@ def fetch_hydro(session, logger):
     return total, dt
 
 
-def fetch_nuclear(session):
-    """Returns 2 element tuple in form (float, arrow object)."""
+def fetch_nuclear(session) -> tuple:
     plant_dts = []
     total = 0.0
     for url in NUCLEAR_URLS:
@@ -147,8 +145,7 @@ def fetch_nuclear(session):
     return total, dt
 
 
-def fetch_load(session):
-    """Returns 2 element tuple in form (float, arrow object)."""
+def fetch_load(session) -> tuple:
     req = session.get(LOAD_URL)
     soup = BeautifulSoup(req.content, 'html.parser')
 
@@ -174,33 +171,6 @@ def fetch_load(session):
 def fetch_production(zone_key = 'KR', session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 # This parser returns Kuwait's electricity system load (assumed to be equal to electricity production)
@@ -7,9 +6,11 @@
 # Scroll down to see the system load gauge
 # Shares of Electricity production in 2017: 65.6% oil, 34.4% gas (source: IEA; https://www.iea.org/statistics/?country=KUWAIT&indicator=ElecGenByFuel)
 
+import re
+
 import arrow
 import requests
-import re
+
 
 def fetch_production(zone_key='KW', target_datetime=None, session=None, logger=None):
     if target_datetime:

--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -38,34 +38,8 @@ def get_data(session=None):
 
 
 def fetch_production(zone_key='MD', session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -94,20 +68,8 @@ def fetch_production(zone_key='MD', session=None, target_datetime=None, logger=N
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two countries
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
 """Parser for Moldova."""
 
-import arrow
 from operator import itemgetter
+
+import arrow
 import requests
 
 TYPE_MAPPING = {

--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -1,15 +1,13 @@
-#!/usr/bin/env python3
 
-import arrow
 import datetime
-import requests
 import urllib
-import pandas as pd
-
-from bs4 import BeautifulSoup
-from dateutil import tz
 from io import StringIO
 
+import arrow
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+from dateutil import tz
 
 MX_PRODUCTION_URL = "https://www.cenace.gob.mx/SIM/VISTA/REPORTES/EnergiaGenLiqAgregada.aspx"
 MX_EXCHANGE_URL = 'https://www.cenace.gob.mx/Paginas/Publicas/Info/DemandaRegional.aspx'

--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -2,14 +2,12 @@
 
 import arrow
 import datetime
-import pandas
 import requests
 import urllib
 import pandas as pd
 
 from bs4 import BeautifulSoup
-from collections import defaultdict
-from dateutil import tz, parser
+from dateutil import tz
 from io import StringIO
 
 

--- a/parsers/MX.py
+++ b/parsers/MX.py
@@ -141,10 +141,9 @@ def fetch_production(zone_key, session=None, target_datetime=None, logger=None):
     return data
 
 
-def fetch_MX_exchange(sorted_zone_keys, s):
+def fetch_MX_exchange(sorted_zone_keys, s) -> float:
     """
     Finds current flow between two Mexican control areas.
-    Returns a float.
     """
 
     req = s.get(MX_EXCHANGE_URL)
@@ -167,21 +166,8 @@ def fetch_MX_exchange(sorted_zone_keys, s):
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None,
                    logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1: the first country code
-    zone_key2: the second country code; order of the two codes in params
-      doesn't matter
-    session: request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     sorted_zone_keys = '->'.join(sorted([zone_key1, zone_key2]))
 

--- a/parsers/MY_WM.py
+++ b/parsers/MY_WM.py
@@ -1,18 +1,18 @@
-#!/usr/bin/env python3
 
 # Parser for Peninsular Malaysia (West Malaysia).
 # This does not include the states of Sarawak and Sarawak.
 # There is pumped storage in the Peninsular but no data is currently available.
 # https://www.scribd.com/document/354635277/Doubling-Up-in-Malaysia-International-Water-Power
 
-from bs4 import BeautifulSoup
-from collections import defaultdict
 import datetime
-from dateutil import parser
+from collections import defaultdict
 from logging import getLogger
-from pytz import timezone
-import requests
 from xml.etree import ElementTree
+
+import requests
+from bs4 import BeautifulSoup
+from dateutil import parser
+from pytz import timezone
 
 fuel_mix_url = 'https://www.gso.org.my/SystemData/FuelMix.aspx'
 current_gen_url = 'https://www.gso.org.my/SystemData/CurrentGen.aspx'

--- a/parsers/MY_WM.py
+++ b/parsers/MY_WM.py
@@ -30,12 +30,11 @@ fuel_mapping = {
 }
 
 
-def get_data(session=None):
+def get_data(session=None) -> tuple:
     """
     Makes two requests for the current generation total and fuel mix.
     Parses the data into raw form and reads time string associated with it.
     Checks that fuel mix sum is equal to generation total.
-    Returns a tuple.
     """
 
     s = session or requests.Session()
@@ -80,10 +79,9 @@ def convert_time_str(ts):
     return dt_aware
 
 
-def data_processer(rawdata, logger):
+def data_processer(rawdata, logger) -> tuple:
     """
     Takes in raw data and converts it into a usable form.
-    Returns a tuple.
     """
 
     converted_time_string = convert_time_str(rawdata[0])
@@ -119,31 +117,6 @@ def data_processer(rawdata, logger):
 def fetch_production(zone_key='MY-WM', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': 0.0,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': None,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -164,10 +137,9 @@ def fetch_production(zone_key='MY-WM', session=None, target_datetime=None, logge
     return production
 
 
-def extract_hidden_values(req):
+def extract_hidden_values(req) -> dict:
     """
     Gets current aspx page values to enable post requests to be sent.
-    Returns a dictionary.
     """
 
     soup = BeautifulSoup(req.content, 'html.parser')
@@ -284,20 +256,8 @@ def zip_and_merge(egat_data, hvdc_data, logger):
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=getLogger(__name__)):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
 
     if target_datetime is not None:

--- a/parsers/NG.py
+++ b/parsers/NG.py
@@ -36,34 +36,8 @@ def fetch_production(
     target_datetime=None,
     logger=logging.getLogger(__name__),
 ):
-    """Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day, a string in the form YYYYMMDD
-    logger (optional) -- handles logging when parser is run
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given zone
     """
 
     if target_datetime is not None:

--- a/parsers/NG.py
+++ b/parsers/NG.py
@@ -1,12 +1,10 @@
-#!/usr/bin/env python3
-
 """Parser for the electricity grid of Nigeria"""
 
-import arrow
 import logging
+
+import arrow
 import requests
 from bs4 import BeautifulSoup
-
 
 LIVE_PRODUCTION_API_URL = "https://www.niggrid.org/GenerationLoadProfileBinary?readingDate={0}&readingTime={1}"
 TYPE_MAPPING = {"hydro": "hydro", "gas": "gas", "gas/steam": "gas", "steam": "gas"}

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -89,7 +89,7 @@ def get_time_from_system_map(text):
     return datetime_datetime
 
 
-def get_production_from_map(requests_obj):
+def get_production_from_map(requests_obj) -> tuple:
     """
     Get frequently-updated information on MAP_URL.
     This page is programmed to refresh every 10 seconds, and the timestamp
@@ -97,8 +97,6 @@ def get_production_from_map(requests_obj):
 
     However, it seems to bundle in solar generation with generation at another plant.
     get_production_from_summary() includes solar explictly.
-
-    :return: tuple(production, datetime_datetime)
     """
 
     response = requests_obj.get(MAP_URL)
@@ -123,7 +121,7 @@ def get_production_from_map(requests_obj):
     return production, data_datetime
 
 
-def get_production_from_summary(requests_obj):
+def get_production_from_summary(requests_obj) -> tuple:
     """
     Get information from SUMMARY_URL. This is updated once an hour, on the hour.
 
@@ -132,8 +130,6 @@ def get_production_from_summary(requests_obj):
 
     However, unlike get_production_from_map(), this includes solar generation,
     which, although small, is nice to specify.
-
-    :return: tuple(production, datetime_datetime)
     """
 
     type_translator = {
@@ -228,23 +224,8 @@ def fetch_production(zone_key='NI', session=None, target_datetime=None, logger=g
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=getLogger(__name__)):
-    """Requests the last known power exchange (in MW) between two regions
-
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the 2nd country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two regions
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -288,30 +269,8 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
 
 def fetch_price(zone_key='NI', session=None, target_datetime=None, logger=getLogger(__name__)):
-    """Requests the most recent known power prices in Nicaragua grid
-
-    Arguments:
-    zone_key (optional) -- ignored, only information for Nicaragua is returned
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A list of dictionaries in the form:
-    [
-        {
-          'zoneKey': 'FR',
-          'currency': EUR,
-          'datetime': '2017-01-01T01:00:00Z',
-          'price': 0.0,
-          'source': 'mysource.com'
-        },
-        {
-          'zoneKey': 'FR',
-          'currency': EUR,
-          'datetime': '2017-01-01T00:00:00Z',
-          'price': 0.0,
-          'source': 'mysource.com'
-        }
-    ]
+    """
+    Requests the most recent known power prices in Nicaragua grid
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/NI.py
+++ b/parsers/NI.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
-import arrow
 from collections import defaultdict
-from .lib.validation import validate
 from logging import getLogger
+
+import arrow
 import requests
+
+from .lib.validation import validate
 
 TIMEZONE = 'America/Managua'
 

--- a/parsers/NL.py
+++ b/parsers/NL.py
@@ -1,14 +1,12 @@
-#!/usr/bin/env python3
 
-import arrow
+import logging
 import math
 
-from . import statnett
-from . import ENTSOE
-from . import DK
-import logging
+import arrow
 import pandas as pd
 import requests
+
+from . import DK, ENTSOE, statnett
 
 
 def fetch_production(zone_key='NL', session=None, target_datetime=None,

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -25,30 +25,8 @@ def fetch(session=None):
 
 
 def fetch_production(zone_key=None, session=None, target_datetime=None, logger=None):
-    """Requests the last known production mix (in MW) of a given zone
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given zone
     """
     if target_datetime:
         raise NotImplementedError('This parser is not able to retrieve data for past dates')
@@ -97,16 +75,8 @@ def fetch_production(zone_key=None, session=None, target_datetime=None, logger=N
 
 def fetch_exchange(zone_key1='NZ-NZN', zone_key2='NZ-NZS', session=None, target_datetime=None,
                    logger=None):
-    """Requests the last known power exchange (in MW) between New Zealand's two islands
-
-    Return:
-    A list of dictionaries in the form:
-    [{
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }]
+    """
+    Requests the last known power exchange (in MW) between New Zealand's two islands
     """
     if target_datetime:
         raise NotImplementedError('This parser is not able to retrieve data for past dates')

--- a/parsers/NZ.py
+++ b/parsers/NZ.py
@@ -1,11 +1,8 @@
-#!/usr/bin/env python3
-
-# The arrow library is used to handle datetimes
-import arrow
-# The request library is used to fetch content through HTTP
-import requests
 
 import json
+
+import arrow
+import requests
 from bs4 import BeautifulSoup
 
 timezone = 'Pacific/Auckland'

--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -100,7 +100,8 @@ def fetch_main_df(data_type, zone_key=None, sorted_zone_keys=None, session=None,
     df = pd.concat([dataset_to_df(ds) for ds in filtered_datasets], axis=1)
     if data_type == 'power' and zone_key:
         # SOLAR_ROOFTOP is only given at 30 min interval, so let's interpolate it
-        df['SOLAR_ROOFTOP'] = df['SOLAR_ROOFTOP'].interpolate(limit=5)
+        if 'SOLAR_ROOFTOP' in df:
+            df['SOLAR_ROOFTOP'] = df['SOLAR_ROOFTOP'].interpolate(limit=5)
         # Parse capacity data
         capacities = dict([
             (obj['id'].split('.')[-2].upper(), obj.get('x_capacity_at_present'))

--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -1,8 +1,9 @@
-import arrow
-import logging
-import requests
 
+import logging
+
+import arrow
 import pandas as pd
+import requests
 
 from tqdm import tqdm
 

--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -1,11 +1,8 @@
 import arrow
-import datetime
-import json
 import logging
 import requests
 
 import pandas as pd
-import numpy as np
 
 from tqdm import tqdm
 

--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -1,14 +1,10 @@
-#!/usr/bin/env python3
 # coding=utf-8
 
-# The arrow library is used to handle datetimes
-import arrow
-# The request library is used to fetch content through HTTP
-import requests
-# The BeautifulSoup library is used to parse HTML
-from bs4 import BeautifulSoup
-
 import logging
+
+import arrow
+import requests
+from bs4 import BeautifulSoup
 
 
 def fetch_production(zone_key='PA', session=None, target_datetime=None, logger: logging.Logger = logging.getLogger(__name__)):

--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -8,34 +8,8 @@ from bs4 import BeautifulSoup
 
 
 def fetch_production(zone_key='PA', session=None, target_datetime=None, logger: logging.Logger = logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -1,11 +1,12 @@
-#!/usr/bin/env python3
 # coding=utf-8
+
+from logging import getLogger
 
 import arrow
 import dateutil
 import requests
+
 from .lib.validation import validate
-from logging import getLogger
 
 tz = 'America/Lima'
 

--- a/parsers/PE.py
+++ b/parsers/PE.py
@@ -30,33 +30,6 @@ def parse_date(item):
 def fetch_production(zone_key='PE', session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'dt': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/PF.py
+++ b/parsers/PF.py
@@ -2,7 +2,6 @@
 
 import logging
 import requests
-import lxml
 from bs4 import BeautifulSoup
 import re
 import json

--- a/parsers/PF.py
+++ b/parsers/PF.py
@@ -15,50 +15,8 @@ def fetch_production(
     target_datetime=None,
     logger: logging.Logger = logging.getLogger(__name__),
 ):
-    """Requests the last known production mix (in MW) of a given country
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     r = session or requests.Session()
     if target_datetime is None:
@@ -112,8 +70,7 @@ def fetch_production(
     return data
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')
     print(fetch_production())

--- a/parsers/PF.py
+++ b/parsers/PF.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python3
 
+import json
 import logging
+import re
+
+import arrow
 import requests
 from bs4 import BeautifulSoup
-import re
-import json
-import arrow
 
 TZ = 'Pacific/Tahiti'
 

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -1,10 +1,10 @@
-#!/usr/bin/python3
 # -*- coding: utf-8 -*-
+
+import json
 
 import arrow
 import dateutil
 import requests
-import json
 
 # RU-1: European and Uralian Market Zone (Zone 1)
 # RU-2: Siberian Market Zone (Zone 2)

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -47,31 +47,6 @@ tz = 'Europe/Moscow'
 def fetch_production(zone_key='RU', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -133,8 +108,7 @@ def fetch_production(zone_key='RU', session=None, target_datetime=None, logger=N
     return data
 
 
-def response_checker(json_content):
-    """Returns False if input is empty list or all zero values, else True."""
+def response_checker(json_content) -> bool:
     flow_values = json_content['Flows']
 
     if not flow_values:
@@ -153,22 +127,8 @@ def response_checker(json_content):
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day, str in format YYYYMMDD
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     if target_datetime:
         today = arrow.get(target_datetime, 'YYYYMMDD')

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import arrow
-from bs4 import BeautifulSoup
-import re
 import dateutil
 import requests
 import json

--- a/parsers/SE.py
+++ b/parsers/SE.py
@@ -1,9 +1,10 @@
+
 import datetime
 from collections import defaultdict
 
 import arrow
-import requests
 import pytz
+import requests
 
 SVK_URL = 'http://www.svk.se/ControlRoom/GetProductionHistory/' \
           '?productionDate={date}&countryCode={zoneKey}'

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -1,13 +1,12 @@
-#!/usr/bin/env python3
 
-from collections import defaultdict
 import logging
 import re
+from collections import defaultdict
 
 import arrow
+import requests
 from PIL import Image
 from pytesseract import image_to_string
-import requests
 
 TIMEZONE = 'Asia/Singapore'
 

--- a/parsers/SG.py
+++ b/parsers/SG.py
@@ -133,7 +133,8 @@ def parse_price(price_str):
 
 
 def find_first_list_item_by_key_value(l, filter_key, filter_value, sought_key):
-    """Parses a common pattern in Singapore JSON response format. Examples:
+    """
+    Parses a common pattern in Singapore JSON response format. Examples:
 
     [d['Value'] for d in energy_section if d['Label'] == 'Demand'][0]
         => find_first_list_item_by_key_value(energy_section, 'Label', 'Demand', 'Value')
@@ -149,9 +150,11 @@ def find_first_list_item_by_key_value(l, filter_key, filter_value, sought_key):
 
 
 def sg_period_to_hour(period_str):
-    """Singapore electricity markets are split into 48 periods.
+    """
+    Singapore electricity markets are split into 48 periods.
     Period 1 starts at 00:00 Singapore time. Period 9 starts at 04:00.
-    This function returns hours since midnight, possibly with 0.5 to indicate 30 minutes."""
+    This function returns hours since midnight, possibly with 0.5 to indicate 30 minutes.
+    """
     return (float(period_str) - 1) / 2.0
 
 
@@ -166,11 +169,8 @@ def sg_data_to_datetime(data):
 
 def fetch_production(zone_key='SG', session=None, target_datetime=None,
                      logger=logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of Singapore.
-
-    Arguments:
-    zone_key       -- ignored here, only information for SG is returned
-    session (optional) -- request session passed in order to re-use an existing session
+    """
+    Requests the last known production mix (in MW) of Singapore.
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -232,30 +232,8 @@ def fetch_production(zone_key='SG', session=None, target_datetime=None,
 
 
 def fetch_price(zone_key='SG', session=None, target_datetime=None, logger=None):
-    """Requests the most recent known power prices in Singapore (USEP).
-
-    See https://www.emcsg.com/marketdata/guidetoprices for details of what different prices in the data source mean.
-    We use USEP here: "The Uniform Singapore Energy Price (USEP) is the uniform price of energy
-    that applies for settlement purposes for all energy injections or withdrawals that are deemed to occur
-    at the Singapore hub. It is the weighted-average of the nodal prices at all off-take nodes in each half hour."
-
-    There are also price forecasts for future prices at https://www.emcsg.com/marketdata/priceinformation
-    that appears to extend to end of day in Singapore, so up to 24 hours into the future,
-    however we don't currently use this.
-
-    Arguments:
-    zone_key (optional) -- ignored, only information for Singapore is returned
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-        {
-          'zoneKey': 'FR',
-          'currency': 'EUR',
-          'datetime': '2017-01-01T01:00:00Z',
-          'price': 0.0,
-          'source': 'mysource.com'
-        }
+    """
+    Requests the most recent known power prices in Singapore (USEP).
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python3
 
-import arrow
-from bs4 import BeautifulSoup
-import requests
 import json
 import re
 from collections import defaultdict
 from operator import itemgetter
+
+import arrow
+import requests
+from bs4 import BeautifulSoup
 
 # This parser gets hourly electricity generation data from ut.com.sv for El Salvador.
 # El Salvador does have wind generation but there is no data available.

--- a/parsers/SV.py
+++ b/parsers/SV.py
@@ -65,12 +65,11 @@ def get_data(session=None):
     return datareq
 
 
-def data_parser(datareq):
+def data_parser(datareq) -> list:
     """
     Accepts a requests response.text object.  Slices the object down to a smaller size then converts
     to usable json.  Loads the data as json then finds the 'result' key.  Uses regex to find the start
     and endpoints of the actual data.  Splits the data into datapoints then cleans them up for processing.
-    Returns a list of lists.
     """
 
     double_json = datareq.text[len('0|/*DX*/('):-1]
@@ -103,11 +102,10 @@ def data_parser(datareq):
     return clean_data
 
 
-def data_processer(data):
+def data_processer(data) -> list:
     """
     Takes data in the form of a list of lists.  Converts each list to a dictionary.
     Joins dictionaries based on shared datetime key.  Maps generation to type.
-    Returns a list of dictionaries.
     """
 
     converted = []
@@ -139,30 +137,6 @@ def data_processer(data):
 def fetch_production(zone_key='SV', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -1,12 +1,13 @@
-#!/usr/bin/env python3
 
-import requests
-import re
-import json
-import arrow
-import logging
-from bs4 import BeautifulSoup
 import datetime as dt
+import json
+import logging
+import re
+
+import arrow
+import requests
+from bs4 import BeautifulSoup
+
 from .lib import zonekey
 
 SEARCH_DATA = re.compile(r'var gunlukUretimEgrisiData = (?P<data>.*);')

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -50,11 +50,10 @@ def as_float(prod):
     return prod
 
 
-def get_last_data_idx(productions):
+def get_last_data_idx(productions) -> int:
     """
     Find index of the last production
     :param productions: list of 24 production dict objects
-    :return: (int) index of the newest data or -1 if no data (empty day)
     """
     for i in range(len(productions)):
         if productions[i]['total'] < 1000:
@@ -102,31 +101,6 @@ def fetch_price(zone_key='TR', session=None, target_datetime=None,
 def fetch_production(zone_key='TR', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -172,8 +146,7 @@ def fetch_production(zone_key='TR', session=None, target_datetime=None, logger=N
 
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy for
-    testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')
     print(fetch_production())

--- a/parsers/TW.py
+++ b/parsers/TW.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3
+
 import arrow
-import requests
-import pandas
 import dateutil
+import pandas
+import requests
 
 
 def fetch_production(zone_key='TW', session=None, target_datetime=None, logger=None):

--- a/parsers/UA.py
+++ b/parsers/UA.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 
 import arrow
 import dateutil

--- a/parsers/US_BPA.py
+++ b/parsers/US_BPA.py
@@ -1,14 +1,11 @@
-#!/usr/bin/env python3
-
 """Parser for the Bonneville Power Administration area of the USA."""
 
-
-from io import StringIO
-import arrow
 import logging
+from io import StringIO
+
+import arrow
 import pandas as pd
 import requests
-
 
 GENERATION_URL = 'https://transmission.bpa.gov/business/operations/Wind/baltwg.txt'
 

--- a/parsers/US_BPA.py
+++ b/parsers/US_BPA.py
@@ -33,12 +33,11 @@ def timestamp_converter(timestamp):
     return dt_aware
 
 
-def data_processor(df, logger):
+def data_processor(df, logger) -> list:
     """
     Takes a dataframe and drops all generation rows that are empty or more
     than 1 day old. Turns each row into a dictionary and removes any generation
     types that are unknown.
-    Returns a list of tuples in the form (datetime, production).
     """
 
     df = df.dropna(thresh=2)
@@ -76,31 +75,6 @@ def data_processor(df, logger):
 def fetch_production(zone_key='US-BPA', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     if target_datetime:

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -1,11 +1,11 @@
-#!/usr/bin/env python3
+
+import logging
+from collections import defaultdict
 
 import arrow
 import pandas
 import requests
 from bs4 import BeautifulSoup
-from collections import defaultdict
-import logging
 
 FUEL_SOURCE_CSV = 'http://www.caiso.com/outlook/SP/fuelsource.csv'
 

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -13,34 +13,8 @@ MX_EXCHANGE_URL = 'http://www.cenace.gob.mx/Paginas/Publicas/Info/DemandaRegiona
 
 def fetch_production(zone_key='US-CA', session=None, target_datetime=None,
                      logger: logging.Logger = logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     if target_datetime:
         return fetch_historical_production(target_datetime, zone_key)
@@ -180,21 +154,8 @@ def fetch_MX_exchange(s):
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None,
                    logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1: the first country code
-    zone_key2: the second country code; order of the two codes in params
-      doesn't matter
-    session: request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     sorted_zone_keys = '->'.join(sorted([zone_key1, zone_key2]))
 

--- a/parsers/US_HI.py
+++ b/parsers/US_HI.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
 
-import logging
 import datetime
+import logging
+
 import arrow
 import requests
 

--- a/parsers/US_HI.py
+++ b/parsers/US_HI.py
@@ -9,53 +9,8 @@ import requests
 def fetch_production(zone_key='US-HI-OA', session=None,
                      target_datetime: datetime.datetime = None,
                      logger: logging.Logger = logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     r = session or requests.session()
     if target_datetime is None:

--- a/parsers/US_IPC.py
+++ b/parsers/US_IPC.py
@@ -48,11 +48,10 @@ def timestamp_converter(timestamp):
     return dt_aware
 
 
-def data_processer(raw_data, logger):
+def data_processer(raw_data, logger) -> list:
     """
     Groups dictionaries by datetime key.
     Removes unneeded keys and logs any new ones.
-    Returns a list of tuples containing (datetime object, dictionary).
     """
 
     dt_key = lambda x: x['datetime']
@@ -93,31 +92,6 @@ def data_processer(raw_data, logger):
 def fetch_production(zone_key = 'US-IPC', session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     if target_datetime is not None:

--- a/parsers/US_IPC.py
+++ b/parsers/US_IPC.py
@@ -1,12 +1,10 @@
-#!usr/bin/env python3
-
 """Parser for the Idaho Power Comapny area of the United States."""
 
-from dateutil import parser, tz
 from itertools import groupby
 from logging import getLogger
-import requests
 
+import requests
+from dateutil import parser, tz
 
 # NOTE No pumped storage yet but future ideas can be found at the following url.
 # https://docs.idahopower.com/pdfs/AboutUs/PlanningForFuture/irp/IRP.pdf

--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -34,10 +34,9 @@ def get_json_data(logger, session=None):
     return json_data
 
 
-def data_processer(json_data, logger):
+def data_processer(json_data, logger) -> tuple:
     """
     Identifies any unknown fuel types and logs a warning.
-    Returns a tuple containing datetime object and production dictionary.
     """
 
     generation = json_data['Fuel']['Type']
@@ -72,33 +71,6 @@ def data_processer(json_data, logger):
 def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     if target_datetime:
@@ -121,19 +93,6 @@ def fetch_production(zone_key='US-MISO', session=None, target_datetime=None, log
 def fetch_wind_forecast(zone_key='US-MISO', session=None, target_datetime=None, logger=None):
     """
     Requests the day ahead wind forecast (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)  -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A list of dictionaries in the form:
-    {
-    'source': 'misoenergy.org',
-    'production': {'wind': 12932.0},
-    'datetime': '2019-01-01T00:00:00Z',
-    'zoneKey': 'US-MISO'
-    }
     """
 
     if target_datetime:

--- a/parsers/US_MISO.py
+++ b/parsers/US_MISO.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python3
-
 """Parser for the MISO area of the United States."""
 
 import logging
+
 import requests
 from dateutil import parser, tz
 

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -1,12 +1,11 @@
-#!/usr/bin/env python3
-
-
 """Real time parser for the New England ISO (NEISO) area."""
-import arrow
-from collections import defaultdict
+
 import logging
-import requests
 import time
+from collections import defaultdict
+
+import arrow
+import requests
 
 url = 'https://www.iso-ne.com/ws/wsclient'
 

--- a/parsers/US_NEISO.py
+++ b/parsers/US_NEISO.py
@@ -60,11 +60,10 @@ def get_json_data(target_datetime, params, session=None):
     return raw_data
 
 
-def production_data_processer(raw_data, logger):
+def production_data_processer(raw_data, logger) -> list:
     """
     Takes raw json data and removes unnecessary keys.
     Separates datetime key and converts to a datetime object.
-    Maps generation to type and returns a list of tuples.
     """
 
     other_keys = {'BeginDateMs', 'Renewables', 'BeginDate', 'Other'}
@@ -118,35 +117,6 @@ def production_data_processer(raw_data, logger):
 def fetch_production(zone_key='US-NEISO', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key: specifies which zone to get
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     postdata = {
@@ -178,23 +148,8 @@ def fetch_production(zone_key='US-NEISO', session=None, target_datetime=None, lo
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-
-    Arguments:
-    zone_key1, zone_key2: specifies which exchange to get
-    session (optional): request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    [{
-      'sortedZoneKeys': 'CA-QC->US-NEISO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }]
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     sorted_zone_keys = '->'.join(sorted([zone_key1, zone_key2]))
 

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -53,11 +53,10 @@ def timestamp_converter(timestamp_string):
     return dt_aware
 
 
-def data_parser(df):
+def data_parser(df) -> list:
     """
     Takes dataframe and loops over rows to form dictionaries consisting of datetime and generation type.
     Merges these dictionaries using datetime key.
-    Maps to type and returns a list of tuples containing datetime string and production.
     """
 
     chunks = []
@@ -97,37 +96,6 @@ def data_parser(df):
 def fetch_production(zone_key='US-NY', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given zone
-
-    Arguments:
-    zone_key: used in case a parser is able to fetch multiple zones
-    session: requests session passed in order to re-use an existing session,
-      not used here due to difficulty providing it to pandas
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime:
         # ensure we have an arrow object
@@ -165,25 +133,8 @@ def fetch_production(zone_key='US-NY', session=None, target_datetime=None, logge
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-
-    Arguments:
-    zone_key1, zone_key2: specifies which exchange to get
-    session: requests session passed in order to re-use an existing session,
-      not used here due to difficulty providing it to pandas
-    target_datetime: the datetime for which we want production data. If not provided, we should
-      default it to now. The provided target_datetime is timezone-aware in UTC.
-    logger: an instance of a `logging.Logger`; all raised exceptions are also logged automatically
-
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     url = 'http://mis.nyiso.com/public/csv/ExternalLimitsFlows/{}ExternalLimitsFlows.csv'
 

--- a/parsers/US_NY.py
+++ b/parsers/US_NY.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python3
-
 """Real time parser for the state of New York."""
+
 from collections import defaultdict
 from datetime import timedelta
 from operator import itemgetter
@@ -8,6 +7,7 @@ from urllib.error import HTTPError
 
 import arrow
 import pandas as pd
+from arrow.parser import ParserError
 
 # Dual Fuel systems can run either Natural Gas or Oil, they represent
 # significantly more capacity in NY State than plants that can only
@@ -18,7 +18,6 @@ import pandas as pd
 # approximation it's just Natural Gas.
 
 # Pumped storage is present but is not split into a separate category.
-from arrow.parser import ParserError
 
 mapping = {
     'Dual Fuel': 'gas',

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -44,12 +44,11 @@ exchange_mapping = {
 }
 
 
-def extract_data(session=None):
+def extract_data(session=None) -> tuple:
     """
     Makes a request to the PJM data url.
     Finds timestamp of current data and converts into a useful form.
     Finds generation data inside script tag.
-    Returns a tuple of generation data and datetime.
     """
 
     s = session or requests.Session()
@@ -104,10 +103,9 @@ def extract_data(session=None):
     return data, dt
 
 
-def data_processer(data):
+def data_processer(data) -> dict:
     """
     Takes a list of dictionaries and extracts generation type and value from each.
-    Returns a dictionary.
     """
 
     production = {}
@@ -120,10 +118,9 @@ def data_processer(data):
 
 
 def fetch_consumption_forecast_7_days(zone_key='US-PJM', session=None,
-                               target_datetime=None, logger=None):
+                               target_datetime=None, logger=None) -> list:
     """
     Gets consumption forecast for specified zone.
-    Returns a list of dictionaries.
     """
 
     if target_datetime:
@@ -164,30 +161,6 @@ def fetch_consumption_forecast_7_days(zone_key='US-PJM', session=None,
 def fetch_production(zone_key='US-PJM', session=None, target_datetime=None, logger=None):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
     if target_datetime is not None:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -215,10 +188,9 @@ def add_default_tz(timestamp):
     return modified_timestamp
 
 
-def get_miso_exchange(session=None):
+def get_miso_exchange(session=None) -> tuple:
     """
     Current exchange status between PJM and MISO.
-    Returns a tuple containing flow and timestamp.
     """
 
     map_url = 'http://pjm.com/markets-and-operations/interregional-map.aspx'
@@ -252,11 +224,10 @@ def get_miso_exchange(session=None):
     return flow, dt_aware
 
 
-def get_exchange_data(interface, session=None):
+def get_exchange_data(interface, session=None) -> list:
     """
     This function can fetch 5min data for any PJM interface in the current day.
     Extracts load and timestamp data from html source then joins them together.
-    Returns a list of tuples.
     """
 
     base_url = 'http://www.pjm.com/Charts/InterfaceChart.aspx?open='
@@ -296,11 +267,10 @@ def get_exchange_data(interface, session=None):
     return converted_flows
 
 
-def combine_NY_exchanges():
+def combine_NY_exchanges() -> list:
     """
     Combination function for the 4 New York interfaces.
     Timestamps are checked to ensure correct combination.
-    Returns a list of tuples.
     """
 
     nyiso = get_exchange_data('nyiso', session=None)
@@ -328,20 +298,8 @@ def combine_NY_exchanges():
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two zones
-    Arguments:
-    zone_key1           -- the first country code
-    zone_key2           -- the second country code; order of the two codes in params doesn't matter
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
+    """
+    Requests the last known power exchange (in MW) between two zones
     """
     if target_datetime is not None:
         raise NotImplementedError('This parser is not yet able to parse past dates')
@@ -389,19 +347,8 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
 
 def fetch_price(zone_key='US-PJM', session=None, target_datetime=None, logger=None):
-    """Requests the last known power price of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'currency': EUR,
-      'datetime': '2017-01-01T00:00:00Z',
-      'price': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power price of a given country
     """
     if target_datetime is not None:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/US_PJM.py
+++ b/parsers/US_PJM.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Parser for the PJM area of the United States."""
 
 import json

--- a/parsers/US_PREPA.py
+++ b/parsers/US_PREPA.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Real-time parser for Puerto Rico.
 
 Fetches data from various pages embedded as an iframe at https://aeepr.com/en-us/Pages/Generaci%C3%B3n.aspx
@@ -7,13 +5,12 @@ Fetches data from various pages embedded as an iframe at https://aeepr.com/en-us
 The electricity authority is known in English as PREPA (Puerto Rico Electric Power Authority) and in Spanish as AEEPR (Autoridad de Energía Eléctrica Puerto Rico)
 """
 
+import json
 import logging
 import re
-# The arrow library is used to handle datetimes
+
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
-import json
 
 timezone_name = 'America/Puerto_Rico'
 GENERATION_BREAKDOWN_URL = "https://aeepr.com/es-pr/generacion/Documents/combustibles.aspx"

--- a/parsers/US_PREPA.py
+++ b/parsers/US_PREPA.py
@@ -1,7 +1,6 @@
-"""Real-time parser for Puerto Rico.
-
+"""
+Real-time parser for Puerto Rico.
 Fetches data from various pages embedded as an iframe at https://aeepr.com/en-us/Pages/Generaci%C3%B3n.aspx
-
 The electricity authority is known in English as PREPA (Puerto Rico Electric Power Authority) and in Spanish as AEEPR (Autoridad de Energía Eléctrica Puerto Rico)
 """
 
@@ -30,9 +29,6 @@ def extract_data(html):
 def convert_timestamp(zone_key, timestamp_string, logger: logging.Logger = logging.getLogger(__name__)):
     """
     Converts timestamp fetched from website into timezone-aware datetime object
-    Arguments:
-    ----------
-    timestamp_string: timestamp in the format 06/01/2020 08:40:00 AM
     """
     timestamp_string = re.sub(r"\s+", " ", timestamp_string)#Replace double spaces with one
 
@@ -40,50 +36,8 @@ def convert_timestamp(zone_key, timestamp_string, logger: logging.Logger = loggi
     return arrow.get(timestamp_string, 'MM/DD/YYYY HH:mm:ss A', tzinfo=timezone_name).datetime
 
 def fetch_production(zone_key='US-PR', session=None, target_datetime=None, logger: logging.Logger = logging.getLogger(__name__)):
-  """Requests the last known production mix (in MW) of a given region
-  Arguments:
-  ----------
-  zone_key: used in case a parser is able to fetch multiple countries
-  session: request session passed in order to re-use an existing session
-  target_datetime: the datetime for which we want production data. If not
-    provided, we should default it to now. If past data is not available,
-    raise a NotImplementedError. Beware that the provided target_datetime is
-    UTC. To convert to local timezone, you can use
-    `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-    Note that `arrow.get(None)` returns UTC now.
-  logger: an instance of a `logging.Logger` that will be passed by the
-    backend. Information logged will be publicly available so that correct
-    execution of the logger can be checked. All Exceptions will automatically
-    be logged, so when something's wrong, simply raise an Exception (with an
-    explicit text). Use `logger.warning` or `logger.info` for information
-    that can useful to check if the parser is working correctly. A default
-    logger is used so that logger output can be seen when coding / debugging.
-  Returns:
-  --------
-  If no data can be fetched, any falsy value (None, [], False) will be
-    ignored by the backend. If there is no data because the source may have
-    changed or is not available, raise an Exception.
-  A dictionary in the form:
-  {
-    'zoneKey': 'FR',
-    'datetime': '2017-01-01T00:00:00Z',
-    'production': {
-        'biomass': 0.0,
-        'coal': 0.0,
-        'gas': 0.0,
-        'hydro': 0.0,
-        'nuclear': null,
-        'oil': 0.0,
-        'solar': 0.0,
-        'wind': 0.0,
-        'geothermal': 0.0,
-        'unknown': 0.0
-    },
-    'storage': {
-        'hydro': -10.0,
-    },
-    'source': 'mysource.com'
-  }
+  """
+  Requests the last known production mix (in MW) of a given region
   """
 
   global renewable_output

--- a/parsers/US_SEC.py
+++ b/parsers/US_SEC.py
@@ -1,9 +1,9 @@
-"""Parser for the Seminole Electric Cooperative in Florida, USA.
-
-Combines hourly gas and coal production data from EIA with hourly solar generation from http://apps.seminole.coop/db/cs/ . Both generally lag a day or so behind, and sometimes as much as 10d behind.
-
-https://www.seminole-electric.com/facilities/generation/ lists two 650MW coal-fired plants, one 810MW gas plant, and a small 2.2MW solar farm. However, EIA combines coal and gas generation data, so we report those together as unknown.
-
+"""
+Parser for the Seminole Electric Cooperative in Florida, USA.
+Combines hourly gas and coal production data from EIA with hourly solar generation from http://apps.seminole.coop/db/cs/ .
+Both generally lag a day or so behind, and sometimes as much as 10d behind.
+https://www.seminole-electric.com/facilities/generation/ lists two 650MW coal-fired plants, one 810MW gas plant, and a small 2.2MW solar farm.
+However, EIA combines coal and gas generation data, so we report those together as unknown.
 https://github.com/tmrowco/electricitymap-contrib/issues/1713
 """
 

--- a/parsers/US_SEC.py
+++ b/parsers/US_SEC.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Parser for the Seminole Electric Cooperative in Florida, USA.
 
 Combines hourly gas and coal production data from EIA with hourly solar generation from http://apps.seminole.coop/db/cs/ . Both generally lag a day or so behind, and sometimes as much as 10d behind.

--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -41,13 +41,11 @@ def get_data(url, session=None):
     return df
 
 
-def data_processor(df, logger):
+def data_processor(df, logger) -> list:
     """
     Takes a dataframe and logging instance as input.
     Checks for new generation types and logs a warning if any are found.
     Parses the dataframe row by row removing unneeded keys.
-    Returns a list of 2 element tuples, each containing a datetime object
-    and production dictionary.
     """
 
     # Remove leading whitespace in column headers.
@@ -101,31 +99,6 @@ def data_processor(df, logger):
 def fetch_production(zone_key = 'US-SPP', session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     if target_datetime is not None:
@@ -177,19 +150,6 @@ def fetch_production(zone_key = 'US-SPP', session=None, target_datetime=None, lo
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the last 24 hours of power exchange (in MW) between two zones
-    Arguments:
-    zone_key1           -- the first zone
-    zone_key2           -- the second zone; order of the two zones in params doesn't matter
-    session (optional)  -- request session passed in order to re-use an existing session
-    Return:
-    A list of dictionaries in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
-    where net flow is from DK into NO
     """
 
     if target_datetime:
@@ -229,19 +189,6 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 def fetch_load_forecast(zone_key='US-SPP', session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the load forecast (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'US-SPP',
-      'datetime': '2017-01-01T00:00:00Z',
-      'value': 28576.0,
-      'source': 'mysource.com'
-    }
     """
 
     if not target_datetime:
@@ -277,19 +224,6 @@ def fetch_load_forecast(zone_key='US-SPP', session=None, target_datetime=None, l
 def fetch_wind_solar_forecasts(zone_key='US-SPP', session=None, target_datetime=None, logger=getLogger(__name__)):
     """
     Requests the load forecast (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'US-SPP',
-      'datetime': '2017-01-01T00:00:00Z',
-      'value': 28576.0,
-      'source': 'mysource.com'
-    }
     """
 
     if not target_datetime:

--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -5,7 +5,6 @@
 from dateutil import parser, tz
 from io import StringIO
 from logging import getLogger
-from pandas.tseries.offsets import DateOffset
 import datetime
 import pandas as pd
 import requests

--- a/parsers/US_SPP.py
+++ b/parsers/US_SPP.py
@@ -1,13 +1,12 @@
-#!usr/bin/env python3
-
 """Parser for the Southwest Power Pool area of the United States."""
 
-from dateutil import parser, tz
+import datetime
 from io import StringIO
 from logging import getLogger
-import datetime
+
 import pandas as pd
 import requests
+from dateutil import parser, tz
 
 HISTORIC_GENERATION_BASE_URL = 'https://marketplace.spp.org/file-browser-api/download/generation-mix-historical?path=%2F'
 

--- a/parsers/US_TX.py
+++ b/parsers/US_TX.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Parser for the ERCOT area of the United States. (~85% of Texas)"""
 
 import csv

--- a/parsers/US_TX.py
+++ b/parsers/US_TX.py
@@ -70,33 +70,6 @@ def get_realtime_data(logger, session=None):
 def fetch_production(zone_key='US-TX', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known production mix (in MW) of a given country
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day
-    logger (optional) -- handles logging when parser is run as main
-    Return:
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
     """
 
     if target_datetime:
@@ -137,8 +110,8 @@ def fetch_production(zone_key='US-TX', session=None, target_datetime=None, logge
 
 
 def fetch_consumption(zone_key='US-TX', session=None, target_datetime=None,
-                      logger=logging.getLogger(__name__)):
-    """Gets consumption for a specified zone, returns a dictionary."""
+                      logger=logging.getLogger(__name__)) -> dict:
+    """Gets consumption for a specified zone."""
 
     realtime_datetime, demand, ties = get_realtime_data(logger, session=session)
 

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -1,11 +1,9 @@
-#!/usr/bin/python3
+
+import re
 
 import arrow
 import dateutil
-import re
 import requests
-
-# BeautifulSoup is used to parse HTML to get information
 from bs4 import BeautifulSoup
 
 tz = 'America/Montevideo'

--- a/parsers/UY.py
+++ b/parsers/UY.py
@@ -110,20 +110,8 @@ def fetch_production(zone_key='UY', session=None, target_datetime=None, logger=N
 
 
 def fetch_exchange(zone_key1='UY', zone_key2='BR-S', session=None, target_datetime=None, logger=None):
-    """Requests the last known power exchange (in MW) between two countries
-
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple countries
-    session (optional)      -- request session passed in order to re-use an existing session
-
-    Return:
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known power exchange (in MW) between two countries
     """
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')

--- a/parsers/XK.py
+++ b/parsers/XK.py
@@ -1,17 +1,11 @@
-#!/usr/bin/env python3
-import logging
+
 import datetime
+import logging
 import re
 
-# Tablib is used to parse XLSX files
-import tablib
-# The arrow library is used to handle datetimes
 import arrow
-# The request library is used to fetch content through HTTP
 import requests
-
-# please try to write PEP8 compliant code (use a linter). One of PEP8's
-# requirement is to limit your line length to 79 characters.
+import tablib
 
 
 def fetch_production(zone_key='XK', session=None,

--- a/parsers/XK.py
+++ b/parsers/XK.py
@@ -11,53 +11,8 @@ import tablib
 def fetch_production(zone_key='XK', session=None,
         target_datetime: datetime.datetime = None,
         logger: logging.Logger = logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given country
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
+    """
+    Requests the last known production mix (in MW) of a given country
     """
     r = session or requests.session()
     if target_datetime is None:
@@ -114,8 +69,7 @@ def fetch_production(zone_key='XK', session=None,
 
 
 if __name__ == '__main__':
-    """Main method, never used by the Electricity Map backend, but handy
-    for testing."""
+    """Main method, never used by the Electricity Map backend, but handy for testing."""
 
     print('fetch_production() ->')
     for datum in fetch_production():

--- a/parsers/ajenti.py
+++ b/parsers/ajenti.py
@@ -7,9 +7,10 @@
 
 import json
 import logging
+
 import arrow
-from signalr import Connection
 from requests import Session
+from signalr import Connection
 
 ZONE_PARAMS = {
     'AUS-TAS-KI': {

--- a/parsers/ajenti.py
+++ b/parsers/ajenti.py
@@ -5,7 +5,6 @@
 # About the data, the feed we get seems to be counters with a 2 seconds interval.
 # That means that if we fetch these counters every 15 minutes, we only are reading "instantaneous" metters that could differ from the total quantity of energies at play. To get the very exact data, we would need to have a parser running constanty to collect those 2-sec interval counters.
 
-import asyncio
 import json
 import logging
 import arrow

--- a/parsers/occtonet.py
+++ b/parsers/occtonet.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
 import logging
-import datetime
 import pandas as pd
 # The arrow library is used to handle datetimes
 import arrow

--- a/parsers/occtonet.py
+++ b/parsers/occtonet.py
@@ -38,38 +38,6 @@ def fetch_exchange(zone_key1='JP-TH', zone_key2='JP-TK', session=None,
                    target_datetime=None, logger=logging.getLogger(__name__)):
     """
     Requests the last known power exchange (in MW) between two zones
-
-    Arguments:
-    ----------
-    zone_key: used in case a parser is able to fetch multiple countries
-    session: request session passed in order to re-use an existing session
-    target_datetime: the datetime for which we want production data. If not
-      provided, we should default it to now. If past data is not available,
-      raise a NotImplementedError. Beware that the provided target_datetime is
-      UTC. To convert to local timezone, you can use
-      `target_datetime = arrow.get(target_datetime).to('America/New_York')`.
-      Note that `arrow.get(None)` returns UTC now.
-    logger: an instance of a `logging.Logger` that will be passed by the
-      backend. Information logged will be publicly available so that correct
-      execution of the logger can be checked. All Exceptions will automatically
-      be logged, so when something's wrong, simply raise an Exception (with an
-      explicit text). Use `logger.warning` or `logger.info` for information
-      that can useful to check if the parser is working correctly. A default
-      logger is used so that logger output can be seen when coding / debugging.
-
-    Returns:
-    --------
-    If no data can be fetched, any falsy value (None, [], False) will be
-      ignored by the backend. If there is no data because the source may have
-      changed or is not available, raise an Exception.
-
-    A dictionary in the form:
-    {
-      'sortedZoneKeys': 'DK->NO',
-      'datetime': '2017-01-01T00:00:00Z',
-      'netFlow': 0.0,
-      'source': 'mysource.com'
-    }
     """
     #get target date in time zone Asia/Tokyo
     query_date = arrow.get(target_datetime).to('Asia/Tokyo').strftime('%Y/%m/%d')

--- a/parsers/occtonet.py
+++ b/parsers/occtonet.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python3
 # coding=utf-8
-import logging
-import pandas as pd
-# The arrow library is used to handle datetimes
-import arrow
-# The request library is used to fetch content through HTTP
-import requests
 
+import logging
 from io import StringIO
+
+import arrow
+import pandas as pd
+import requests
 
 # Abbreviations:
 # JP-HKD : Hokkaido

--- a/parsers/statnett.py
+++ b/parsers/statnett.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python3
-# The arrow library is used to handle datetimes
-import arrow
+
 import logging
-# The request library is used to fetch content through HTTP
+
+import arrow
 import requests
+
 exchanges_mapping = {
     'BY->LT': [
         'BY->LT'

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,7 +11,7 @@ python-dateutil = ">=2.7.0"
 
 [[package]]
 name = "astroid"
-version = "2.5.1"
+version = "2.5.3"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
@@ -175,7 +175,7 @@ itk = ["itk"]
 
 [[package]]
 name = "importlib-metadata"
-version = "3.7.3"
+version = "3.10.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -187,11 +187,11 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "isort"
-version = "5.7.0"
+version = "5.8.0"
 description = "A Python utility / library to sort Python imports."
 category = "dev"
 optional = false
@@ -204,11 +204,11 @@ colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
 name = "lazy-object-proxy"
-version = "1.5.2"
+version = "1.6.0"
 description = "A fast and thorough lazy object proxy."
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "lxml"
@@ -328,7 +328,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyflakes"
-version = "2.3.0"
+version = "2.3.1"
 description = "passive checker of Python programs"
 category = "dev"
 optional = false
@@ -336,14 +336,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pylint"
-version = "2.7.2"
+version = "2.7.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = "~=3.6"
 
 [package.dependencies]
-astroid = ">=2.5.1,<2.6"
+astroid = ">=2.5.2,<2.7"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
@@ -508,8 +508,21 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tqdm"
+version = "4.60.0"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = true
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+telegram = ["requests"]
+
+[[package]]
 name = "typed-ast"
-version = "1.4.2"
+version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
@@ -599,12 +612,12 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-parsers = ["arrow", "beautifulsoup4", "demjson", "eiapy", "html5lib", "imageio", "lxml", "mock", "pandas", "Pillow", "pytesseract", "ree", "requests", "tablib", "opencv-python", "xlrd", "freezegun", "signalr-client-threads"]
+parsers = ["arrow", "beautifulsoup4", "demjson", "eiapy", "html5lib", "imageio", "lxml", "mock", "pandas", "Pillow", "pytesseract", "ree", "requests", "tablib", "opencv-python", "xlrd", "freezegun", "signalr-client-threads", "tqdm"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = '>= 3.6, < 3.8'
-content-hash = "d96a196e4cb1998d1d37ebef3968c15ea8a5563b1ae3bf79e6968744127b8d2c"
+content-hash = "f73d4d7a06ee86dea5264a2faf25b428e512c8351148947aad23d9289105177c"
 
 [metadata.files]
 arrow = [
@@ -612,8 +625,8 @@ arrow = [
     {file = "arrow-0.16.0.tar.gz", hash = "sha256:92aac856ea5175c804f7ccb96aca4d714d936f1c867ba59d747a8096ec30e90a"},
 ]
 astroid = [
-    {file = "astroid-2.5.1-py3-none-any.whl", hash = "sha256:21d735aab248253531bb0f1e1e6d068f0ee23533e18ae8a6171ff892b98297cf"},
-    {file = "astroid-2.5.1.tar.gz", hash = "sha256:cfc35498ee64017be059ceffab0a25bedf7548ab76f2bea691c5565896e7128d"},
+    {file = "astroid-2.5.3-py3-none-any.whl", hash = "sha256:bea3f32799fbb8581f58431c12591bc20ce11cbc90ad82e2ea5717d94f2080d5"},
+    {file = "astroid-2.5.3.tar.gz", hash = "sha256:ad63b8552c70939568966811a088ef0bc880f99a24a00834abd0e3681b514f91"},
 ]
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.6.0-py2-none-any.whl", hash = "sha256:7015e76bf32f1f574636c4288399a6de66ce08fb7b2457f628a8d70c0fbabb11"},
@@ -671,38 +684,36 @@ imageio = [
     {file = "imageio-2.8.0.tar.gz", hash = "sha256:fb5fd6d3d17126bbaac9af29fe340e2c97a196eb9416d4f28c0e543744a152cf"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.7.3-py3-none-any.whl", hash = "sha256:b74159469b464a99cb8cc3e21973e4d96e05d3024d337313fedb618a6e86e6f4"},
-    {file = "importlib_metadata-3.7.3.tar.gz", hash = "sha256:742add720a20d0467df2f444ae41704000f50e1234f46174b51f9c6031a1bd71"},
+    {file = "importlib_metadata-3.10.0-py3-none-any.whl", hash = "sha256:d2d46ef77ffc85cbf7dac7e81dd663fde71c45326131bea8033b9bad42268ebe"},
+    {file = "importlib_metadata-3.10.0.tar.gz", hash = "sha256:c9db46394197244adf2f0b08ec5bc3cf16757e9590b02af1fca085c16c0d600a"},
 ]
 isort = [
-    {file = "isort-5.7.0-py3-none-any.whl", hash = "sha256:fff4f0c04e1825522ce6949973e83110a6e907750cd92d128b0d14aaaadbffdc"},
-    {file = "isort-5.7.0.tar.gz", hash = "sha256:c729845434366216d320e936b8ad6f9d681aab72dc7cbc2d51bedc3582f3ad1e"},
+    {file = "isort-5.8.0-py3-none-any.whl", hash = "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"},
+    {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
 ]
 lazy-object-proxy = [
-    {file = "lazy-object-proxy-1.5.2.tar.gz", hash = "sha256:5944a9b95e97de1980c65f03b79b356f30a43de48682b8bdd90aa5089f0ec1f4"},
-    {file = "lazy_object_proxy-1.5.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e960e8be509e8d6d618300a6c189555c24efde63e85acaf0b14b2cd1ac743315"},
-    {file = "lazy_object_proxy-1.5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:522b7c94b524389f4a4094c4bf04c2b02228454ddd17c1a9b2801fac1d754871"},
-    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3782931963dc89e0e9a0ae4348b44762e868ea280e4f8c233b537852a8996ab9"},
-    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:429c4d1862f3fc37cd56304d880f2eae5bd0da83bdef889f3bd66458aac49128"},
-    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-win32.whl", hash = "sha256:cd1bdace1a8762534e9a36c073cd54e97d517a17d69a17985961265be6d22847"},
-    {file = "lazy_object_proxy-1.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:ddbdcd10eb999d7ab292677f588b658372aadb9a52790f82484a37127a390108"},
-    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ecb5dd5990cec6e7f5c9c1124a37cb2c710c6d69b0c1a5c4aa4b35eba0ada068"},
-    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b6577f15d5516d7d209c1a8cde23062c0f10625f19e8dc9fb59268859778d7d7"},
-    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-win32.whl", hash = "sha256:c8fe2d6ff0ff583784039d0255ea7da076efd08507f2be6f68583b0da32e3afb"},
-    {file = "lazy_object_proxy-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:fa5b2dee0e231fa4ad117be114251bdfe6afe39213bd629d43deb117b6a6c40a"},
-    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1d33d6f789697f401b75ce08e73b1de567b947740f768376631079290118ad39"},
-    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:57fb5c5504ddd45ed420b5b6461a78f58cbb0c1b0cbd9cd5a43ad30a4a3ee4d0"},
-    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-win32.whl", hash = "sha256:e7273c64bccfd9310e9601b8f4511d84730239516bada26a0c9846c9697617ef"},
-    {file = "lazy_object_proxy-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6f4e5e68b7af950ed7fdb594b3f19a0014a3ace0fedb86acb896e140ffb24302"},
-    {file = "lazy_object_proxy-1.5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cadfa2c2cf54d35d13dc8d231253b7985b97d629ab9ca6e7d672c35539d38163"},
-    {file = "lazy_object_proxy-1.5.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e7428977763150b4cf83255625a80a23dfdc94d43be7791ce90799d446b4e26f"},
-    {file = "lazy_object_proxy-1.5.2-cp38-cp38-win32.whl", hash = "sha256:2f2de8f8ac0be3e40d17730e0600619d35c78c13a099ea91ef7fb4ad944ce694"},
-    {file = "lazy_object_proxy-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:38c3865bd220bd983fcaa9aa11462619e84a71233bafd9c880f7b1cb753ca7fa"},
-    {file = "lazy_object_proxy-1.5.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:8a44e9901c0555f95ac401377032f6e6af66d8fc1fbfad77a7a8b1a826e0b93c"},
-    {file = "lazy_object_proxy-1.5.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fa7fb7973c622b9e725bee1db569d2c2ee64d2f9a089201c5e8185d482c7352d"},
-    {file = "lazy_object_proxy-1.5.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:71a1ef23f22fa8437974b2d60fedb947c99a957ad625f83f43fd3de70f77f458"},
-    {file = "lazy_object_proxy-1.5.2-cp39-cp39-win32.whl", hash = "sha256:ef3f5e288aa57b73b034ce9c1f1ac753d968f9069cd0742d1d69c698a0167166"},
-    {file = "lazy_object_proxy-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:37d9c34b96cca6787fe014aeb651217944a967a5b165e2cacb6b858d2997ab84"},
+    {file = "lazy-object-proxy-1.6.0.tar.gz", hash = "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win32.whl", hash = "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27m-win_amd64.whl", hash = "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93"},
+    {file = "lazy_object_proxy-1.6.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win32.whl", hash = "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f"},
+    {file = "lazy_object_proxy-1.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win32.whl", hash = "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd"},
+    {file = "lazy_object_proxy-1.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win32.whl", hash = "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8"},
+    {file = "lazy_object_proxy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win32.whl", hash = "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61"},
+    {file = "lazy_object_proxy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"},
 ]
 lxml = [
     {file = "lxml-4.6.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a9d6bc8642e2c67db33f1247a77c53476f3a166e09067c0474facb045756087f"},
@@ -889,12 +900,12 @@ pycodestyle = [
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.3.0-py2.py3-none-any.whl", hash = "sha256:910208209dcea632721cb58363d0f72913d9e8cf64dc6f8ae2e02a3609aba40d"},
-    {file = "pyflakes-2.3.0.tar.gz", hash = "sha256:e59fd8e750e588358f1b8885e5a4751203a0516e0ee6d34811089ac294c8806f"},
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pylint = [
-    {file = "pylint-2.7.2-py3-none-any.whl", hash = "sha256:d09b0b07ba06bcdff463958f53f23df25e740ecd81895f7d2699ec04bbd8dc3b"},
-    {file = "pylint-2.7.2.tar.gz", hash = "sha256:0e21d3b80b96740909d77206d741aa3ce0b06b41be375d92e1f3244a274c1f8a"},
+    {file = "pylint-2.7.4-py3-none-any.whl", hash = "sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a"},
+    {file = "pylint-2.7.4.tar.gz", hash = "sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee"},
 ]
 pytesseract = [
     {file = "pytesseract-0.2.0.tar.gz", hash = "sha256:35035b0a69a789224d1e981d95453d644c95f8bf869372787f2164b9872d597f"},
@@ -963,37 +974,41 @@ toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
+tqdm = [
+    {file = "tqdm-4.60.0-py2.py3-none-any.whl", hash = "sha256:daec693491c52e9498632dfbe9ccfc4882a557f5fa08982db1b4d3adbe0887c3"},
+    {file = "tqdm-4.60.0.tar.gz", hash = "sha256:ebdebdb95e3477ceea267decfc0784859aa3df3e27e22d23b83e9b272bf157ae"},
+]
 typed-ast = [
-    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
-    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
-    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
-    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
-    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
-    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
-    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
-    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
-    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
-    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
-    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
-    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
-    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
-    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
-    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
-    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
-    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
-    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
-    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
-    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
-    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
-    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
-    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
-    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
-    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
-    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
-    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
-    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
-    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
-    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
+    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
+    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
+    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
+    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
+    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
+    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
+    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
+    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
+    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
+    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ opencv-python = {version="4.2.0.32", optional=true}
 xlrd = {version="1.2.0", optional=true}
 freezegun = {version="0.3.15", optional=true}
 signalr-client-threads = {version="0.0.12", optional=true}
+tqdm = {version="^4.19.5", optional=true}
 
 [tool.poetry.dev-dependencies]
 click = "6.7"
@@ -62,7 +63,8 @@ parsers = [
     "opencv-python",
     "xlrd",
     "freezegun",
-    "signalr-client-threads"
+    "signalr-client-threads",
+    "tqdm"
 ]
 
 [build-system]

--- a/test_parser.py
+++ b/test_parser.py
@@ -21,6 +21,7 @@ from parsers.lib.quality import (
 )
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
 
 
 @click.command()


### PR DESCRIPTION
- Clean unused imports
- Sort imports
- Remove docstrings that are copied from "example"
- Remove "return" from docstrings and replace with a type hint