### PR TITLE
add US capacities

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -347,6 +347,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - United Arab Emirates: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
 - United States of America
   - Federal: [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)
+             [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
   - BPA: [BPA](https://transmission.bpa.gov/business/operations/Wind/baltwg.aspx)
   - CAISO

--- a/config/zones.json
+++ b/config/zones.json
@@ -5670,7 +5670,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5708,7 +5709,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5746,7 +5748,8 @@
    },
    "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+     "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5784,7 +5787,8 @@
    },
    "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+     "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5822,7 +5826,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5860,7 +5865,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5898,7 +5904,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5936,7 +5943,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -5974,7 +5982,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6012,7 +6021,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6050,7 +6060,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6086,7 +6097,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6124,7 +6136,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6163,7 +6176,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6201,7 +6215,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6239,7 +6254,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6277,7 +6293,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6315,7 +6332,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6353,7 +6371,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6415,7 +6434,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6453,7 +6473,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6491,7 +6512,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6529,7 +6551,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6567,7 +6590,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6606,7 +6630,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6644,7 +6669,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6692,7 +6718,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6730,7 +6757,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6772,7 +6800,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6810,7 +6839,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6848,7 +6878,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6874,7 +6905,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6912,7 +6944,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6950,7 +6983,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -6988,7 +7022,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7048,7 +7083,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7084,7 +7120,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7122,7 +7159,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7160,7 +7198,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7198,7 +7237,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7236,7 +7276,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7274,7 +7315,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7312,7 +7354,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7350,7 +7393,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7388,7 +7432,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7426,7 +7471,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7464,7 +7510,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7502,7 +7549,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7540,7 +7588,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7576,7 +7625,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7614,7 +7664,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7652,7 +7703,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7688,7 +7740,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7726,7 +7779,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7764,7 +7818,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7800,7 +7855,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7838,7 +7894,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7874,7 +7931,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7910,7 +7968,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7946,7 +8005,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -7984,7 +8044,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -8022,7 +8083,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -8060,7 +8122,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -8098,7 +8161,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {
@@ -8136,7 +8200,8 @@
     },
     "contributors": [
       "https://github.com/systemcatch",
-      "https://github.com/robertahunt"
+      "https://github.com/robertahunt",
+      "https://github.com/KabelWlan"
     ],
     "flag_file_name": "us.png",
     "parsers": {

--- a/config/zones.json
+++ b/config/zones.json
@@ -5654,6 +5654,20 @@
   },
   "US-CAL-BANC": {
     "comment": "Balancing Authority Of Northern California",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 9,
+      "coal": 0,
+      "gas": 1934.8,
+      "geothermal": 0,
+      "hydro": 740.3,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 72.2,
+      "solar": 147.7,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5679,9 +5693,18 @@
   "US-CAL-CISO": {
     "comment": "California Independent System Operator",
     "capacity": {
-      "solar": 13147,
-      "wind": 6690,
-      "geothermal": 1387
+      "battery storage": 610.4,
+      "biomass": 1194.6,
+      "coal": 62.5,
+      "gas": 32964.7,
+      "geothermal": 2103.5,
+      "hydro": 6714.3,
+      "hydro storage": 2094.4,
+      "nuclear": 2323,
+      "oil": 466,
+      "solar": 14801.6,
+      "unknown": 99.7,
+      "wind": 5912.5
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -5707,7 +5730,21 @@
   },
   "US-CAL-IID": {
     "comment": "Imperial Irrigation District",
-    "contributors": [
+    "capacity": {
+      "battery storage": 30,
+      "biomass": 94.6,
+      "coal": 0,
+      "gas": 605.5,
+      "geothermal": 791.4,
+      "hydro": 83.9,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 24.9,
+      "solar": 371.4,
+      "unknown": 0,
+      "wind": 0
+   },
+   "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
     ],
@@ -5731,7 +5768,21 @@
   },
   "US-CAL-LDWP": {
     "comment": "Los Angeles Department Of Water And Power",
-    "contributors": [
+    "capacity": {
+      "battery storage": 23.5,
+      "biomass": 56,
+      "coal": 1640,
+      "gas": 5005.5,
+      "geothermal": 0,
+      "hydro": 328.3,
+      "hydro storage": 1626,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 988.1,
+      "unknown": 31.9,
+      "wind": 440.5
+   },
+   "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
     ],
@@ -5755,6 +5806,20 @@
   },
   "US-CAL-TIDC": {
     "comment": "Turlock Irrigation District",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 573.9,
+      "geothermal": 0,
+      "hydro": 186.8,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5779,6 +5844,20 @@
   },
   "US-CAR-CPLE": {
     "comment": "Duke Energy Progress East",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 559.1,
+      "coal": 3373.9,
+      "gas": 6489.8,
+      "geothermal": 0,
+      "hydro": 228,
+      "hydro storage": 0,
+      "nuclear": 3722.7,
+      "oil": 282.1,
+      "solar": 1504.1,
+      "unknown": 54,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5803,6 +5882,20 @@
   },
   "US-CAR-CPLW": {
     "comment": "Duke Energy Progress West",
+    "capacity": {
+      "battery storage": 8.8,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 21.5,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5827,6 +5920,20 @@
   },
   "US-CAR-DUK": {
     "comment": "Duke Energy Carolinas",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 90.9,
+      "coal": 7317.1,
+      "gas": 10719,
+      "geothermal": 0,
+      "hydro": 1180.7,
+      "hydro storage": 2070,
+      "nuclear": 7517.5,
+      "oil": 144,
+      "solar": 2221,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5851,6 +5958,20 @@
   },
   "US-CAR-SC": {
     "comment": "South Carolina Public Service Authority",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 219.5,
+      "coal": 3650.1,
+      "gas": 1102,
+      "geothermal": 0,
+      "hydro": 231.2,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 229.4,
+      "solar": 98.2,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5875,6 +5996,20 @@
   },
   "US-CAR-SCEG": {
     "comment": "South Carolina Electric & Gas Company",
+    "capacity": {
+      "battery storage": 4,
+      "biomass": 229.6,
+      "coal": 1431.5,
+      "gas": 3511.2,
+      "geothermal": 0,
+      "hydro": 254.9,
+      "hydro storage": 587.2,
+      "nuclear": 1029.6,
+      "oil": 33.8,
+      "solar": 874,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5899,6 +6034,20 @@
   },
   "US-CAR-YAD": {
     "comment": "Alcoa Power Generating, Inc. - Yadkin Division",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 215.2,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5921,6 +6070,20 @@
   },
   "US-CENT-SPA": {
     "comment": "Southwestern Power Administration",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 261,
+      "gas": 32.8,
+      "geothermal": 0,
+      "hydro": 1507.1,
+      "hydro storage": 161.4,
+      "nuclear": 0,
+      "oil": 15,
+      "solar": 17,
+      "unknown": 0,
+      "wind": 499
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5945,6 +6108,20 @@
   },
   "US-CENT-SWPP": {
     "comment": "Southwest Power Pool",
+    "capacity": {
+      "battery storage": 25,
+      "biomass": 345.8,
+      "coal": 22064.3,
+      "gas": 36389,
+      "geothermal": 0,
+      "hydro": 3104.1,
+      "hydro storage": 259.2,
+      "nuclear": 2068.7,
+      "oil": 2181.4,
+      "solar": 391.6,
+      "unknown": 62,
+      "wind": 24769.5
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5970,6 +6147,20 @@
   },
   "US-FLA-FMPP": {
     "comment": "Florida Municipal Power Pool",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 1292.8,
+      "gas": 3119.3,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 95.8,
+      "solar": 166.9,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -5994,6 +6185,20 @@
   },
   "US-FLA-FPC": {
     "comment": "Duke Energy Florida Inc",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 272.4,
+      "coal": 1478.4,
+      "gas": 11191.6,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 1329.7,
+      "solar": 446.5,
+      "unknown": 18.8,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6018,6 +6223,20 @@
   },
   "US-FLA-FPL": {
     "comment": "Florida Power & Light Company",
+    "capacity": {
+      "battery storage": 14,
+      "biomass": 622.4,
+      "coal": 0,
+      "gas": 22017,
+      "geothermal": 0,
+      "hydro": 43.5,
+      "hydro storage": 0,
+      "nuclear": 3797.2,
+      "oil": 1988.1,
+      "solar": 2275.3,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6042,6 +6261,20 @@
   },
   "US-FLA-GVL": {
     "comment": "Gainesville Regional Utilities",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 116.1,
+      "coal": 250.7,
+      "gas": 377.9,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 2.8,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6066,6 +6299,20 @@
   },
   "US-FLA-HST": {
     "comment": "City Of Homestead",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 35.6,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0.1,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6090,6 +6337,20 @@
   },
   "US-FLA-JEA": {
     "comment": "Jea",
+    "capacity": {
+      "battery storage": 5,
+      "biomass": 148.5,
+      "coal": 595,
+      "gas": 2166.9,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 248.4,
+      "solar": 37.5,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6138,6 +6399,20 @@
   },
   "US-FLA-SEC": {
     "comment": "Seminole Electric Cooperative",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 1.6,
+      "coal": 1471.8,
+      "gas": 897,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6162,6 +6437,20 @@
   },
   "US-FLA-TAL": {
     "comment": "City Of Tallahassee",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 961.8,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 62,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6186,6 +6475,20 @@
   },
   "US-FLA-TEC": {
     "comment": "Tampa Electric Company",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 71.6,
+      "coal": 1124.4,
+      "gas": 5535.7,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 133.4,
+      "solar": 659.7,
+      "unknown": 335.3,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6210,6 +6513,20 @@
   },
   "US-MIDA-OVEC": {
     "comment": "Ohio Valley Electric Corporation",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 2390.3,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6234,6 +6551,20 @@
   },
   "US-MIDA-PJM": {
     "comment": "Pjm Interconnection, Llc",
+    "capacity": {
+      "battery storage": 299.9,
+      "biomass": 2348.3,
+      "coal": 49937.8,
+      "gas": 98841.1,
+      "geothermal": 0,
+      "hydro": 3308.7,
+      "hydro storage": 5103.3,
+      "nuclear": 34466.6,
+      "oil": 6987.1,
+      "solar": 4626,
+      "unknown": 133.2,
+      "wind": 10171.5
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6259,6 +6590,20 @@
   },
   "US-MIDW-AECI": {
     "comment": "Associated Electric Cooperative, Inc.",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 4,
+      "coal": 2481.7,
+      "gas": 3056.5,
+      "geothermal": 0,
+      "hydro": 30,
+      "hydro storage": 31,
+      "nuclear": 0,
+      "oil": 164.7,
+      "solar": 2.5,
+      "unknown": 941.4,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6283,6 +6628,20 @@
   },
   "US-MIDW-EEI": {
     "comment": "Electric Energy, Inc.",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 1099.8,
+      "gas": 301.5,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6317,6 +6676,20 @@
   },
   "US-MIDW-LGEE": {
     "comment": "Louisville Gas And Electric Company And Kentucky Utilities",
+    "capacity": {
+      "battery storage": ,
+      "biomass": 2,
+      "coal": 5807.2,
+      "gas": 4011.6,
+      "geothermal": 0,
+      "hydro": 137.8,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 11.5,
+      "solar": 10,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6341,6 +6714,20 @@
   },
   "US-MIDW-MISO": {
     "comment": "Midcontinent Independent Transmission System Operator, Inc..",
+    "capacity": {
+      "battery storage": 55.4,
+      "biomass": 2490.4,
+      "coal": 61208.4,
+      "gas": 83019.3,
+      "geothermal": 0,
+      "hydro": 2423.7,
+      "hydro storage": 2414.8,
+      "nuclear": 13080.8,
+      "oil": 5037.4,
+      "solar": 2061,
+      "unknown": 632,
+      "wind": 26455
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6369,6 +6756,20 @@
   },
   "US-NE-ISNE": {
     "comment": "Iso New England Inc.",
+    "capacity": {
+      "battery storage": 95.1,
+      "biomass": 1616.1,
+      "coal": 959.2,
+      "gas": 19672.1,
+      "geothermal": 0,
+      "hydro": 1926.2,
+      "hydro storage": 1799,
+      "nuclear": 3404.9,
+      "oil": 6400.8,
+      "solar": 1487.5,
+      "unknown": 0,
+      "wind": 1504.4
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6393,6 +6794,20 @@
   },
   "US-NW-AVA": {
     "comment": "Avista Corporation",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 199.9,
+      "coal": 0,
+      "gas": 563.7,
+      "geothermal": 0,
+      "hydro": 1255.6,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 2.8,
+      "solar": 19.2,
+      "unknown": 0,
+      "wind": 249.3
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6417,6 +6832,20 @@
   },
   "US-NW-AVRN": {
     "comment": "Avangrid Renewables Cooperative",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 619.1,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 10
+      "unknown": 0,
+      "wind": 1496.4
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6429,6 +6858,20 @@
   },
   "US-NW-BPAT": {
     "comment": "Bonneville Power Administration",
+    "capacity": {
+      "battery storage": 3,
+      "biomass": 417.9,
+      "coal": 729.9
+      "gas": 2277.5,
+      "geothermal": 18,
+      "hydro": 21708.1,
+      "hydro storage": 314,
+      "nuclear": 1200,
+      "oil": 0,
+      "solar": 143.7,
+      "unknown": 0,
+      "wind": 3377.5
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6453,6 +6896,20 @@
   },
   "US-NW-CHPD": {
     "comment": "Public Utility District No. 1 Of Chelan County",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 1988.2,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6477,6 +6934,20 @@
   },
   "US-NW-DOPD": {
     "comment": "Pud No. 1 Of Douglas County",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 774,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6501,6 +6972,20 @@
   },
   "US-NW-GCPD": {
     "comment": "Public Utility District No. 2 Of Grant County, Washington",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 1236,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6547,6 +7032,20 @@
   },
   "US-NW-GWA": {
     "comment": "Naturener Power Watch, Llc (Gwa)",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 210
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6569,6 +7068,20 @@
   },
   "US-NW-IPCO": {
     "comment": "Idaho Power Company",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 24.6,
+      "coal": 6.2,
+      "gas": 774.4,
+      "geothermal": 33,
+      "hydro": 2028.7,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 5,
+      "solar": 318.3,
+      "unknown": 15.9,
+      "wind": 716.8
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6593,6 +7106,20 @@
   },
   "US-NW-NEVP": {
     "comment": "Nevada Power Company",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 35.2,
+      "coal": 809,
+      "gas": 7828.2,
+      "geothermal": 782.8,
+      "hydro": 12.8,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 21,
+      "solar": 1593.8,
+      "unknown": 7.5,
+      "wind": 150
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6617,6 +7144,20 @@
   },
   "US-NW-NWMT": {
     "comment": "Northwestern Energy (Nwmt)",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 1814.7,
+      "gas": 259.6,
+      "geothermal": 0,
+      "hydro": 668.7,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 72.7,
+      "solar": 17,
+      "unknown": 0,
+      "wind": 452.9
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6641,6 +7182,20 @@
   },
   "US-NW-PACE": {
     "comment": "Pacificorp - East",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 15.3,
+      "coal": 7841.5,
+      "gas": 3409.9,
+      "geothermal": 83.8,
+      "hydro": 271.7,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 30.4,
+      "solar": 1286.4,
+      "unknown": 52.8,
+      "wind": 2690.1
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6665,6 +7220,20 @@
   },
   "US-NW-PACW": {
     "comment": "Pacificorp - West",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 161,
+      "coal": 0,
+      "gas": 621.2,
+      "geothermal": 3.7,
+      "hydro": 1127.6,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 239.8,
+      "unknown": 0,
+      "wind": 714.3
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6689,6 +7258,20 @@
   },
   "US-NW-PGE": {
     "comment": "Portland General Electric Company",
+    "capacity": {
+      "battery storage": 5,
+      "biomass": 14.7,
+      "coal": 0,
+      "gas": 2115.3,
+      "geothermal": 0,
+      "hydro": 676.2,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 125.7,
+      "unknown": 0,
+      "wind": 716.5
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6713,6 +7296,20 @@
   },
   "US-NW-PSCO": {
     "comment": "Public Service Company Of Colorado",
+    "capacity": {
+      "battery storage": 1,
+      "biomass": 30.8,
+      "coal": 1311.3,
+      "gas": 6510,
+      "geothermal": 0,
+      "hydro": 55.2,
+      "hydro storage": 300,
+      "nuclear": 0,
+      "oil": 50.4,
+      "solar": 520.5,
+      "unknown": 0,
+      "wind": 4490.8
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6737,6 +7334,20 @@
   },
   "US-NW-PSEI": {
     "comment": "Puget Sound Energy",
+    "capacity": {
+      "battery storage": 2,
+      "biomass": 37.9,
+      "coal": 0,
+      "gas": 2053.5,
+      "geothermal": 0,
+      "hydro": 347.8,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 2.7,
+      "solar": 0.5
+      "unknown": 0,
+      "wind": 502.9
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6761,6 +7372,20 @@
   },
   "US-NW-SCL": {
     "comment": "Seattle City Light",
+    "capacity": {
+      "battery storage": 5,
+      "biomass": 4.6,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 2007.4,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 10,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6785,6 +7410,20 @@
   },
   "US-NW-TPWR": {
     "comment": "City Of Tacoma, Department Of Public Utilities, Light Division",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 64,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 716.6,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6809,6 +7448,20 @@
   },
   "US-NW-WACM": {
     "comment": "Western Area Power Administration - Rocky Mountain Region",
+        "capacity": {
+      "battery storage": 8.2,
+      "biomass": 3.2,
+      "coal": 5929.6,
+      "gas": 1947.4,
+      "geothermal": 0,
+      "hydro": 704.3,
+      "hydro storage": 208.5,
+      "nuclear": 0,
+      "oil": 158.8,
+      "solar": 192.2,
+      "unknown": 11.5,
+      "wind": 781.6
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6833,6 +7486,20 @@
   },
   "US-NW-WAUW": {
     "comment": "Western Area Power Administration Ugp West",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 969.1,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 77.6
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6857,6 +7524,20 @@
   },
   "US-NW-WWA": {
     "comment": "Naturener Wind Watch, Llc",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 189
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6878,18 +7559,21 @@
     ]
   },
   "US-NY-NYIS": {
-    "capacity": {
-      "coal": 676,
-      "gas": 23956,
-      "hydro": 4247,
-      "hydro storage": 1407,
-      "nuclear": 5391,
-      "oil": 2416,
-      "solar": 32,
-      "wind": 1739,
-      "unknown": 327
-    },
     "comment": "New York Independent System Operator",
+    "capacity": {
+      "battery storage": 48.1,
+      "biomass": 517.7,
+      "coal": 627.2,
+      "gas": 27127.6,
+      "geothermal": 0,
+      "hydro": 4690.2,
+      "hydro storage": 1240,
+      "nuclear": 4410.4,
+      "oil": 3831.1,
+      "solar": 642.7,
+      "unknown": 20,
+      "wind": 1989.2
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6914,6 +7598,20 @@
   },
   "US-SE-AEC": {
     "comment": "Powersouth Energy Cooperative",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 4.8,
+      "coal": 0,
+      "gas": 1330,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6938,6 +7636,20 @@
   },
   "US-SE-SEPA": {
     "comment": "Southeastern Power Administration",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 1.7,
+      "coal": 0,
+      "gas": 0,
+      "geothermal": 0,
+      "hydro": 1081.9,
+      "hydro storage": 328,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 26.4,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6960,6 +7672,20 @@
   },
   "US-SE-SOCO": {
     "comment": "Southern Company Services, Inc. - Trans",
+    "capacity": {
+      "battery storage": 2.2,
+      "biomass": 1997.7,
+      "coal": 16164.8,
+      "gas": 34926.9,
+      "geothermal": 0,
+      "hydro": 3310.4,
+      "hydro storage": 1306.6,
+      "nuclear": 6054.4,
+      "oil": 1284.8,
+      "solar": 2589.6,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -6984,6 +7710,20 @@
   },
   "US-SW-AZPS": {
     "comment": "Arizona Public Service Company",
+    "capacity": {
+      "battery storage": 2,
+      "biomass": 36.2,
+      "coal": 1749.8,
+      "gas": 2714.6,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 123.8,
+      "solar": 769.2,
+      "unknown": 0,
+      "wind": 174.3
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7008,6 +7748,20 @@
   },
   "US-SW-DEAA": {
     "comment": "Arlington Valley, Llc - Avba",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 713,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7030,6 +7784,20 @@
   },
   "US-SW-EPE": {
     "comment": "El Paso Electric Company",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 3.2,
+      "coal": 0,
+      "gas": 1922.9,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 127.3,
+      "unknown": 0,
+      "wind": 50.4
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7054,6 +7822,20 @@
   },
   "US-SW-GRIF": {
     "comment": "Griffith Energy, Llc",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 655,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7076,6 +7858,20 @@
   },
   "US-SW-GRMA": {
     "comment": "Gila River Power, Llc",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 619,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7098,6 +7894,20 @@
   },
   "US-SW-HGMA": {
     "comment": "New Harquahala Generating Company, Llc - Hgba",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 0,
+      "gas": 1325.1,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 0,
+      "unknown": 0,
+      "wind": 0
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7120,6 +7930,20 @@
   },
   "US-SW-PNM": {
     "comment": "Public Service Company Of New Mexico",
+    "capacity": {
+      "battery storage": 1.8,
+      "biomass": 14.6,
+      "coal": 924,
+      "gas": 1833.9,
+      "geothermal": 19.2,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 30.4,
+      "solar": 369.9,
+      "unknown": 1.1,
+      "wind": 1065.8
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7144,6 +7968,20 @@
   },
   "US-SW-SRP": {
     "comment": "Salt River Project",
+    "capacity": {
+      "battery storage": 20,
+      "biomass": 0,
+      "coal": 821.8,
+      "gas": 8265.6,
+      "geothermal": 0,
+      "hydro": 92.3,
+      "hydro storage": 154.1,
+      "nuclear": 4209.6,
+      "oil": 0,
+      "solar": 355.4,
+      "unknown": 0,
+      "wind": 63
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7168,6 +8006,20 @@
   },
   "US-SW-TEPC": {
     "comment": "Tucson Electric Power Company",
+    "capacity": {
+      "battery storage": 20,
+      "biomass": 0,
+      "coal": 1765.8,
+      "gas": 1012.7,
+      "geothermal": 0,
+      "hydro": 0,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 0,
+      "solar": 323.5,
+      "unknown": 0,
+      "wind": 30
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7192,6 +8044,20 @@
   },
   "US-SW-WALC": {
     "comment": "Western Area Power Administration - Desert Southwest Region",
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 0,
+      "coal": 204,
+      "gas": 2407.3,
+      "geothermal": 0,
+      "hydro": 5610.5,
+      "hydro storage": 65.2,
+      "nuclear": 0,
+      "oil": 4.5,
+      "solar": 142.2,
+      "unknown": 0,
+      "wind": 350
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7216,6 +8082,20 @@
   },
   "US-TEN-TVA": {
     "comment": "Tennessee Valley Authority",
+    "capacity": {
+      "battery storage": 1,
+      "biomass": 288.9,
+      "coal": 8593.9,
+      "gas": 17502.6,
+      "geothermal": 0,
+      "hydro": 4871.8,
+      "hydro storage": 1808.6,
+      "nuclear": 8474.8,
+      "oil": 74.6,
+      "solar": 293,
+      "unknown": 0,
+      "wind": 28.8
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"
@@ -7240,6 +8120,20 @@
   },
   "US-TEX-ERCO": {
     "comment": "Electric Reliability Council Of Texas, Inc.",
+    "capacity": {
+      "battery storage": 223.1,
+      "biomass": 189.5,
+      "coal": 15217.2,
+      "gas": 64479,
+      "geothermal": 0,
+      "hydro": 567,
+      "hydro storage": 0,
+      "nuclear": 5138.6,
+      "oil": 111.8,
+      "solar": 4912,
+      "unknown": 234.7,
+      "wind": 28110.8
+    },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt"

--- a/config/zones.json
+++ b/config/zones.json
@@ -6842,7 +6842,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 0,
-      "solar": 10
+      "solar": 10,
       "unknown": 0,
       "wind": 1496.4
     },
@@ -6861,7 +6861,7 @@
     "capacity": {
       "battery storage": 3,
       "biomass": 417.9,
-      "coal": 729.9
+      "coal": 729.9,
       "gas": 2277.5,
       "geothermal": 18,
       "hydro": 21708.1,
@@ -7344,7 +7344,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 2.7,
-      "solar": 0.5
+      "solar": 0.5,
       "unknown": 0,
       "wind": 502.9
     },

--- a/config/zones.json
+++ b/config/zones.json
@@ -6677,7 +6677,7 @@
   "US-MIDW-LGEE": {
     "comment": "Louisville Gas And Electric Company And Kentucky Utilities",
     "capacity": {
-      "battery storage": ,
+      "battery storage": 0,
       "biomass": 2,
       "coal": 5807.2,
       "gas": 4011.6,


### PR DESCRIPTION
I added the generation capacites to the US zones. Got the idea from the issue #2495. 

I used the following source, which I'll add to data_sources.md: https://www.eia.gov/electricity/data/eia860M/

(It shows me in the preview that there are some colones missing in the zones AVRN, BPAT and PSEI. I don't know why because they're there in the normal file.) -> figured it out, it was the commas...