### PR TITLE
Fix header logo link on open source and API website

### DIFF
--- a/web/src/components/sharedheader.js
+++ b/web/src/components/sharedheader.js
@@ -153,7 +153,7 @@ const SharedHeader = ({
   logo,
 }) => (
   <Wrapper inverted={inverted} collapsed={collapsed}>
-    <a href="/map">
+    <a href="https://www.electricitymap.org/map">
       <Logo src={logo} alt="logo" />
     </a>
     <ResponsiveMenu collapsed={collapsed}>


### PR DESCRIPTION
Thought we actually fixed this a while ago, but the open-source site and API site will result in an error when clicking on the logo. I think it's fine to always link to the map as the "main point"

![image](https://user-images.githubusercontent.com/45588799/114926711-f9b5eb80-9e30-11eb-936c-d39083c0a2ce.png)
![image](https://user-images.githubusercontent.com/45588799/114926788-0c302500-9e31-11eb-8078-7d8026379beb.png)

I think this fixes it, but it is perhaps cleaner to have the logo href as a parameter to the sharedHeader class so this sort of logic comes from implementation and is not hidden in this helper-component

Fixes https://github.com/tmrowco/electricitymap/issues/416