### PR TITLE
Wind solar data error

### DIFF
--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -95,7 +95,8 @@
         "cpinfo": "<b>consumption</b> takes imports and exports into account, <b>production</b> ignores them",
         "selectLanguage": "Select language",
         "lowCarbDescription": "Includes renewables and nuclear",
-        "dataIsDelayed": "Data is delayed"
+        "dataIsDelayed": "Data is delayed",
+        "missingWindAndOrSolar": "Missing wind and/or solar data"
     },
     "misc": {
         "maintitle": "Live CO₂ emissions of electricity consumption",

--- a/web/src/components/tooltips/mapcountrytooltip.js
+++ b/web/src/components/tooltips/mapcountrytooltip.js
@@ -13,7 +13,7 @@ const mapStateToProps = state => ({
 });
 
 const TooltipContent = React.memo(({
-  isDataDelayed, hasParser, co2intensity, fossilFuelPercentage, renewablePercentage,
+  isDataDelayed, hasParser, co2intensity, fossilFuelPercentage, renewablePercentage, isMissingWindAndOrSolar
 }) => {
   if (!hasParser) {
     return (
@@ -54,6 +54,14 @@ const TooltipContent = React.memo(({
           <div className="country-col-headline">{__('country-panel.renewable')}</div>
         </div>
       </div>
+      <div id="tooltip-missing-wind-solar" className="country-missing-wind-solar">
+        <div className="country-missing-wind-solar-message">
+          {isMissingWindAndOrSolar && <span>&#9888;</span>}
+        </div>
+        <div className="country-missing-wind-solar-message">
+          {isMissingWindAndOrSolar && <h5>{__('tooltips.missingWindAndOrSolar')}</h5>}
+        </div>
+      </div>
     </div>
   );
 });
@@ -65,6 +73,8 @@ const MapCountryTooltip = ({
   onClose,
 }) => {
   if (!zoneData) return null;
+  // Determines if a zone with data is missing solar and/or wind data
+  const isMissingWindAndOrSolar = ((zoneData.production.wind == null) || (zoneData.production.solar == null)) && zoneData.co2intensity != undefined;
 
   const isDataDelayed = zoneData.delays && zoneData.delays.production;
 
@@ -97,6 +107,7 @@ const MapCountryTooltip = ({
         co2intensity={co2intensity}
         fossilFuelPercentage={fossilFuelPercentage}
         renewablePercentage={renewablePercentage}
+        isMissingWindAndOrSolar={isMissingWindAndOrSolar}
       />
     </Tooltip>
   );

--- a/web/src/scss/content/map/_map.scss
+++ b/web/src/scss/content/map/_map.scss
@@ -67,7 +67,6 @@
     .country-missing-wind-solar-message {
         color: darkorange;
         display: inline-block;
-        margin: auto;
     }
 }
 

--- a/web/src/scss/content/map/_map.scss
+++ b/web/src/scss/content/map/_map.scss
@@ -63,6 +63,12 @@
             display: none;
         }
     }
+
+    .country-missing-wind-solar-message {
+        color: darkorange;
+        display: inline-block;
+        margin: auto;
+    }
 }
 
 .country-spot-price,


### PR DESCRIPTION
This pull request was inspired by issue #3002. I created a small front end feature that displays a simple error message on the country tooltip if that country/zone is missing solar and/or wind data. The error does not display for countries with no available data.

Sample Image:
![image](https://user-images.githubusercontent.com/53071155/115642254-9e7c7100-a2e8-11eb-9264-a4355dc2768e.png)


