### PR TITLE
Update JP-TK and KR capacities.

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -259,6 +259,8 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - biomass: [MNRE.GOV.IN](https://www.mnre.gov.in/bio-energy/current-status)
   - other: [NPP](https://npp.gov.in/publishedReports)
   - (Punjab): [PUNJABSLDC](http://www.punjabsldc.org/realtimepbGen.aspx)
+- Japan:
+  - Tokyo: [Power-Plants](http://agora.ex.nii.ac.jp/earthquake/201103-eastjapan/energy/electrical-japan/operator/3.html.ja)
 - Kosovo: [TSO](https://www.kostt.com/Content/ViewFiles/Transparency/BasicMarketDataOnGeneration/EN/Installed%20capacity%20of%20production%20units.pdf)
 - Kuwait
   - Gas & oil: [KAPSARC](https://datasource.kapsarc.org/api/datasets/1.0/kuwait-power-plants-database/attachments/power_plants_xlsx/)

--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -316,7 +316,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Other: [Energy Market Authority](https://www.ema.gov.sg/cmsmedia/Publications_and_Statistics/Publications/SES/2016/Singapore%20Energy%20Statistics%202016.pdf)
 - Slovakia: [SEPS](https://www.sepsas.sk/Dokumenty/RocenkySed/ROCENKA_SED_2015.pdf)
 - Slovenia: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
-- South Korea: [KHNP](http://cms.khnp.co.kr/content/163/main.do?mnCd=FN05040101)
+- South Korea:
+  - [KHNP](http://cms.khnp.co.kr/content/163/main.do?mnCd=FN05040101)
+  - [EPSIS](http://epsis.kpx.or.kr/epsisnew/selectEkpoBftChart.do?menuId=020100)
 - Spain:
   - Biomass: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
   - Gas, Oil: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show?)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3388,11 +3388,15 @@
       ]
     ],
     "capacity": {
-      "nuclear": 22529,
-      "coal": 36709,
-      "oil": 4155,
-      "gas": 37838,
-      "hydro": 1789
+      "biomass": 1320,
+      "coal": 36721,
+      "gas": 41828,
+      "hydro": 1806,
+      "hydro storage": 4700,
+      "nuclear": 23250,
+      "oil": 2159,
+      "solar": 15697,
+      "wind": 1692
     },
     "contributors": [
       "https://github.com/systemcatch",

--- a/config/zones.json
+++ b/config/zones.json
@@ -1261,6 +1261,9 @@
     "parsers": {
       "production": "CL.fetch_production"
     },
+    "delays": {
+      "production": 24
+    },
     "timezone": "America/Santiago"
   },
   "CL-SEA": {

--- a/config/zones.json
+++ b/config/zones.json
@@ -3355,6 +3355,16 @@
     ]
   },
   "JP-TK": {
+    "capacity": {
+      "gas": 29251,
+      "hydro": 2195,
+      "hydro storage": 7678,
+      "oil": 8692,
+      "coal": 1200,
+      "nuclear": 17306,
+      "solar": 32,
+      "wind": 18
+    },
     "contributors": [
       "https://github.com/tmslaine",
       "https://github.com/lorrieq"

--- a/parsers/CL.py
+++ b/parsers/CL.py
@@ -6,20 +6,28 @@ import arrow
 import logging
 import requests
 from collections import defaultdict
+from datetime import datetime
 from operator import itemgetter
 from .lib.validation import validate
 
 # Historical API
 API_BASE_URL = "https://sipub.coordinador.cl/api/v1/recursos/generacion_centrales_tecnologia_horario?"
 # Live API
-API_BASE_URL_LIVE_TOT = 'http://panelapp.coordinadorelectrico.cl/api/chart/demanda'
-API_BASE_URL_LIVE_REN = 'http://panelapp.coordinadorelectrico.cl/api/chart/ernc'  # ERNC = energias renovables no convencionales
+API_BASE_URL_LIVE_TOT = "http://panelapp.coordinadorelectrico.cl/api/chart/demanda"
+API_BASE_URL_LIVE_REN = "http://panelapp.coordinadorelectrico.cl/api/chart/ernc"  # ERNC = energias renovables no convencionales
 
-TYPE_MAPPING = {'hidraulica': 'hydro',
-                'termica': 'unknown',
-                'eolica': 'wind',
-                'solar': 'solar',
-                'geotermica': 'geothermal'}
+# Live parser disabled because of a insuffcient breakdown of Unknown.
+# It lumps Hydro & Geothermal into unknown which makes it difficult to calculate a proper CFE%/co2 intensity
+# We can reenable if we find a way to get the Hydro production
+ENABLE_LIVE_PARSER = False
+
+TYPE_MAPPING = {
+    "hidraulica": "hydro",
+    "termica": "unknown",
+    "eolica": "wind",
+    "solar": "solar",
+    "geotermica": "geothermal",
+}
 
 
 def get_data_live(session, logger):
@@ -38,19 +46,21 @@ def production_processor_live(json_tot, json_ren):
     Returns a list of dictionaries for all of the available "live" data, usually that day.
     """
 
-    gen_total = json_tot['data'][0]['values']
+    gen_total = json_tot["data"][0]["values"]
 
-    if json_ren['data'][1]['key'] == 'ENERGÍA SOLAR':
-        rawgen_sol = json_ren['data'][1]['values']
+    if json_ren["data"][1]["key"] == "ENERGÍA SOLAR":
+        rawgen_sol = json_ren["data"][1]["values"]
     else:
         raise RuntimeError(
-            f"Unexpected data label. Expected 'ENERGÍA SOLAR' and got {json_ren['data'][1]['key']}")
+            f"Unexpected data label. Expected 'ENERGÍA SOLAR' and got {json_ren['data'][1]['key']}"
+        )
 
-    if json_ren['data'][0]['key'] == 'ENERGÍA EÓLICA':
-        rawgen_wind = json_ren['data'][0]['values']
+    if json_ren["data"][0]["key"] == "ENERGÍA EÓLICA":
+        rawgen_wind = json_ren["data"][0]["values"]
     else:
         raise RuntimeError(
-            f"Unexpected data label. Expected 'ENERGÍA EÓLICA' and got {json_ren['data'][0]['key']}")
+            f"Unexpected data label. Expected 'ENERGÍA EÓLICA' and got {json_ren['data'][0]['key']}"
+        )
 
     mapped_totals = []
 
@@ -67,10 +77,12 @@ def production_processor_live(json_tot, json_ren):
                 wind = pair[1]
                 break
 
-        datapoint['datetime'] = arrow.get(dt / 1000, tzinfo='Chile/Continental').datetime
-        datapoint['unknown'] = (total[1] - wind - solar)
-        datapoint['wind'] = wind
-        datapoint['solar'] = solar
+        datapoint["datetime"] = arrow.get(
+            dt / 1000, tzinfo="Chile/Continental"
+        ).datetime
+        datapoint["unknown"] = total[1] - wind - solar
+        datapoint["wind"] = wind
+        datapoint["solar"] = solar
         mapped_totals.append(datapoint)
 
     return mapped_totals
@@ -84,14 +96,16 @@ def production_processor_historical(raw_data):
     clean_datapoints = []
     for datapoint in raw_data:
         clean_datapoint = {}
-        date, hour = datapoint['fecha'], datapoint['hora']
+        date, hour = datapoint["fecha"], datapoint["hora"]
         hour -= 1  # `hora` starts at 1
-        date = arrow.get(date, "YYYY-MM-DD", tzinfo='Chile/Continental').shift(hours=hour)
-        clean_datapoint['datetime'] = date.datetime
+        date = arrow.get(date, "YYYY-MM-DD", tzinfo="Chile/Continental").shift(
+            hours=hour
+        )
+        clean_datapoint["datetime"] = date.datetime
 
-        gen_type_es = datapoint['tipo_central']
+        gen_type_es = datapoint["tipo_central"]
         mapped_gen_type = TYPE_MAPPING[gen_type_es]
-        value_mw = float(datapoint['generacion_sum'])
+        value_mw = float(datapoint["generacion_sum"])
 
         clean_datapoint[mapped_gen_type] = value_mw
 
@@ -99,56 +113,32 @@ def production_processor_historical(raw_data):
 
     combined = defaultdict(dict)
     for elem in clean_datapoints:
-        combined[elem['datetime']].update(elem)
+        combined[elem["datetime"]].update(elem)
 
     ordered_data = sorted(combined.values(), key=itemgetter("datetime"))
 
-    # For consistency with live API, hydro and geothermal must be squeezed into unknown
-    for datapoint in ordered_data:
-        if 'unknown' not in datapoint:
-            datapoint['unknown'] = 0
-        if 'hydro' in datapoint:
-            datapoint['unknown'] += datapoint['hydro']
-            del datapoint['hydro']
-        if 'geothermal' in datapoint:
-            datapoint['unknown'] += datapoint['geothermal']
-            del datapoint['geothermal']
+    if ENABLE_LIVE_PARSER:
+        # For consistency with live API, hydro and geothermal must be squeezed into unknown
+        for datapoint in ordered_data:
+            if 'unknown' not in datapoint:
+                datapoint['unknown'] = 0
+            if 'hydro' in datapoint:
+                datapoint['unknown'] += datapoint['hydro']
+                del datapoint['hydro']
+            if 'geothermal' in datapoint:
+                datapoint['unknown'] += datapoint['geothermal']
+                del datapoint['geothermal']
 
     return ordered_data
 
 
-def fetch_production(zone_key='CL', session=None, target_datetime=None, logger=logging.getLogger(__name__)):
-    """Requests the last known production mix (in MW) of a given zone
-    Arguments:
-    zone_key (optional) -- used in case a parser is able to fetch multiple zones
-    session (optional) -- request session passed in order to re-use an existing session
-    target_datetime (optional) -- used if parser can fetch data for a specific day, a string in the form YYYYMMDD
-    logger (optional) -- handles logging when parser is run
-    Return:
-    A list of dictionaries in the form:
-    {
-      'zoneKey': 'FR',
-      'datetime': '2017-01-01T00:00:00Z',
-      'production': {
-          'biomass': 0.0,
-          'coal': 0.0,
-          'gas': 0.0,
-          'hydro': 0.0,
-          'nuclear': null,
-          'oil': 0.0,
-          'solar': 0.0,
-          'wind': 0.0,
-          'geothermal': 0.0,
-          'unknown': 0.0
-      },
-      'storage': {
-          'hydro': -10.0,
-      },
-      'source': 'mysource.com'
-    }
-    """
-
-    if target_datetime is None:
+def fetch_production(
+    zone_key: str = "CL-SEN",
+    session: requests.session = None,
+    target_datetime: datetime = None,
+    logger: logging.Logger = logging.getLogger(__name__),
+):
+    if target_datetime is None and ENABLE_LIVE_PARSER:
         gen_tot, gen_ren = get_data_live(session, logger)
 
         processed_data = production_processor_live(gen_tot, gen_ren)
@@ -156,19 +146,18 @@ def fetch_production(zone_key='CL', session=None, target_datetime=None, logger=l
         data = []
 
         for production_data in processed_data:
-            dt = production_data.pop('datetime')
+            dt = production_data.pop("datetime")
 
             datapoint = {
-                'zoneKey': zone_key,
-                'datetime': dt,
-                'production': production_data,
-                'storage': {
-                    'hydro': None,
+                "zoneKey": zone_key,
+                "datetime": dt,
+                "production": production_data,
+                "storage": {
+                    "hydro": None,
                 },
-                'source': 'coordinadorelectrico.cl'
+                "source": "coordinadorelectrico.cl",
             }
-            datapoint = validate(datapoint, logger,
-                                 remove_negative=True, floor=1000)
+            datapoint = validate(datapoint, logger, remove_negative=True, floor=1000)
 
             data.append(datapoint)
 
@@ -178,31 +167,33 @@ def fetch_production(zone_key='CL', session=None, target_datetime=None, logger=l
     start = arr_target_datetime.shift(days=-1).format("YYYY-MM-DD")
     end = arr_target_datetime.format("YYYY-MM-DD")
 
-    date_component = 'fecha__gte={}&fecha__lte={}'.format(start, end)
+    date_component = "fecha__gte={}&fecha__lte={}".format(start, end)
 
     # required for access
-    headers = {'Referer': 'https://www.coordinador.cl/operacion/graficos/operacion-real/generacion-real-del-sistema/',
-               'Origin': 'https://www.coordinador.cl'}
+    headers = {
+        "Referer": "https://www.coordinador.cl/operacion/graficos/operacion-real/generacion-real-del-sistema/",
+        "Origin": "https://www.coordinador.cl",
+    }
 
     s = session or requests.Session()
     url = API_BASE_URL + date_component
 
     req = s.get(url, headers=headers)
-    raw_data = req.json()['aggs']
+    raw_data = req.json()["aggs"]
     processed_data = production_processor_historical(raw_data)
 
     data = []
     for production_data in processed_data:
-        dt = production_data.pop('datetime')
+        dt = production_data.pop("datetime")
 
         datapoint = {
-            'zoneKey': zone_key,
-            'datetime': dt,
-            'production': production_data,
-            'storage': {
-                'hydro': None,
+            "zoneKey": zone_key,
+            "datetime": dt,
+            "production": production_data,
+            "storage": {
+                "hydro": None,
             },
-            'source': 'coordinador.cl'
+            "source": "coordinador.cl",
         }
 
         data.append(datapoint)
@@ -213,7 +204,7 @@ def fetch_production(zone_key='CL', session=None, target_datetime=None, logger=l
 
 if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
-    print('fetch_production() ->')
+    print("fetch_production() ->")
     print(fetch_production())
     # For fetching historical data instead, try:
     print(fetch_production(target_datetime=arrow.get("20200220", "YYYYMMDD")))


### PR DESCRIPTION
# Methodology

__KR__: 
Pull out the capacity data from [here](http://epsis.kpx.or.kr/epsisnew/selectEkpoBftChart.do?menuId=020100) and take the figures for `2020-03`
* What is translated to "Positive Number" by google trad is actually pumped hydro.
* Coal is accounted as: "Bituminous coal" + "Hard coal" + "Coal gasification" + "Etc" ("Etc" = residual heating)
* Gas is accounted as: "LNG" + "Fuell cell"

__JP-TK__:
Pulled out the map of all the TEPCO power plants from [here](http://agora.ex.nii.ac.jp/earthquake/201103-eastjapan/energy/electrical-japan/operator/3.html.ja), extracted the html table and parsed it into an excel file.
Then I went out to check each thermal's plant fuel and computed the total capacity for each production factor.
The final csv can be found here:

[JP-TK_plants.csv](https://github.com/tmrowco/electricitymap-contrib/files/6360428/JP-TK_plants.csv)
