### PR TITLE
remove tqdm from OpenNEM parser

### DIFF
--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -7,8 +7,6 @@ import requests
 import pandas as pd
 import numpy as np
 
-from tqdm import tqdm
-
 ZONE_KEY_TO_REGION = {
     'AUS-NSW': 'NSW1',
     'AUS-QLD': 'QLD1',
@@ -199,7 +197,7 @@ def fetch_production(zone_key=None, session=None, target_datetime=None, logger=l
         },
         'source': SOURCE,
         'zoneKey': zone_key,
-    } for dt, row in tqdm(df.iterrows())]
+    } for dt, row in df.iterrows()]
 
     # Validation
     logger.debug('Validating..')


### PR DESCRIPTION
Triggered by comment on the original OpenNEM PR (https://github.com/tmrowco/electricitymap-contrib/pull/2860#issuecomment-828051290) I checked Kibana, and there's a fair amount of errors like:

```
Traceback (most recent call last):
  File "/home/projects/feeder-electricity/src/lib/fetch_data.py", line 203, in launch_parsers
    objs = res.get(timeout) or []
  File "/usr/local/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
  File "/usr/local/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/home/projects/feeder-electricity/src/lib/fetch_data.py", line 199, in <lambda>
    *keys, session, logger=public_logger, **parser_kwargs
  File "/home/src/electricitymap/contrib/parsers/OPENNEM.py", line 202, in fetch_production
    } for dt, row in tqdm(df.iterrows())]
  File "/usr/local/lib/python3.6/site-packages/tqdm/_tqdm.py", line 859, in __init__
    self.pos = self._get_free_pos(self)
  File "/usr/local/lib/python3.6/site-packages/tqdm/_tqdm.py", line 466, in _get_free_pos
    return max(inst.pos for inst in cls._instances
  File "/usr/local/lib/python3.6/site-packages/tqdm/_tqdm.py", line 467, in <genexpr>
    if inst is not instance) + 1
AttributeError: 'tqdm' object has no attribute 'pos'
```

[kibana search for `tqdm` in AUS zones](https://kibana.electricitymap.org/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96f67170-0c49-11e9-85c1-1d63df8c862c',key:extra.key,negate:!f,params:(query:'AUS-*',type:phrase),type:phrase,value:'AUS-*'),query:(match:(extra.key:(query:'AUS-*',type:phrase))))),index:'96f67170-0c49-11e9-85c1-1d63df8c862c',interval:auto,query:(language:lucene,query:tqdm),sort:!('@timestamp',desc))) shows 179 errors in last 24 hours.

That seems like maybe a weird tqdm bug, maybe related to running parsers in worker threads (see https://github.com/tqdm/tqdm/issues/323, though that seemed to have been fixed in 2019?) but the easiest solution seems to be just to remove `tqdm` since it's only a debugging nice-to-have (it was added in #3066).

Let me know what you think, or if you have a better idea what's causing this error?
