### PR TITLE
Mobile app iteration: update documentation 

### DIFF
--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -6,8 +6,10 @@ A few prerequisite:
 
 - iOS: install cocoapods
 - Run `npm install -g cordova@9.0.0 code-push-cli@2.1.9`
-- Download `GoogleService-Info.plist` from Firebase (any alternative for contributors?)
 - Run `npm install`
+- Optional (required for some internal Tomorrow builds): download `GoogleService-Info.plist` from Firebase
+
+If you want your local JavaScript changes to be reflected, you need to disable Codepush by commenting out the `codePush.sync` calls in `src/cordova.js`.
 
 To build the JavaScript:
 
@@ -165,9 +167,10 @@ var pathToManifest = path.join(
 );
 ```
 
-### iOS: Module 'Firebase' not found
+### iOS: Building for iOS, but the embedded framework 'Sentry.framework' was built for iOS + iOS Simulator.
 
-```bash
-cd platforms/ios
-pod install
+```
+cordova platform remove ios && cordova platform add ios
+cordova plugin remove sentry-cordova
+cordova prepare
 ```

--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -9,7 +9,7 @@ A few prerequisite:
 - Run `npm install`
 - Optional (required for some internal Tomorrow builds): download `GoogleService-Info.plist` from Firebase
 
-If you want your local JavaScript changes to be reflected, you need to disable Codepush by commenting out the `codePush.sync` calls in `src/cordova.js`.
+If you want your local JavaScript changes to be reflected, you need to disable Codepush by commenting out the `codePush.sync` calls in `../web/src/cordova.js`.
 
 To build the JavaScript:
 

--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -11,7 +11,7 @@ A few prerequisite:
 
 If you want your local JavaScript changes to be reflected, you need to disable Codepush by commenting out the `codePush.sync` calls in `../web/src/cordova.js`.
 
-To build the JavaScript:
+To build the JavaScript (you need to export BRICK_ELECTRICITYMAP_PUBLIC_TOKEN in order to access the API):
 
 ```
 docker-compose build web && ./build.sh

--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -12,8 +12,7 @@ A few prerequisite:
 To build the JavaScript:
 
 ```
-cd ../ && docker-compose build web
-cd mobileapp && ./build.sh
+docker-compose build web && ./build.sh
 ```
 
 When installing for first time, run:

--- a/mobileapp/README.md
+++ b/mobileapp/README.md
@@ -1,40 +1,54 @@
-Requires docker build (from project folder / parent repository)
+# Mobileapp
+
+##
+
+A few prerequisite:
+
+- iOS: install cocoapods
+- Run `npm install -g cordova@9.0.0 code-push-cli@2.1.9`
+- Download `GoogleService-Info.plist` from Firebase (any alternative for contributors?)
+- Run `npm install`
+
+To build the JavaScript:
+
 ```
-docker-compose build public_web 
+cd ../ && docker-compose build web
+cd mobileapp && ./build.sh
 ```
 
-To build js:
-```
-./build.sh
-```
+When installing for first time, run:
 
-when installing for first time, run
 ```
-npm install
 cordova prepare
 ```
 
-To build cordova:
+To build the cordova app:
+
 ```
+export SENTRY_SKIP_AUTO_RELEASE=true
 cordova build {ios,android}
 ```
 
-To run:
+To run the app:
+
 ```
 cordova run {ios,android}
 ```
 
 To do a release build (android):
+
 ```
 cordova build android --release -- --keystore=electricitymap.keystore --alias=electricitymapkey
 ```
 
 To do a release build (ios):
+
 ```
 cordova build ios --release
 ```
 
 To push a new release:
+
 ```
 code-push release-cordova electricitymap-{ios,android} {ios,android}
 code-push promote electricitymap-{ios,android} Staging Production
@@ -43,6 +57,7 @@ code-push promote electricitymap-{ios,android} Staging Production
 Note about releases: bumping the release number will cause a new binary to be created. All code-push updates are tied to a binary version, meaning that apps will only update to code-push updates that are compatible with their binary version.
 
 ## App/Play Store Release Checklist
+
 - Run a debug build on iOS/Android and check that code-push properly installs an update.
 - Check app icons
 
@@ -58,8 +73,7 @@ ld: library not found for -lGoogleToolboxForMac
 
 while building for ios, you should run `pod install` from the `platforms/ios` directory.
 
-
-If you get ablank screen on iOS, as https://github.com/Microsoft/cordova-plugin-code-push/issues/434 hardcodes the cordova-plugin-file version, you must:
+If you get a blank screen on iOS, as https://github.com/Microsoft/cordova-plugin-code-push/issues/434 hardcodes the cordova-plugin-file version, you must:
 
 ```
 cordova plugin rm cordova-plugin-file --force
@@ -71,11 +85,13 @@ cordova plugin add cordova-plugin-file-transfer@latest
 If the Android icons are not working, check the AndroidManifest.xml and double check that the key "@mipmap/ic_launcher" is correctly set (and not @mipmap/icon)
 
 ### Cannot find module '../../src/plugman/platforms/ios'
+
 (From https://github.com/nordnet/cordova-universal-links-plugin/issues/131#issuecomment-387761895)
 
 In plugins\cordova-universal-links-plugin\hooks\lib\ios\xcodePreferences.js
 
 Change line 135-150:
+
 ```javascript
 function loadProjectFile() {
   var platform_ios;
@@ -121,13 +137,38 @@ function loadProjectFile() {
 ```
 
 ### Cannot read property 'manifest' of undefined
+
 (From https://stackoverflow.com/a/57638582/11940257)
 
 Go to file `plugins/cordova-universal-links-plugin/hooks/lib/android/manifestWriter.js` and change the following:
+
 ```javascript
-var pathToManifest = path.join(cordovaContext.opts.projectRoot, 'platforms', 'android', 'cordovaLib', 'AndroidManifest.xml');
+var pathToManifest = path.join(
+  cordovaContext.opts.projectRoot,
+  "platforms",
+  "android",
+  "cordovaLib",
+  "AndroidManifest.xml"
+);
 ```
+
 to
+
 ```javascript
-var pathToManifest = path.join( cordovaContext.opts.projectRoot, 'platforms', 'android', 'app', 'src', 'main', 'AndroidManifest.xml');
+var pathToManifest = path.join(
+  cordovaContext.opts.projectRoot,
+  "platforms",
+  "android",
+  "app",
+  "src",
+  "main",
+  "AndroidManifest.xml"
+);
+```
+
+### iOS: Module 'Firebase' not found
+
+```bash
+cd platforms/ios
+pod install
 ```

--- a/mobileapp/package.json
+++ b/mobileapp/package.json
@@ -28,7 +28,8 @@
     "url": "https://github.com/corradio/electricitymap.git"
   },
   "scripts": {
-    "build": "bash build.sh"
+    "build": "bash build.sh",
+    "clean": "rm -rf platforms plugins src ui_web_hooks www/electricitymap locales"
   },
   "cordova": {
     "plugins": {


### PR DESCRIPTION
This PR updates the documentation to get the mobile app running locally. 

### Random findings
- build error: `platforms/ios/electricityMap.xcodeproj Building for iOS Simulator, but the embedded framework 'Sentry.framework' was built for iOS + iOS Simulator.`
- `cordova platform remove ios && cordova platform add ios` might help
- building from Xcode resolves some issues (without running `cordova prepare`)
- when building through Xcode I don't need the `GoogleService-Info.plist` file
