### PR TITLE
Fix iOS layout regression

### DIFF
--- a/mobileapp/.gitignore
+++ b/mobileapp/.gitignore
@@ -6,3 +6,9 @@ plugins
 platforms
 
 www/electricitymap
+
+src
+ul_web_hooks/
+GoogleService-Info.plist
+google-services.json
+locales-config.json

--- a/web/src/cordova.js
+++ b/web/src/cordova.js
@@ -39,27 +39,24 @@ export const cordovaApp = {
         #mobile-header {
           padding-top: ${top};
         }
+        .controls-container {
+          margin-top: ${top};
+        }
+        .flash-message .inner {
+          padding-top: ${top};
+        }
+        .mapboxgl-zoom-controls {
+          transform: translate(0, ${top});
+        }
+        .layer-buttons-container {
+          transform: translate(0, ${top});
+        }
 
-        @include respond-to('small') {
-          .controls-container {
-            margin-top: ${top};
-          }
-          .flash-message .inner {
-            padding-top: ${top};
-          }
-          .mapboxgl-zoom-controls {
-            transform: translate(0, ${top});
-          }
-          .layer-buttons-container {
-            transform: translate(0, ${top});
-          }
-
-          #tab {
-            padding-bottom: ${bottom};
-          }
-          .modal {
-            padding-bottom: ${bottom};
-          }
+        #tab {
+          padding-bottom: ${bottom};
+        }
+        .modal {
+          padding-bottom: ${bottom};
         }
         `
       };


### PR DESCRIPTION
#3034

https://github.com/tmrowco/electricitymap-contrib/pull/3109 introduced a regression. I believe this issue is related to trying to avoid the padding on larger screens. but the `@include respond-to('small')` selector is scss and needs a preprocessor.

I'll look into adding a proper media query, but it could be done in another PR.

### Before this PR

<img width="528" alt="Screenshot 2021-05-06 at 21 18 24" src="https://user-images.githubusercontent.com/1260305/117355195-8abd3700-aeb2-11eb-99f8-48648c802b0e.png">


### After this PR

For some reason we see a lot of 500 internal server errors when developing locally for `v3/state`. So I couldn't get a nice screenshot 🤔 

<img width="520" alt="Screenshot 2021-05-06 at 21 29 01" src="https://user-images.githubusercontent.com/1260305/117355154-7aa55780-aeb2-11eb-816c-8b1a95796e1b.png">
 <img width="528" alt="Screenshot 2021-05-06 at 21 27 21" src="https://user-images.githubusercontent.com/1260305/117355167-7ed17500-aeb2-11eb-8e05-382d96c58edd.png">
