### PR TITLE
Handle None hydro value for EIA parser

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -418,7 +418,7 @@ def fetch_production_mix(zone_key, session=None, target_datetime=None, logger=No
                 0 > point['value'] >= negative_threshold:
                 point['value'] = 0
 
-            if type == 'hydro' and point['value'] < 0:
+            if type == 'hydro' and point['value'] and point['value'] < 0:
                 point.update({
                     'production': {},# required by merge_production_outputs()
                     'storage': {type: point.pop('value')},


### PR DESCRIPTION
Simple check for None values to stop the EIA parser from breaking.

It looks like there aren't any existing tests for this parser so I wasn't sure if I should be adding a regression test?