### PR TITLE
update USA capacites Q1

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -306,6 +306,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Biomass, Solar, Wind and Geothermal: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
   - Coal: [TEJO](https://www.tejoenergia.com/en/aboutus/)
   - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- Puerto Rico:[EIA](https://www.eia.gov/electricity/data/eia860M/)
 - Qatar: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
 - Romania:
   - Nuclear: [Nuclearelectrica](http://www.nuclearelectrica.ro/cne/)
@@ -346,7 +347,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - United Arab Emirates: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
 - United States of America
   - Federal: [EIA](https://www.eia.gov/electricity/data.cfm#gencapacity)
-             [EIA](https://www.eia.gov/electricity/data/eia860M/)
+  - Balancing Authorities: [EIA](https://www.eia.gov/electricity/data/eia860M/)
   - States: [EIA](https://www.eia.gov/electricity/data/state/)
   - BPA: [BPA](https://transmission.bpa.gov/business/operations/Wind/baltwg.aspx)
   - CAISO

--- a/config/zones.json
+++ b/config/zones.json
@@ -5549,6 +5549,20 @@
     "timezone": null
   },
   "PR": {
+    "capacity": {
+      "battery storage": 0,
+      "biomass": 4.8,
+      "coal": 510,
+      "gas": 1400,
+      "geothermal": 0,
+      "hydro": 98.1,
+      "hydro storage": 0,
+      "nuclear": 0,
+      "oil": 4004.1,
+      "solar": 157.7,
+      "unknown": 0,
+      "wind": 125.1
+    },
     "contributors": [
       "https://github.com/q--",
       "https://github.com/systemcatch",
@@ -5703,7 +5717,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 72.2,
-      "solar": 147.7,
+      "solar": 310.1,
       "unknown": 0,
       "wind": 0
     },
@@ -5733,18 +5747,18 @@
   "US-CAL-CISO": {
     "comment": "California Independent System Operator",
     "capacity": {
-      "battery storage": 610.4,
-      "biomass": 1194.6,
+      "battery storage": 735.4,
+      "biomass": 1177.9,
       "coal": 62.5,
       "gas": 32964.7,
       "geothermal": 2103.5,
-      "hydro": 6714.3,
+      "hydro": 6716.3,
       "hydro storage": 2094.4,
       "nuclear": 2323,
-      "oil": 466,
-      "solar": 14801.6,
+      "oil": 391.5,
+      "solar": 14850.8,
       "unknown": 99.7,
-      "wind": 5912.5
+      "wind": 5961.3
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -5781,7 +5795,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 24.9,
-      "solar": 371.4,
+      "solar": 383.4,
       "unknown": 0,
       "wind": 0
    },
@@ -5890,7 +5904,7 @@
     "comment": "Duke Energy Progress East",
     "capacity": {
       "battery storage": 0,
-      "biomass": 559.1,
+      "biomass": 356.6,
       "coal": 3373.9,
       "gas": 6489.8,
       "geothermal": 0,
@@ -5898,7 +5912,7 @@
       "hydro storage": 0,
       "nuclear": 3722.7,
       "oil": 282.1,
-      "solar": 1504.1,
+      "solar": 1511.1,
       "unknown": 54,
       "wind": 0
     },
@@ -5968,15 +5982,15 @@
     "comment": "Duke Energy Carolinas",
     "capacity": {
       "battery storage": 0,
-      "biomass": 90.9,
-      "coal": 7317.1,
+      "biomass": 100.2,
+      "coal": 7045.1,
       "gas": 10719,
       "geothermal": 0,
       "hydro": 1180.7,
       "hydro storage": 2070,
       "nuclear": 7517.5,
-      "oil": 144,
-      "solar": 2221,
+      "oil": 143.4,
+      "solar": 2213.6,
       "unknown": 0,
       "wind": 0
     },
@@ -6054,7 +6068,7 @@
       "hydro storage": 587.2,
       "nuclear": 1029.6,
       "oil": 33.8,
-      "solar": 874,
+      "solar": 903.2,
       "unknown": 0,
       "wind": 0
     },
@@ -6126,7 +6140,7 @@
       "coal": 261,
       "gas": 32.8,
       "geothermal": 0,
-      "hydro": 1507.1,
+      "hydro": 1512.1,
       "hydro storage": 161.4,
       "nuclear": 0,
       "oil": 15,
@@ -6163,15 +6177,15 @@
       "battery storage": 25,
       "biomass": 345.8,
       "coal": 22064.3,
-      "gas": 36389,
+      "gas": 36392.2,
       "geothermal": 0,
       "hydro": 3104.1,
       "hydro storage": 259.2,
       "nuclear": 2068.7,
       "oil": 2181.4,
-      "solar": 391.6,
+      "solar": 396.4,
       "unknown": 62,
-      "wind": 24769.5
+      "wind": 25352.5
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -6240,15 +6254,15 @@
     "comment": "Duke Energy Florida Inc",
     "capacity": {
       "battery storage": 0,
-      "biomass": 272.4,
+      "biomass": 269.2,
       "coal": 1478.4,
-      "gas": 11191.6,
+      "gas": 11223.9,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 1329.7,
-      "solar": 446.5,
+      "solar": 596.3,
       "unknown": 18.8,
       "wind": 0
     },
@@ -6278,16 +6292,16 @@
   "US-FLA-FPL": {
     "comment": "Florida Power & Light Company",
     "capacity": {
-      "battery storage": 14,
+      "battery storage": 24,
       "biomass": 622.4,
       "coal": 0,
-      "gas": 22017,
+      "gas": 23743.6,
       "geothermal": 0,
       "hydro": 43.5,
       "hydro storage": 0,
       "nuclear": 3797.2,
-      "oil": 1988.1,
-      "solar": 2275.3,
+      "oil": 261.5,
+      "solar": 2796.8,
       "unknown": 0,
       "wind": 0
     },
@@ -6460,8 +6474,8 @@
     "capacity": {
       "battery storage": 0,
       "biomass": 1.6,
-      "coal": 1471.8,
-      "gas": 897,
+      "coal": 1429.2,
+      "gas": 853.3,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
@@ -6614,16 +6628,16 @@
   "US-MIDA-PJM": {
     "comment": "Pjm Interconnection, Llc",
     "capacity": {
-      "battery storage": 299.9,
-      "biomass": 2348.3,
-      "coal": 49937.8,
-      "gas": 98841.1,
+      "battery storage": 300.7,
+      "biomass": 2330.3,
+      "coal": 49679.5,
+      "gas": 98749.2,
       "geothermal": 0,
       "hydro": 3308.7,
       "hydro storage": 5103.3,
       "nuclear": 34466.6,
-      "oil": 6987.1,
-      "solar": 4626,
+      "oil": 6963.6,
+      "solar": 4894.3,
       "unknown": 133.2,
       "wind": 10171.5
     },
@@ -6782,17 +6796,17 @@
     "comment": "Midcontinent Independent Transmission System Operator, Inc..",
     "capacity": {
       "battery storage": 55.4,
-      "biomass": 2490.4,
-      "coal": 61208.4,
-      "gas": 83019.3,
+      "biomass": 2487.4,
+      "coal": 61158.4,
+      "gas": 82858.1,
       "geothermal": 0,
-      "hydro": 2423.7,
+      "hydro": 2428,
       "hydro storage": 2414.8,
       "nuclear": 13080.8,
-      "oil": 5037.4,
-      "solar": 2061,
-      "unknown": 632,
-      "wind": 26455
+      "oil": 5047.2,
+      "solar": 2204.2,
+      "unknown": 624.7,
+      "wind": 27159.1
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -6824,16 +6838,16 @@
   "US-NE-ISNE": {
     "comment": "Iso New England Inc.",
     "capacity": {
-      "battery storage": 95.1,
-      "biomass": 1616.1,
+      "battery storage": 107.6,
+      "biomass": 1613.9,
       "coal": 959.2,
-      "gas": 19672.1,
+      "gas": 19607.8,
       "geothermal": 0,
-      "hydro": 1926.2,
+      "hydro": 1918.6,
       "hydro storage": 1799,
       "nuclear": 3404.9,
-      "oil": 6400.8,
-      "solar": 1487.5,
+      "oil": 6325,
+      "solar": 1535,
       "unknown": 0,
       "wind": 1504.4
     },
@@ -6868,7 +6882,7 @@
       "coal": 0,
       "gas": 563.7,
       "geothermal": 0,
-      "hydro": 1255.6,
+      "hydro": 1173.9,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 2.8,
@@ -6930,7 +6944,7 @@
     "comment": "Bonneville Power Administration",
     "capacity": {
       "battery storage": 3,
-      "biomass": 417.9,
+      "biomass": 419.5,
       "coal": 729.9,
       "gas": 2277.5,
       "geothermal": 18,
@@ -6938,7 +6952,7 @@
       "hydro storage": 314,
       "nuclear": 1200,
       "oil": 0,
-      "solar": 143.7,
+      "solar": 87.9,
       "unknown": 0,
       "wind": 3377.5
     },
@@ -7192,7 +7206,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 21,
-      "solar": 1593.8,
+      "solar": 1845.8,
       "unknown": 7.5,
       "wind": 150
     },
@@ -7270,7 +7284,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 30.4,
-      "solar": 1286.4,
+      "solar": 1466.4,
       "unknown": 52.8,
       "wind": 2690.1
     },
@@ -7309,7 +7323,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 0,
-      "solar": 239.8,
+      "solar": 413.7,
       "unknown": 0,
       "wind": 714.3
     },
@@ -7348,7 +7362,7 @@
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 0,
-      "solar": 125.7,
+      "solar": 133,
       "unknown": 0,
       "wind": 716.5
     },
@@ -7378,7 +7392,7 @@
   "US-NW-PSCO": {
     "comment": "Public Service Company Of Colorado",
     "capacity": {
-      "battery storage": 1,
+      "battery storage": 2,
       "biomass": 30.8,
       "coal": 1311.3,
       "gas": 6510,
@@ -7386,8 +7400,8 @@
       "hydro": 55.2,
       "hydro storage": 300,
       "nuclear": 0,
-      "oil": 50.4,
-      "solar": 520.5,
+      "oil": 33.2,
+      "solar": 548.5,
       "unknown": 0,
       "wind": 4490.8
     },
@@ -7420,7 +7434,7 @@
       "battery storage": 2,
       "biomass": 37.9,
       "coal": 0,
-      "gas": 2053.5,
+      "gas": 2072,
       "geothermal": 0,
       "hydro": 347.8,
       "hydro storage": 0,
@@ -7537,7 +7551,7 @@
       "battery storage": 8.2,
       "biomass": 3.2,
       "coal": 5929.6,
-      "gas": 1947.4,
+      "gas": 1928.8,
       "geothermal": 0,
       "hydro": 704.3,
       "hydro storage": 208.5,
@@ -7545,7 +7559,7 @@
       "oil": 158.8,
       "solar": 192.2,
       "unknown": 11.5,
-      "wind": 781.6
+      "wind": 805.6
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -7649,16 +7663,16 @@
   "US-NY-NYIS": {
     "comment": "New York Independent System Operator",
     "capacity": {
-      "battery storage": 48.1,
+      "battery storage": 49.6,
       "biomass": 517.7,
-      "coal": 627.2,
-      "gas": 27127.6,
+      "coal": 531.2,
+      "gas": 27098.2,
       "geothermal": 0,
       "hydro": 4690.2,
       "hydro storage": 1240,
-      "nuclear": 4410.4,
-      "oil": 3831.1,
-      "solar": 642.7,
+      "nuclear": 3398.4,
+      "oil": 3858.8,
+      "solar": 666.9,
       "unknown": 20,
       "wind": 1989.2
     },
@@ -7765,15 +7779,15 @@
     "comment": "Southern Company Services, Inc. - Trans",
     "capacity": {
       "battery storage": 2.2,
-      "biomass": 1997.7,
+      "biomass": 1991.1,
       "coal": 16164.8,
-      "gas": 34926.9,
+      "gas": 34930.1,
       "geothermal": 0,
       "hydro": 3310.4,
       "hydro storage": 1306.6,
       "nuclear": 6054.4,
       "oil": 1284.8,
-      "solar": 2589.6,
+      "solar": 2609.4,
       "unknown": 0,
       "wind": 0
     },
@@ -7804,15 +7818,15 @@
     "comment": "Arizona Public Service Company",
     "capacity": {
       "battery storage": 2,
-      "biomass": 36.2,
-      "coal": 1749.8,
+      "biomass": 33.4,
+      "coal": 2062.1,
       "gas": 2714.6,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 123.8,
-      "solar": 769.2,
+      "solar": 757.5,
       "unknown": 0,
       "wind": 174.3
     },
@@ -8040,7 +8054,7 @@
       "oil": 30.4,
       "solar": 369.9,
       "unknown": 1.1,
-      "wind": 1065.8
+      "wind": 1230.8
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -8077,7 +8091,7 @@
       "hydro storage": 154.1,
       "nuclear": 4209.6,
       "oil": 0,
-      "solar": 355.4,
+      "solar": 360,
       "unknown": 0,
       "wind": 63
     },
@@ -8110,15 +8124,15 @@
       "battery storage": 20,
       "biomass": 0,
       "coal": 1765.8,
-      "gas": 1012.7,
+      "gas": 965.7,
       "geothermal": 0,
       "hydro": 0,
       "hydro storage": 0,
       "nuclear": 0,
       "oil": 0,
-      "solar": 323.5,
+      "solar": 456.5,
       "unknown": 0,
-      "wind": 30
+      "wind": 279.8
     },
     "contributors": [
       "https://github.com/systemcatch",
@@ -8227,15 +8241,15 @@
       "battery storage": 223.1,
       "biomass": 189.5,
       "coal": 15217.2,
-      "gas": 64479,
+      "gas": 64842,
       "geothermal": 0,
-      "hydro": 567,
+      "hydro": 569.7,
       "hydro storage": 0,
       "nuclear": 5138.6,
       "oil": 111.8,
-      "solar": 4912,
+      "solar": 6042,
       "unknown": 234.7,
-      "wind": 28110.8
+      "wind": 28384
     },
     "contributors": [
       "https://github.com/systemcatch",


### PR DESCRIPTION
I updated the capacities of the USA with the same source as before. EIA publishes the new data on a monthly basis with a 3 months delay. I'll do an update every quarter since it is a lot of work going through all the balacing authorities and most of the USA isn't colored at the moment anyway. 

Also I added Puerto Ricos capacities. They're included in the same report.