### PR TITLE
Update installed capacity data for Ontario

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1065,11 +1065,11 @@
   "CA-ON": {
     "capacity": {
       "biomass": 295,
-      "gas": 11270,
-      "hydro": 9065,
+      "gas": 11317,
+      "hydro": 9060,
       "nuclear": 13009,
       "solar": 478,
-      "wind": 4486,
+      "wind": 4786,
       "coal": 0
     },
     "contributors": [


### PR DESCRIPTION
Updates the installed generation capacity data for Ontario according to the latest [IESO Reliability Outlook](file:///C:/Users/Felix/AppData/Local/Temp/ReliabilityOutlook2021Mar.pdf) from March 2021.