### PR TITLE
Removes old CL-SIC zone

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1292,20 +1292,6 @@
     ],
     "timezone": "America/Punta_Arenas"
   },
-  "CL-SIC": {
-    "_todo": "remove. See https://github.com/tmrowco/tmrow/issues/3188",
-    "bounding_box": [
-      [
-        -74.71,
-        -44.02
-      ],
-      [
-        -66.88,
-        -17.39
-      ]
-    ],
-    "timezone": "Chile/Continental"
-  },
   "CL-CHP": {
     "bounding_box": [
       [

--- a/web/locales/cs.json
+++ b/web/locales/cs.json
@@ -413,10 +413,6 @@
             "countryName": "Chile",
             "zoneName": "SING"
         },
-        "CL-SIC": {
-            "countryName": "Chile",
-            "zoneName": "SIC"
-        },
         "CL-SEM": {
             "countryName": "Chile",
             "zoneName": "SEM"

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -421,10 +421,6 @@
             "countryName": "Chile",
             "zoneName": "SING"
         },
-        "CL-SIC": {
-            "countryName": "Chile",
-            "zoneName": "SIC"
-        },
         "CL-SEM": {
             "countryName": "Chile",
             "zoneName": "SEM"

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -430,10 +430,6 @@
             "countryName": "Chili",
             "zoneName": "SING - SIC"
         },
-        "CL-SIC": {
-            "countryName": "Chili",
-            "zoneName": "SIC"
-        },
         "CL-SEM": {
             "countryName": "Chili",
             "zoneName": "SEM"

--- a/web/locales/ru.json
+++ b/web/locales/ru.json
@@ -337,10 +337,6 @@
             "countryName": "Чили",
             "zoneName": "SEM"
         },
-        "CL-SIC": {
-            "countryName": "Чили",
-            "zoneName": "SIC"
-        },
         "CL-SING": {
             "countryName": "Чили",
             "zoneName": "SING"

--- a/web/locales/sk.json
+++ b/web/locales/sk.json
@@ -409,10 +409,6 @@
             "countryName": "Čile",
             "zoneName": "SING"
         },
-        "CL-SIC": {
-            "countryName": "Čile",
-            "zoneName": "SIC"
-        },
         "CL-SEM": {
             "countryName": "Čile",
             "zoneName": "SEM"


### PR DESCRIPTION
## Description

This zone is no longer in use and was replaced a while ago by a new parser source in https://github.com/tmrowco/electricitymap-contrib/pull/2454.

Therefore we're removing it to reduce confusing and simplify code :)