### PR TITLE
Update US-ISO-NE coal capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -6826,7 +6826,7 @@
     "capacity": {
       "battery storage": 107.6,
       "biomass": 1613.9,
-      "coal": 959.2,
+      "coal": 559.2,
       "gas": 19607.8,
       "geothermal": 0,
       "hydro": 1918.6,


### PR DESCRIPTION
Update US-ISO-NE New England coal capacity to reflect [June 1st, 2021 retirement of coal fired 400-MW Bridgeport Harbor Station Unit 3 in Bridgeport, Connecticut](https://www.spglobal.com/platts/en/market-insights/latest-news/electric-power/060121-us-coal-fired-power-output-decline-continues-with-last-pseg-coal-plant-retirement).