### PR TITLE
change CA-NB unknown emission factor

### DIFF
--- a/config/co2eq_parameters.json
+++ b/config/co2eq_parameters.json
@@ -184,6 +184,13 @@
           "value": 597.2654373454017
         }
       },
+      "CA-NB": {
+        "unknown": {
+          "_comment": "Source: https://www.cer-rec.gc.ca/en/data-analysis/energy-markets/provincial-territorial-energy-profiles/provincial-territorial-energy-profiles-new-brunswick.html",
+          "source": "2018 Provincial and Territorial Energy Profiles - New Brunswick",
+          "value": 223
+        }
+      },
       "CA-NS": {
         "hydro discharge": {
           "source": "2017 average by Tomorrow",


### PR DESCRIPTION
I added/changed the emission factor of "unknown" for New Brunswick to 223. 
The data for the calculation is from the New Brunswicks Provincial and Territorial Energy Profile (https://www.cer-rec.gc.ca/en/data-analysis/energy-markets/provincial-territorial-energy-profiles/provincial-territorial-energy-profiles-new-brunswick.html).
I hope it can be colored on the map now too.