### PR TITLE
Update FR Coal Capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -2014,7 +2014,7 @@
     "capacity": {
       "battery storage": 7,
       "biomass": 1579,
-      "coal": 2977,
+      "coal": 2397,
       "gas": 12218,
       "geothermal": 16,
       "hydro": 18743.6955,
@@ -2026,6 +2026,7 @@
       "unknown": 1366
     },
     "contributors": [
+      "https://github.com/brandongalbraith",
       "https://github.com/corradio",
       "https://github.com/lorrieq",
       "https://github.com/nessie2013"


### PR DESCRIPTION
Update FR coal capacity to reflect March 31st, 2021 retirement of coal fired 580-MW Le Havre power station.

https://www.enerdata.net/publications/daily-energy-news/frances-edf-closes-580-mw-coal-fired-power-unit-le-havre.html