### PR TITLE
Update NYISO capacity data source and generation capacity data

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -354,7 +354,7 @@ For many European countries, data is available from [ENTSO-E](https://transparen
     - CEC: [CEC](https://ww2.energy.ca.gov/almanac/electricity_data/electric_generation_capacity.html)
     - Renewables: [CAISO](http://www.caiso.com/informed/Pages/CleanGrid/default.aspx)
     - Nuclear: [wikipedia.org](https://en.wikipedia.org/wiki/Diablo_Canyon_Power_Plant)
-  - NYISO: [NYISO Gold Book](https://home.nyiso.com/wp-content/uploads/2017/12/2017_Gold-Book.pdf)
+  - NYISO: [NYISO Gold Book](https://www.nyiso.com/documents/20142/2226333/2021-Gold-Book-Final-Public.pdf)
   - PJM: [PJM](http://www.pjm.com/-/media/markets-ops/ops-analysis/capacity-by-fuel-type-2019.ashx?la=en)
   - SPP: [SPP](https://www.spp.org/about-us/fast-facts/)
 - Uruguay: [UTE](https://portal.ute.com.uy/institucional/infraestructura/fuentes-de-generacion)

--- a/config/zones.json
+++ b/config/zones.json
@@ -7651,7 +7651,7 @@
     "capacity": {
       "battery storage": 49.6,
       "biomass": 517.7,
-      "coal": 531.2,
+      "coal": 0,
       "gas": 27098.2,
       "geothermal": 0,
       "hydro": 4690.2,
@@ -7665,7 +7665,8 @@
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/robertahunt",
-      "https://github.com/KabelWlan"
+      "https://github.com/KabelWlan",
+      "https://github.com/brandongalbraith"
     ],
     "flag_file_name": "us.png",
     "parsers": {


### PR DESCRIPTION
- [x] Update NYISO data source link to [new Gold Book URL](https://www.nyiso.com/documents/20142/2226333/2021-Gold-Book-Final-Public.pdf).
- [x] Update NYISO generation capacity data based on gold book content (page ~71-72 of PDF).

@KabelWlan recently updated this zone using [EIA's Preliminary Monthly Electric Generator Inventory](https://www.eia.gov/electricity/data/eia860M/) as part of https://github.com/tmrowco/electricitymap-contrib/pull/3166, but some reconciliation is required (NYISO Gold Book doesn't break out solar, and EIA data lists three coal fired units as out of service and not returning to service that Gold Book indicates have been permanently deactivated).