### PR TITLE
Fix pt-br one letter typo

### DIFF
--- a/web/locales/pt-br.json
+++ b/web/locales/pt-br.json
@@ -83,7 +83,7 @@
         "showWindLayer": "Mostrar a camada de vento",
         "hideWindLayer": "Esconder a camada de vento",
         "showSolarLayer": "Mostrar a camada solar",
-        "hideSolarLayer": "Esconder a camada solae",
+        "hideSolarLayer": "Esconder a camada solar",
         "toggleDarkMode": "Alternar modo escuro",
         "noParserInfo": "Nenhum dado disponível",
         "temporaryDataOutage": "Dados temporariamente indisponíveis",


### PR DESCRIPTION
Correcting the misspelled word "solae" to "solar" at line 86