### PR TITLE
Changes US-CA to use a simple proxy service based in US

### DIFF
--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -7,7 +7,8 @@ from bs4 import BeautifulSoup
 from collections import defaultdict
 import logging
 
-FUEL_SOURCE_CSV = 'http://www.caiso.com/outlook/SP/fuelsource.csv'
+CAISO_PROXY = 'https://us-ca-proxy-jfnx5klx2a-uw.a.run.app'
+FUEL_SOURCE_CSV = f'{CAISO_PROXY}/outlook/SP/fuelsource.csv'
 
 MX_EXCHANGE_URL = 'http://www.cenace.gob.mx/Paginas/Publicas/Info/DemandaRegional.aspx'
 


### PR DESCRIPTION
## Description

As discussed in #3183, the source is currently down because certain European countries (including the one where our server is located in).

A (somewhat temporary) solution to this is to change the parser to call a new proxy service [created by @steren](https://github.com/steren/simple-url-proxy-server).


### Preview

![Screenshot 2021-07-19 at 11 56 27](https://user-images.githubusercontent.com/3296643/126142284-7fbd02b8-5ec4-4c0b-b1f3-df3408bfc5c4.png)
