### PR TITLE
Edit russia

### DIFF
--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -1308,7 +1308,7 @@
       43.158267
     ],
     "parsers": {
-      "exchange": "GE.fetch_exchange"
+      "exchange": "RU.fetch_exchange"
     },
     "rotation": 0
   },

--- a/config/exchanges.json
+++ b/config/exchanges.json
@@ -2370,6 +2370,16 @@
     },
     "rotation": -135
   },
+  "RU-1->UA-CR": {
+    "lonlat": [
+      36.60,
+      45.25
+    ],
+    "parsers": {
+      "exchange": "RU.fetch_exchange"
+    },
+    "rotation": -90
+  },
   "SE-SE1->SE-SE2": {
     "parsers": {
       "exchangeForecast": "ENTSOE.fetch_exchange_forecast"

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -24,21 +24,21 @@ MAP_GENERATION = {
     'P_REN': 'solar'
 }
 
-exchange_ids = {'CN->RU-AS': 764,
-                'MN->RU': 276,
-                'MN->RU-2': 276,
-                'KZ->RU': 785,
-                'KZ->RU-1': 2394,
-                'KZ->RU-2': 344,
-                'RU-1->RU-2': 139,
-                'GE->RU': 752,
-                'GE->RU-1': 752,
+exchange_ids = {'RU-AS->CN': 764,
+                'RU->MN': 276,
+                'RU-2->MN': 276,
+                'RU->KZ': 785,
+                'RU-1->KZ': 2394,
+                'RU-2->KZ': 344,
+                'RU-2->RU-1': 139,
+                'RU->GE': 752,
+                'RU-1->GE': 752,
                 'AZ->RU': 598,
                 'AZ->RU-1': 598,
                 'BY->RU': 321,
                 'BY->RU-1': 321,
                 'RU-1->UA-CR': 5688,
-                'RU-1->UA':880}
+                'UA->RU-1': 880}
 
 # Each exchange is contained in a div tag with a "data-id" attribute that is unique.
 
@@ -161,8 +161,15 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
             continue
 
     sortedcodes = '->'.join(sorted([zone_key1, zone_key2]))
+    reversesortedcodes = '->'.join(sorted([zone_key1, zone_key2], reverse=True))
 
-    if sortedcodes not in exchange_ids.keys():
+    if sortedcodes in exchange_ids.keys():
+        exchange_id = exchange_ids[sortedcodes]
+        direction = 1
+    elif reversesortedcodes in exchange_ids.keys():
+        exchange_id = exchange_ids[reversesortedcodes]
+        direction = -1
+    else:
         raise NotImplementedError('This exchange pair is not implemented.')
 
     exchange_id = exchange_ids[sortedcodes]
@@ -171,7 +178,7 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
     for datapoint, hour in datapoints:
         try:
             exchange = [item for item in datapoint if item['Id'] == exchange_id][0]
-            flow = exchange.get('NumValue')
+            flow = exchange.get('NumValue') * direction
         except KeyError:
             # flow is unknown or not available
             flow = None

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -37,7 +37,7 @@ exchange_ids = {'CN->RU-AS': 764,
                 'AZ->RU-1': 598,
                 'BY->RU': 321,
                 'BY->RU-1': 321,
-                'RU->UA': 880,
+                'RU-1->UA-CR': 5688,
                 'RU-1->UA':880}
 
 # Each exchange is contained in a div tag with a "data-id" attribute that is unique.
@@ -221,8 +221,8 @@ if __name__ == '__main__':
     print(fetch_exchange('BY', 'RU'))
     print('fetch_exchange(BY, RU-1) ->')
     print(fetch_exchange('BY', 'RU-1'))
-    print('fetch_exchange(RU, UA) ->')
-    print(fetch_exchange('RU', 'UA'))
+    print('fetch_exchange(RU-1, UA-CR) ->')
+    print(fetch_exchange('RU-1', 'UA-CR'))
     print('fetch_exchange(RU-1, UA) ->')
     print(fetch_exchange('RU-1', 'UA'))
     print('fetch_exchange(RU-1, RU-2) ->')

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -37,6 +37,9 @@ exchange_ids = {'RU-AS->CN': 764,
                 'AZ->RU-1': 598,
                 'BY->RU': 321,
                 'BY->RU-1': 321,
+                'RU->FI': 187,
+                'RU-1->FI': 187,
+                'RU-KGD->LT': 212,
                 'RU-1->UA-CR': 5688,
                 'UA->RU-1': 880}
 

--- a/parsers/RU.py
+++ b/parsers/RU.py
@@ -175,8 +175,6 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
     else:
         raise NotImplementedError('This exchange pair is not implemented.')
 
-    exchange_id = exchange_ids[sortedcodes]
-
     data = []
     for datapoint, hour in datapoints:
         try:

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -1244,17 +1244,19 @@
           },
           "RU-1": {
             "countryName": "Russia",
-            "zoneName": "European Russia and Ural"
+            "zoneName": "Europe-Ural"
           },
           "RU-2": {
             "countryName": "Russia",
             "zoneName": "Siberia"
           },
           "RU-EU": {
-            "zoneName": "Russia"
+            "countryName": "Russia",
+            "zoneName": "Arctic"
           },
           "RU-AS": {
-            "zoneName": "Russia"
+            "countryName": "Russia",
+            "zoneName": "East"
           },
           "RU-KGD": {
             "countryName": "Russia",
@@ -1379,8 +1381,8 @@
             "zoneName": "Ukraine"
           },
           "UA-CR": {
-            "countryName": "Crimea",
-            "zoneName": "Ukraine"
+            "countryName": "Ukraine",
+            "zoneName": "Crimea"
           },
           "UG": {
             "zoneName": "Uganda"

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -1367,8 +1367,8 @@
             "zoneName": "Ukraine"
         },
         "UA-CR": {
-            "countryName": "Crimée",
-            "zoneName": "Ukraine"
+            "zoneName": "Crimée",
+            "countryName": "Ukraine"
         },
         "UG": {
             "zoneName": "Ouganda"

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -1232,17 +1232,19 @@
         },
         "RU-1": {
             "countryName": "Russie",
-            "zoneName": "Russie européenne et Ural"
+            "zoneName": "Europe-Oural"
         },
         "RU-2": {
             "countryName": "Russie",
             "zoneName": "Sibérie"
         },
         "RU-EU": {
-            "zoneName": "Russie"
+            "countryName": "Russie",
+            "zoneName": "Arctique"
         },
         "RU-AS": {
-            "zoneName": "Russie"
+            "countryName": "Russie",
+            "zoneName": "Orient"
         },
         "RU-KGD": {
             "countryName": "Russie",


### PR DESCRIPTION
Hello,
I propose these updates on Russia's data:
- add exchange data and arrow between european Russia and Crimea
- edit some wrong direction of exchanges between Russia and some other states. It was assumed that the direction was from states based on their alphabetical order, which is not the case. I checked consistency on https://br.so-ups.ru/ to get the right one.
- add some exchange informations between Russia and Finland and Lituania even if it already existed with other sources but it can be useful
- changed the source for exchange between Russia and Georgia because the current one doesn't look like it is working, so I put the source to RU.fetch_exchange