### PR TITLE
Adds executors, faster checkout and minor changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,12 @@ version: 2.1
 executors:
   js-exec:
     docker:
-      - image: node:12.22
+      - image: node:12.22-alpine
 
 commands:
   fast-checkout:
     steps:
+      - run: command -v apk >/dev/null && command apk add git "$@" || exit 0
       - run: git clone --depth 1 https://github.com/tmrowco/electricitymap-contrib.git --branch "$CIRCLE_BRANCH" --single-branch .
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,21 @@
-version: 2
+version: 2.1
+
+executors:
+  js-exec:
+    docker:
+      - image: node:12.22
+
+commands:
+  fast-checkout:
+    steps:
+      - run: git clone --depth 1 https://github.com/tmrowco/electricitymap-contrib.git --branch "$CIRCLE_BRANCH" --single-branch .
+
 jobs:
   verify_python:
     docker:
       - image: circleci/python:3.7.9
     steps:
-      - checkout
+      - fast-checkout
       - restore_cache:
           key: venv-{{ checksum "poetry.lock" }}
       - run:
@@ -28,54 +39,51 @@ jobs:
             - ".venv"
 
   lint_json:
-    docker:
-      - image: circleci/node:12.13
+    executor: js-exec
     steps:
-      - checkout
+      - fast-checkout
       - run:
           command: |
-            sudo npm install -g jsonlint-mod
-            jsonlint config/*.json web/locales/*.json
+            npm install -g jsonlint-mod
+            jsonlint -q config/*.json web/locales/*.json
 
   test_js:
-    docker:
-      - image: circleci/node:12.13
+    executor: js-exec
     steps:
-      - checkout
+      - fast-checkout
       - run:
           command: |
-            sudo npm install -g jest
+            npm install -g jest
             jest
 
   lint_js:
-    docker:
-      - image: circleci/node:12.13
+    executor: js-exec
     steps:
-      - checkout
+      - fast-checkout
       - restore_cache:
           key: node_modules-{{ .Branch }}-{{ checksum "web/yarn.lock" }}
       - run:
           command: |
             set -eux -o pipefail
-            pushd web
-            yarn
-            yarn lint
+            cd web
+            yarn install --frozen-lockfile
+            yarn lint --quiet
       - save_cache:
           key: node_modules-{{ .Branch }}-{{ checksum "web/yarn.lock" }}
           paths:
-            - "web/node_modules"
+            - web/node_modules
 
   build_test:
     machine:
       image: circleci/classic:201808-01
       docker_layer_caching: true
     steps:
-      - checkout
+      - fast-checkout
       - run:
           name: Build
           command: |
             set -euo pipefail
-            docker-compose build
+            docker-compose build mockserver web
             # Make sure files are available outside of container
             CONTAINER_ID=$(docker create eu.gcr.io/tmrow-152415/electricitymap_web:latest)
             docker cp $CONTAINER_ID:/home/src/electricitymap/contrib/web/public/dist web/public/dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,12 @@ executors:
 commands:
   fast-checkout:
     steps:
-      - run: command -v apk >/dev/null && command apk add git "$@" || exit 0
-      - run: git clone --depth 1 https://github.com/tmrowco/electricitymap-contrib.git --branch "$CIRCLE_BRANCH" --single-branch .
+      - run: 
+          name: install git (if required)
+          command: command -v apk >/dev/null && command apk add git "$@" || exit 0
+      - run: 
+          name: fast-checkout
+          command: git clone --depth 1 https://github.com/tmrowco/electricitymap-contrib.git --branch "$CIRCLE_BRANCH" --single-branch .
 
 jobs:
   verify_python:

--- a/mockserver/Dockerfile
+++ b/mockserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.7-alpine
 WORKDIR /home
 EXPOSE 8000
 ADD server.py server.py

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p public/dist/
 ADD web/third_party_maps ./third_party_maps
 ADD web/generate-geometries.js web/topogen.sh ./
 ADD web/src/world.json ./src/world.json
-RUN /bin/sh topogen.sh
+RUN time /bin/sh topogen.sh
 
 ARG ELECTRICITYMAP_PUBLIC_TOKEN
 
@@ -20,7 +20,8 @@ ARG ELECTRICITYMAP_PUBLIC_TOKEN
 # (note: this will override the world.json that was previously created)
 ADD config /home/src/electricitymap/contrib/config
 ADD web ./
-RUN yarn lint && yarn build-release
+RUN time yarn lint
+RUN time yarn build-release
 
 EXPOSE 8000
 ENV PORT 8000

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,18 +1,18 @@
-FROM node:12.13.1
+FROM node:12.22-alpine
 WORKDIR /home/src/electricitymap/contrib/web
 
 # Install dependencies
-RUN apt-get update && apt-get install -y jq unzip
+RUN apk add jq unzip curl
 ADD web/package.json ./package.json
 ADD web/yarn.lock ./yarn.lock
-RUN yarn
+RUN yarn install --frozen-lockfile
 
 # Generate map
 RUN mkdir -p public/dist/
 ADD web/third_party_maps ./third_party_maps
 ADD web/generate-geometries.js web/topogen.sh ./
 ADD web/src/world.json ./src/world.json
-RUN bash topogen.sh
+RUN /bin/sh topogen.sh
 
 ARG ELECTRICITYMAP_PUBLIC_TOKEN
 


### PR DESCRIPTION
## Description

This should make CI a bit faster.

It's unfortunately not as much as I would have liked, but I ended up spending quite some time trying to cache/reuse node_modules across `docker` and `machine` executors (which didn't go well).

The webpack building could probably be optimized and the geo-generation (downloading maps) could also be improved :)

**Improvements here:**

- Switches to `alpine` images
- Uses custom, faster checkout step
- Avoids building `web-watch` imager
