### PR TITLE
Update data-source and add archive for moldova

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -274,7 +274,10 @@ For many European countries, data is available from [ENTSO-E](https://transparen
 - Malaysia: [GSO](https://www.gso.org.my/SystemData/PowerStation.aspx)
 - Moldova
   - Renewable: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
-  - Other: [FAS](<http://en.fas.gov.ru/upload/other/National%20Agency%20for%20Energy%20Regulation%20(G.%20Pyrzy).pdf>)
+  - Gas (CET-1 & CET-2 Chişinău): [Termoelectrica](https://www.termoelectrica.md/ro_RO/despre/informatii-tehnice/)
+  - Gas (CET-Nord): [CET-Nord](https://www.cet-nord.md/en/transparent/tep)
+  - Gas and coal (CERS Moldovenească): [MOLDGRES](http://moldgres.com/o-predpriyatii/equipment)
+  - Summary as permanent document (slightly outdated): [FAS](<http://en.fas.gov.ru/upload/other/National%20Agency%20for%20Energy%20Regulation%20(G.%20Pyrzy).pdf>)
 - Montenegro
   - Solar, Hydro & Wind: [IRENA](https://www.irena.org/-/media/Files/IRENA/Agency/Publication/2020/Mar/IRENA_RE_Capacity_Statistics_2020.pdf)
   - Other: [EPCG](http://www.epcg.com/en/about-us/production-facilities)

--- a/config/zones.json
+++ b/config/zones.json
@@ -3678,19 +3678,22 @@
     ],
     "capacity": {
       "biomass": 6,
-      "gas": 335,
+      "gas": 1263,
       "hydro": 64,
       "solar": 4,
       "wind": 29,
-      "unknown": 2520
+      "coal": 1600
     },
     "contributors": [
       "https://github.com/systemcatch",
       "https://github.com/alixunderplatz",
       "https://github.com/nessie2013",
-      "https://github.com/lgrigoryeva1"
+      "https://github.com/lgrigoryeva1",
+      "https://github.com/Impelon"
     ],
     "parsers": {
+      "consumption": "MD.fetch_consumption",
+      "price": "MD.fetch_price",
       "production": "MD.fetch_production"
     },
     "timezone": "Europe/Chisinau"

--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -4,35 +4,59 @@
 """Parser for Moldova."""
 
 import arrow
-from operator import itemgetter
 import requests
 
-TYPE_MAPPING = {
-    u'tmva476': 'hydro',  # NHE Costeşti (run-of-river) #2 index
-    u'tmva112': 'hydro',  # NHE Dubăsari (run-of-river) #4 index
-    u'tmva367': 'gas',  # CET Nord (CHPP) #3 index
-    u'tmva42': 'gas',  # CET-1 Chişinău (CHPP) #6 index
-    u'tmva378': 'gas',  # CET-2 Chişinău (CHPP) #5 index
-    u'tmva1024': 'gas',  # CERS Moldovenească (fuel mix 2017 99.92% gas, 0.08% oil) #7 index
-}
 
 display_url = 'http://www.moldelectrica.md/ro/activity/system_state'
-data_url = 'http://www.moldelectrica.md/utils/load4.php'
+data_url = 'http://www.moldelectrica.md/utils/load5.php'
+
+# To match the fields with the respective index and meaning,
+# I used the following code which may be used in the future for maintenance:
+# https://gist.github.com/Impelon/09407f739cdff05134f8c77cb7a92ada
+
+# Fields that can be fetched from data_url linked to production.
+# Types of production and translations have been added manually.
+production_fields = (
+    {'index': 2, 'name': 'NHE Costeşti', 'type': 'hydro'},  # run-of-river
+    {'index': 3, 'name': 'CET Nord', 'type': 'gas'},  # CHPP
+    {'index': 4, 'name': 'NHE Dubăsari', 'type': 'hydro'},
+    {'index': 5, 'name': 'CET-2 Chişinău', 'type': 'gas'},  # CHPP
+    {'index': 6, 'name': 'CET-1 Chişinău', 'type': 'gas'},  # CHPP
+    {'index': 7, 'name': 'CERS Moldovenească', 'type': 'gas'},  # fuel mix: 99.94% gas, 0.01% coal, 0.05% oil (2020)
+)
+# Other relevant fields that can be fetched from data_url.
+other_fields = (
+    {'index': 26, 'name': 'consumption'},
+    {'index': 27, 'name': 'generation'},
+    {'index': 28, 'name': 'exchange UA->MD'},
+    {'index': 29, 'name': 'exchange RO->MD'},
+    {'index': 30, 'name': 'utility frequency'},
+)
+
+# Further information on the equipment used at CERS Moldovenească can be found at:
+# http://moldgres.com/o-predpriyatii/equipment
+# Further information on the fuel-mix used at CERS Moldovenească can be found at:
+# http://moldgres.com/search/%D0%9F%D1%80%D0%BE%D0%B8%D0%B7%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%B5%D0%BD%D0%BD%D1%8B%D0%B5%20%D0%BF%D0%BE%D0%BA%D0%B0%D0%B7%D0%B0%D1%82%D0%B5%D0%BB%D0%B8
+# (by searching for 'Производственные показатели' aka. 'Performance Indicators')
+# Data for the fuel-mix at CERS Moldovenească for the year 2020 can be found at:
+# http://moldgres.com/wp-content/uploads/2021/02/proizvodstvennye-pokazateli-zao-moldavskaja-gres-za-2020-god.pdf
+
+# Annual reports from moldelectrica can be found at:
+# https://moldelectrica.md/ro/network/annual_report
 
 
-def get_data(session=None):
-    """ Returns generation data as a list of floats."""
-
+def get_data(session=None) -> list:
+    """Returns data as a list of floats."""
     s = session or requests.Session()
 
-    #In order for the data url to return data, cookies from the display url must be obtained then reused.
+    # In order for data_url to return data, cookies from display_url must be obtained then reused.
     response = s.get(display_url, verify=False)
     data_response = s.get(data_url, verify=False)
     raw_data = data_response.text
     try:
-        data = [float(i) for i in raw_data.split(',')]
+        data = [float(i) if i else None for i in raw_data.split(',')]
     except:
-        raise Exception("Not able to parse received data. Check that the specifed URL returns correct data.")
+        raise Exception('Not able to parse received data. Check that the specifed URL returns correct data.')
 
     return data
 
@@ -42,14 +66,24 @@ def fetch_production(zone_key='MD', session=None, target_datetime=None, logger=N
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
 
-    grid_status = get_data(session=session)
-    production = {'solar': None, 'wind': None, 'biomass': None, 'nuclear': 0.0}
+    field_values = get_data(session)
+    production = {'solar': None, 'wind': None, 'biomass': 0.0, 'nuclear': 0.0, 'gas': 0.0, 'hydro': 0.0}
 
-    production['gas'] = sum(itemgetter(3, 5, 6)(grid_status))
-    production['hydro'] = sum(itemgetter(2, 4)(grid_status))
-    production['unknown'] = grid_status[7]
+    non_renewables_production = 0.0
+    for field in production_fields:
+        produced = field_values[field['index']]
+        non_renewables_production += produced
+        production[field['type']] += produced
 
-    consumption = grid_status[-5]
+    # Renewables (solar + biogas + wind) make up a small part of the energy produced.
+    # They do not have an explicit entry,
+    # hence the difference between the actual generation and
+    # the sum of all other sectors are the renewables.
+    # The exact mix of renewable enegry sources is unknown,
+    # so everything is attributed to biomass.
+    production['biomass'] = field_values[other_fields[1]['index']] - non_renewables_production
+
+    consumption = field_values[other_fields[0]['index']]
 
     dt = arrow.now('Europe/Chisinau').datetime
 
@@ -72,12 +106,12 @@ def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, log
 
     sortedZoneKeys = '->'.join(sorted([zone_key1, zone_key2]))
 
-    exchange_status = get_data(session=session)
+    field_values = get_data(session)
 
     if sortedZoneKeys == 'MD->UA':
-        netflow = -1 * exchange_status[-3]
+        netflow = -1 * field_values[other_fields[2]['index']]
     elif sortedZoneKeys == 'MD->RO':
-        netflow = -1 * exchange_status[-2]
+        netflow = -1 * field_values[other_fields[3]['index']]
     else:
         raise NotImplementedError('This exchange pair is not implemented')
 

--- a/parsers/MD.py
+++ b/parsers/MD.py
@@ -5,7 +5,37 @@
 
 import arrow
 import requests
+from collections import namedtuple
 
+# Supports the following formats:
+# - type=csv for zip-data with semicolon-separated-values
+# - type=array for a 2D json-array containing an array for each datapoint
+# - type=html for a HTML-table (default when no type is given)
+archive_base_url = 'https://moldelectrica.md/utils/archive2.php?id=table&type=array'
+
+# Format for date and time used in archive-datapoints.
+archive_datetime_format = 'YYYY-MM-DD HH:mm'
+# Format for date only used in the archive-url.
+archive_date_format = 'DD.MM.YYYY'
+
+# Fields that can be fetched from archive_url in order.
+archive_fields = (
+    'datetime',
+    'consumption',
+    'planned_consumption',
+    'production',
+    'planned_production',
+    'tpp',  # production from thermal power plants
+    'hpp',  # production from thermal power plants
+    'res',  # production from renewable energy sources
+    'exchange_UA_to_MD',
+    'planned_exchange_UA_to_MD',
+    'exchange_RO_to_MD',
+    'planned_exchange_RO_to_MD',
+)
+
+# Datapoint in the archive-data.
+ArchiveDatapoint = namedtuple('ArchiveDatapoint', archive_fields)
 
 display_url = 'http://www.moldelectrica.md/ro/activity/system_state'
 data_url = 'http://www.moldelectrica.md/utils/load5.php'
@@ -45,6 +75,73 @@ other_fields = (
 # https://moldelectrica.md/ro/network/annual_report
 
 
+def template_price_response(zone_key, datetime, price) -> dict:
+    return {
+        'zoneKey': zone_key,
+        'datetime': datetime,
+        'currency': 'MDL',
+        'price': price,
+        'source': 'moldelectrica.md',
+    }
+
+
+def template_consumption_response(zone_key, datetime, consumption) -> dict:
+    return {
+        'zoneKey': zone_key,
+        'datetime': datetime,
+        'consumption': consumption,
+        'source': 'moldelectrica.md',
+    }
+
+
+def template_production_response(zone_key, datetime, production) -> dict:
+    return {
+        'zoneKey': zone_key,
+        'datetime': datetime,
+        'production': production,
+        'storage': {},
+        'source': 'moldelectrica.md',
+    }
+
+
+def template_exchange_response(sorted_zone_keys, datetime, netflow) -> dict:
+    return {
+        'sortedZoneKeys': sorted_zone_keys,
+        'datetime': datetime,
+        'netFlow': netflow,
+        'source': 'moldelectrica.md',
+    }
+
+
+def get_archive_data(session=None, dates=None) -> list:
+    """
+    Returns archive data as a list of ArchiveDatapoint.
+
+    Optionally accepts a date to fetch the data for,
+    or two dates specifing the range to fetch the data for.
+    Specifying a date-range too high will cause errors with the archive-server.
+    If no dates are specified data for the last 24 hours is fetched.
+    """
+    s = session or requests.Session()
+
+    try:
+        date1, date2 = sorted(dates)
+    except:
+        date1 = date2 = dates
+
+    archive_url = archive_base_url
+    if date1 and date2:
+        archive_url += '&date1={}'.format(arrow.get(date1).to('Europe/Chisinau').format(archive_date_format))
+        archive_url += '&date2={}'.format(arrow.get(date2).to('Europe/Chisinau').format(archive_date_format))
+
+    data_response = s.get(archive_url, verify=False)
+    data = data_response.json()
+    try:
+        return [ArchiveDatapoint(arrow.get(entry[0], archive_datetime_format, tzinfo='Europe/Chisinau').datetime, *map(float, entry[1:])) for entry in data]
+    except:
+        raise Exception('Not able to parse received data. Check that the specifed URL returns correct data.')
+
+
 def get_data(session=None) -> list:
     """Returns data as a list of floats."""
     s = session or requests.Session()
@@ -61,78 +158,147 @@ def get_data(session=None) -> list:
     return data
 
 
-def fetch_production(zone_key='MD', session=None, target_datetime=None, logger=None) -> dict:
-    """Requests the last known production mix (in MW) of a given country."""
+def fetch_price(zone_key='MD', session=None, target_datetime=None, logger=None) -> dict:
+    """
+    Returns the static price of electricity as specified here:
+    https://moldelectrica.md/ro/activity/tariff
+    It is defined by the following government-agency decision,
+    which is still in effect at the time of writing this (July 2021):
+    http://lex.justice.md/viewdoc.php?action=view&view=doc&id=360109&lang=1
+    """
     if target_datetime:
-        raise NotImplementedError('This parser is not yet able to parse past dates')
-
-    field_values = get_data(session)
-    production = {'solar': None, 'wind': None, 'biomass': 0.0, 'nuclear': 0.0, 'gas': 0.0, 'hydro': 0.0}
-
-    non_renewables_production = 0.0
-    for field in production_fields:
-        produced = field_values[field['index']]
-        non_renewables_production += produced
-        production[field['type']] += produced
-
-    # Renewables (solar + biogas + wind) make up a small part of the energy produced.
-    # They do not have an explicit entry,
-    # hence the difference between the actual generation and
-    # the sum of all other sectors are the renewables.
-    # The exact mix of renewable enegry sources is unknown,
-    # so everything is attributed to biomass.
-    production['biomass'] = field_values[other_fields[1]['index']] - non_renewables_production
-
-    consumption = field_values[other_fields[0]['index']]
+        raise NotImplementedError('This parser is not yet able to parse past dates for price')
 
     dt = arrow.now('Europe/Chisinau').datetime
+    return template_price_response(zone_key, dt, '0.145')
 
-    datapoint = {
-        'zoneKey': zone_key,
-        'datetime': dt,
-        'consumption': consumption,
-        'production': production,
-        'storage': {},
-        'source': 'moldelectrica.md'
-    }
 
-    return datapoint
+def fetch_consumption(zone_key='MD', session=None, target_datetime=None, logger=None) -> dict:
+    """Requests the consumption (in MW) of a given country."""
+    if target_datetime:
+        archive_data = get_archive_data(session, target_datetime)
+
+        datapoints = []
+        for entry in archive_data:
+            datapoint = template_consumption_response(zone_key, entry.datetime, entry.consumption)
+            datapoints.append(datapoint)
+        return datapoints
+    else:
+        field_values = get_data(session)
+
+        consumption = field_values[other_fields[0]['index']]
+
+        dt = arrow.now('Europe/Chisinau').datetime
+
+        datapoint = template_consumption_response(zone_key, dt, consumption)
+
+        return datapoint
+
+
+def fetch_production(zone_key='MD', session=None, target_datetime=None, logger=None) -> dict:
+    """Requests the production mix (in MW) of a given country."""
+    if target_datetime:
+        archive_data = get_archive_data(session, target_datetime)
+
+        datapoints = []
+        for entry in archive_data:
+            production = {'solar': None, 'wind': None, 'biomass': 0.0, 'nuclear': 0.0, 'gas': 0.0, 'hydro': 0.0}
+
+            production['gas'] += entry.tpp
+            production['hydro'] += entry.hpp
+            # Renewables (solar + biogas + wind) make up a small part of the energy produced.
+            # The exact mix of renewable enegry sources is unknown,
+            # so everything is attributed to biomass.
+            production['biomass'] += entry.res
+
+            datapoint = template_production_response(zone_key, entry.datetime, production)
+            datapoints.append(datapoint)
+        return datapoints
+    else:
+        field_values = get_data(session)
+
+        production = {'solar': None, 'wind': None, 'biomass': 0.0, 'nuclear': 0.0, 'gas': 0.0, 'hydro': 0.0}
+
+        non_renewables_production = 0.0
+        for field in production_fields:
+            produced = field_values[field['index']]
+            non_renewables_production += produced
+            production[field['type']] += produced
+
+        # Renewables (solar + biogas + wind) make up a small part of the energy produced.
+        # They do not have an explicit entry,
+        # hence the difference between the actual generation and
+        # the sum of all other sectors are the renewables.
+        # The exact mix of renewable enegry sources is unknown,
+        # so everything is attributed to biomass.
+        production['biomass'] = field_values[other_fields[1]['index']] - non_renewables_production
+
+        dt = arrow.now('Europe/Chisinau').datetime
+
+        datapoint = template_production_response(zone_key, dt, production)
+
+        return datapoint
 
 
 def fetch_exchange(zone_key1, zone_key2, session=None, target_datetime=None, logger=None) -> dict:
     """Requests the last known power exchange (in MW) between two countries."""
+    sorted_zone_keys = '->'.join(sorted([zone_key1, zone_key2]))
+
     if target_datetime:
-        raise NotImplementedError('This parser is not yet able to parse past dates')
+        archive_data = get_archive_data(session, target_datetime)
 
-    sortedZoneKeys = '->'.join(sorted([zone_key1, zone_key2]))
+        datapoints = []
+        for entry in archive_data:
+            if sorted_zone_keys == 'MD->UA':
+                netflow = -1 * entry.exchange_UA_to_MD
+            elif sorted_zone_keys == 'MD->RO':
+                netflow = -1 * entry.exchange_RO_to_MD
+            else:
+                raise NotImplementedError('This exchange pair is not implemented')
 
-    field_values = get_data(session)
-
-    if sortedZoneKeys == 'MD->UA':
-        netflow = -1 * field_values[other_fields[2]['index']]
-    elif sortedZoneKeys == 'MD->RO':
-        netflow = -1 * field_values[other_fields[3]['index']]
+            datapoint = template_exchange_response(sorted_zone_keys, entry.datetime, netflow)
+            datapoints.append(datapoint)
+        return datapoints
     else:
-        raise NotImplementedError('This exchange pair is not implemented')
+        field_values = get_data(session)
 
-    dt = arrow.now('Europe/Chisinau').datetime
+        if sorted_zone_keys == 'MD->UA':
+            netflow = -1 * field_values[other_fields[2]['index']]
+        elif sorted_zone_keys == 'MD->RO':
+            netflow = -1 * field_values[other_fields[3]['index']]
+        else:
+            raise NotImplementedError('This exchange pair is not implemented')
 
-    exchange = {
-        'sortedZoneKeys': sortedZoneKeys,
-        'datetime': dt,
-        'netFlow': netflow,
-        'source': 'moldelectrica.md'
-    }
+        dt = arrow.now('Europe/Chisinau').datetime
 
-    return exchange
+        datapoint = template_exchange_response(sorted_zone_keys, dt, netflow)
+
+        return datapoint
 
 
 if __name__ == '__main__':
     """Main method, never used by the Electricity Map backend, but handy for testing."""
 
-    print('fetch_production() ->')
-    print(fetch_production())
-    print('fetch_exchange(MD, UA) ->')
-    print(fetch_exchange('MD', 'UA'))
-    print('fetch_exchange(MD, RO) ->')
-    print(fetch_exchange('MD', 'RO'))
+    def try_print(callable, *args, **kwargs):
+        try:
+            result = callable(*args, **kwargs)
+            try:
+                print("[{}, ... ({} more elements)]".format(result[0], len(result)))
+            except:
+                print(result)
+        except Exception as e:
+            print(repr(e))
+
+    for target_datetime in (None, "2021-07-25T15:00"):
+        print('For target_datetime {}:'.format(target_datetime))
+        print('fetch_price() ->')
+        try_print(fetch_price, target_datetime=target_datetime)
+        print('fetch_consumption() ->')
+        try_print(fetch_consumption, target_datetime=target_datetime)
+        print('fetch_production() ->')
+        try_print(fetch_production, target_datetime=target_datetime)
+        print('fetch_exchange(MD, UA) ->')
+        try_print(fetch_exchange, 'MD', 'UA', target_datetime=target_datetime)
+        print('fetch_exchange(MD, RO) ->')
+        try_print(fetch_exchange, 'MD', 'RO', target_datetime=target_datetime)
+        print('------------')


### PR DESCRIPTION
I noticed Moldova's biggest power plant was still listed as *unknown*, despite it being classified as *gas* in #973.
The problem is that #1380 just modified a value in an unused constant, so the change had no effect.

Regarding dafc431:
I've noticed that there is a new URL for the data-source (http://www.moldelectrica.md/utils/load5.php) and I redesigned the parser using it.
**The old URL seems to just be stuck at some point in time, hence why the data for Moldova is not updated at all!**
I've also added links to some additional documents explaining how the *CERS Moldovenească* power plant operates.
Notably I can confirm that in 2019 and 2020 the power plant still uses mostly gas (over 99%) as fuel:
http://moldgres.com/wp-content/uploads/2021/02/proizvodstvennye-pokazateli-zao-moldavskaja-gres-za-2020-god.pdf
(By searching for *Производственные показатели* aka. *Performance Indicators* on http://moldgres.com/ all available documents can be found. They are written in Russian, but I've been able to easily translate them using Google.)

Additionally this commit takes the renewable energy generation (solar + wind + biogas) in Moldova into consideration. With a capacity of around 3 MW it is quite low and not distinctly mentioned on the map or the `data_url`.
But it can easily be calculated as the difference between the total production and all other forms of production.
The values seem to match up with the values from https://moldelectrica.md/ro/activity/operative_info.
Unfortunately it is not mentioned how this renewable energy mix is composed exactly, so I attributed it all to *biomass*.
(The [presentation](http://en.fas.gov.ru/upload/other/National%20Agency%20for%20Energy%20Regulation%20(G.%20Pyrzy).pdf) mentioned in #926 would indicate that this is mostly biomass, but those figures do not add up with the current data from Moldelectrica anyways.)

In my fork I also added 0903c614d90f8ee530cbb175cd921dffb3b7501e, which represents the code I used to check what the csv-data from `data_url` actually represents. This uses the contents of the `display_url`, where the contents of the data-url are directly mapped to the represented map. In case the data fetched changes slightly in the future, but `display_url` and `data_url` work the same, the code from 0903c614d90f8ee530cbb175cd921dffb3b7501e could be used to update the parser again.
But I do not know how much it fits with the rest of the parser, so I chose not to include it in this PR. Do you have any recommendations on where to put this *maintanence*-code? 

Regarding beeb6ab2:
I added the archive-data used at https://moldelectrica.md/ro/activity/operative_info to the parser as well,
meaning the parser does now support `target_datetime` for past dates.
The data-url for the archive is https://moldelectrica.md/utils/archive2.php?id=table&type=html; various formats are supported and additionally other time-series with higher time-resolution (f.e. for the electricity mix) are supported by passing other numerical values for the id. (I only implemented fetching the table archive data, not for the higher resolution timeseries.)
The archive-data contains data from the end of 2018 to 2021 and ongoing.

Notably the archive also contains `planned` values for production, exchange and consumption. 
You can take a look at https://moldelectrica.md/ro/activity/operative_info to see how the planned values compare to the actual values.
The archive does not contain `planned` values for future dates, so I'm not sure if these values are what the `*_forecast`-methods should return. 
If desired, I could also quickly add implementations for `fetch_consumption_forecast`, `fetch_generation_forecast`, `fetch_exchange_forecast` using the archive to this PR.

Keep in mind, I do not know if the data for the correct timerange is returned when `target_datetime` is used; right now it returns all data for the given date, the time-component is ignored.

----------

This fixes #973.