### PR TITLE
Bulgaria: Fixes URL for parser

### DIFF
--- a/parsers/BG.py
+++ b/parsers/BG.py
@@ -34,7 +34,7 @@ def fetch_production(zone_key='BG', session=None, target_datetime=None, logger=N
         raise NotImplementedError('This parser is not yet able to parse past dates')
 
     r = session or requests.session()
-    url = 'http://www.eso.bg/?did=124'
+    url = 'http://www.eso.bg/doc?124'
     response = r.get(url)
     html = response.text
     soup = BeautifulSoup(html, 'html.parser')


### PR DESCRIPTION
The URL has changed structure, so we're not getting any data:

<img width="572" alt="Screenshot 2021-07-29 at 11 28 02" src="https://user-images.githubusercontent.com/3296643/127468218-1bb86963-8933-43d7-b927-541bfbc62c68.png">

This PR fixes that:

<img width="713" alt="Screenshot 2021-07-29 at 11 28 11" src="https://user-images.githubusercontent.com/3296643/127468273-fb19e4bf-0cad-4547-8733-7d37bdbaf175.png">
