### PR TITLE
Update capacity about zone IN-MH

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -2783,6 +2783,7 @@
     "timezone": null
   },
   "IN-MH": {
+    "comment": "partial source: installed capacity in Jun-2021 https://cea.nic.in/dashboard/?lang=en",
     "bounding_box": [
       [
         72.79941,
@@ -2796,17 +2797,19 @@
     "capacity": {
       "biomass": 2597,
       "coal": 24966,
-      "gas": 3427.6,
+      "gas": 3207.08,
       "hydro": 3047,
       "nuclear": 1400,
       "oil": 0,
       "solar": 2295,
-      "wind": 5010.8
+      "wind": 5010.8,
+      "unknown": 480.55
     },
     "contributors": [
       "https://github.com/GitMatze",
       "https://github.com/alixunderplatz",
-      "https://github.com/systemcatch"
+      "https://github.com/systemcatch",
+      "https://github.com/Manu1400"
     ],
     "flag_file_name": "in.png",
     "parsers": {


### PR DESCRIPTION
partial source : row data from https://cea.nic.in/dashboard/?lang=en

State Name	Coal	Gas	Diesel	Nuclear	Hydro	RES	Total Installed Capacity
Maharashtra
Jun-2021	24966	3207.08	0	1400	3047	10383.35	43003.43