### PR TITLE
Preconnect to API endpoint

### DIFF
--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -46,6 +46,9 @@
         <meta name="msapplication-TileImage" content="<%= resolvePath('images/ms-icon-144x144.png') %>">
         <meta name="theme-color" content="#ffffff">
 
+        <!-- Pre-connect to improve performances -->
+        <link rel="preconnect" href="https://api.electricitymap.org/">
+
         <!-- CSS -->
         <link rel="stylesheet" type="text/css" href="<%= resolvePath('dist/styles.' + stylesHash + '.css') %>">
         <link rel="stylesheet" type="text/css" href="<%= resolvePath('dist/vendor.' + vendorStylesHash + '.css') %>">


### PR DESCRIPTION
Sending a request to api.electricitymap.org takes time because it is a CORS request, and therefore needs to send first a Preflight request. By pre-connecting to the domain immediately, the Preflight request should be sent as soon as possible. Potentially saving ~500ms to retrievethe map data.

![image](https://user-images.githubusercontent.com/360895/127821008-25b3652c-cff4-4cd8-a373-65082dcde93f.png)
