### PR TITLE
Ks/fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   js-exec:
     docker:
-      - image: node:12.22-alpine
+      - image: circleci/node:12.13
 
 jobs:
   verify_python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - checkout
       - run:
           command: |
-            npm install -g jsonlint-mod
+            sudo npm install -g jsonlint-mod
             jsonlint -q config/*.json web/locales/*.json
 
   test_js:
@@ -48,7 +48,7 @@ jobs:
       - checkout
       - run:
           command: |
-            npm install -g jest
+            sudo npm install -g jest
             jest
 
   lint_js:


### PR DESCRIPTION
This updates the Docker image introduced in https://github.com/tmrowco/electricitymap-contrib/pull/3233/files that is missing Python (used by node-sass).