### PR TITLE
enable language-sensitive number formatting

### DIFF
--- a/web/src/components/tooltips/mapexchangetooltip.js
+++ b/web/src/components/tooltips/mapexchangetooltip.js
@@ -18,7 +18,7 @@ const MapExchangeTooltip = ({ exchangeData, position, onClose }) => {
     <Tooltip id="exchange-tooltip" position={position} onClose={onClose}>
       {__('tooltips.crossborderexport')}:
       <br />
-      <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{netFlow}</b> MW
+      <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{netFlowFormated}</b> MW
       <br />
       <br />
       {__('tooltips.carbonintensityexport')}:

--- a/web/src/components/tooltips/mapexchangetooltip.js
+++ b/web/src/components/tooltips/mapexchangetooltip.js
@@ -12,7 +12,7 @@ const MapExchangeTooltip = ({ exchangeData, position, onClose }) => {
   const netFlow = Math.abs(Math.round(exchangeData.netFlow));
   const zoneFrom = exchangeData.countryCodes[isExporting ? 0 : 1];
   const zoneTo = exchangeData.countryCodes[isExporting ? 1 : 0];
-  const netFlowFormated = new Intl.NumberFormat().format(netFlow);
+  const netFlowFormatted = new Intl.NumberFormat().format(netFlow);
 
   return (
     <Tooltip id="exchange-tooltip" position={position} onClose={onClose}>

--- a/web/src/components/tooltips/mapexchangetooltip.js
+++ b/web/src/components/tooltips/mapexchangetooltip.js
@@ -18,7 +18,7 @@ const MapExchangeTooltip = ({ exchangeData, position, onClose }) => {
     <Tooltip id="exchange-tooltip" position={position} onClose={onClose}>
       {__('tooltips.crossborderexport')}:
       <br />
-      <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{netFlowFormated}</b> MW
+      <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{netFlowFormatted}</b> MW
       <br />
       <br />
       {__('tooltips.carbonintensityexport')}:

--- a/web/src/components/tooltips/mapexchangetooltip.js
+++ b/web/src/components/tooltips/mapexchangetooltip.js
@@ -12,6 +12,7 @@ const MapExchangeTooltip = ({ exchangeData, position, onClose }) => {
   const netFlow = Math.abs(Math.round(exchangeData.netFlow));
   const zoneFrom = exchangeData.countryCodes[isExporting ? 0 : 1];
   const zoneTo = exchangeData.countryCodes[isExporting ? 1 : 0];
+  const netFlowFormated = new Intl.NumberFormat().format(netFlow);
 
   return (
     <Tooltip id="exchange-tooltip" position={position} onClose={onClose}>


### PR DESCRIPTION
ElectricityMap UI: in a exchange tooltip format the net flow realtime value.

i.e: in a french 🇫🇷  browser
### before
`zone A → zone B: 1286 MW`
### after
`zone A → zone B: 1 286 MW`