### PR TITLE
Consistently use window so we can render in node.js/Gatsby

### DIFF
--- a/web/src/helpers/translation.js
+++ b/web/src/helpers/translation.js
@@ -1,6 +1,8 @@
 /* eslint-disable prefer-rest-params */
 /* eslint-disable prefer-spread */
 // TODO: re-enable rules
+// TODO: move to LinguiJS or react-intl that doesn't depend on the global
+// object or a node.js process running.
 
 import { vsprintf } from 'sprintf-js';
 
@@ -19,10 +21,9 @@ function translateWithLocale(locale, keyStr) {
 }
 
 export function translate() {
-  // Will use the `locale` global variable
   const args = Array.prototype.slice.call(arguments);
   // Prepend locale
-  args.unshift(locale);
+  args.unshift(window.locale);
   return translateWithLocale.apply(null, args);
 }
 


### PR DESCRIPTION
Consistently use window so we can render in node.js/Gatsby in the translation helper.

I would love to revamp the translation system (likely with [LinguiJS](https://lingui.js.org/) or [react-intl](https://formatjs.io/docs/getting-started/installation/)) which would enable us to:
- get rid of node.js for preparing the language files (they can be loaded dynamically)
- have the default english text in the code (less moving parts + easier to grep for)
- leverage automatic ID generation 
- easier share components with subsystems by not relying on the global object to provide locales and locale