### PR TITLE
Set battery storage and hydro capacity in CA-YT, Yukon (Canada) 🇨🇦 

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -1206,7 +1206,8 @@
   "CA-YT": {
     "contributors": [
       "https://github.com/jarek",
-      "https://github.com/nessie2013"
+      "https://github.com/nessie2013",
+      "https://github.com/Manu1400"
     ],
     "flag_file_name": "ca.png",
     "parsers": {
@@ -1224,7 +1225,9 @@
       ]
     ],
     "capacity": {
-      "hydro": 92
+      "battery storage": 0,
+      "hydro": 92,
+      "solar": 0.0104
     }
   },
   "CH": {

--- a/config/zones.json
+++ b/config/zones.json
@@ -1227,7 +1227,10 @@
     "capacity": {
       "battery storage": 0,
       "hydro": 92,
-      "solar": 0.0104
+      "nuclear": 0,
+      "solar": 0.0104,
+      "wind": 0.81,
+      "unknown": 23.1796
     }
   },
   "CH": {


### PR DESCRIPTION
### Set battery storage and hydro capacity in CA-YT

source: Yukon Energy
* https://yukonenergy.ca/energy-in-yukon/projects-facilities/solar (40 * 260W = 10400 W)
* https://yukonenergy.ca/energy-in-yukon/projects-facilities/battery-storage (status: project, 2022)

### Update/set capacities in CA-YT

Sources: 
* https://en.wikipedia.org/wiki/List_of_generating_stations_in_Yukon
> Yukon Energy facilities have a total capacity of 116 MW
* https://en.wikipedia.org/wiki/Yukon_Energy