### PR TITLE
Changed kptclwebsite domain from .com to .in

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -61,7 +61,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - India (Gujarat): [sldcguj](https://www.sldcguj.com/RealTimeData/RealTimeDemand.php)
 - India (Himachal Pradesh): [HPSLDC](https://hpsldc.com/intra-state-power-transaction/)
 - India (Maharashtra) [mahasldc](https://mahasldc.in/wp-content/reports/sldc/mvrreport3.jpg)
-- India (Karnataka): [kptclsldc.com](http://kptclsldc.com/StateGen.aspx)
+- India (Karnataka): [kptclsldc.in](http://kptclsldc.in/StateGen.aspx)
 - India (Punjab): [punjabsldc](http://www.punjabsldc.org/pungenrealw.asp?pg=pbGenReal)
 - India (Uttar Pradesh): [upsldc](http://www.upsldc.org/real-time-data)
 - India (Uttarakhand): [uksldc](http://uksldc.in/real-time-data.php)

--- a/parsers/IN_KA.py
+++ b/parsers/IN_KA.py
@@ -13,7 +13,7 @@ def fetch_consumption(zone_key='IN-KA', session=None, target_datetime=None, logg
         raise NotImplementedError('This parser is not yet able to parse past dates')
 
     zonekey.assert_zone_key(zone_key, 'IN-KA')
-    html = web.get_response_soup(zone_key, 'http://kptclsldc.com/Default.aspx', session)
+    html = web.get_response_soup(zone_key, 'http://kptclsldc.in/Default.aspx', session)
 
     india_date_time = IN.read_datetime_from_span_id(html, 'Label6', 'DD/MM/YYYY HH:mm')
 
@@ -23,7 +23,7 @@ def fetch_consumption(zone_key='IN-KA', session=None, target_datetime=None, logg
         'zoneKey': zone_key,
         'datetime': india_date_time.datetime,
         'consumption': demand_value,
-        'source': 'kptclsldc.com'
+        'source': 'kptclsldc.in'
     }
 
     return data
@@ -36,7 +36,7 @@ def fetch_production(zone_key='IN-KA', session=None, target_datetime=None, logge
 
     zonekey.assert_zone_key(zone_key, 'IN-KA')
 
-    html = web.get_response_soup(zone_key, 'http://kptclsldc.com/StateGen.aspx', session)
+    html = web.get_response_soup(zone_key, 'http://kptclsldc.in/StateGen.aspx', session)
 
     india_date_time = IN.read_datetime_from_span_id(html, 'lbldate', 'M/D/YYYY h:mm:ss A')
 
@@ -111,7 +111,7 @@ def fetch_production(zone_key='IN-KA', session=None, target_datetime=None, logge
     cgs_value = IN.read_value_from_span_id(html, 'lblcgs')
 
     # NCEP (Non-Conventional Energy Production)
-    ncep_html = web.get_response_soup(zone_key, 'http://kptclsldc.com/StateNCEP.aspx', session)
+    ncep_html = web.get_response_soup(zone_key, 'http://kptclsldc.in/StateNCEP.aspx', session)
     ncep_date_time = IN.read_datetime_from_span_id(ncep_html, 'Label1', 'DD/MM/YYYY HH:mm:ss')
 
     # Check ncep date is similar than state gen date
@@ -159,7 +159,7 @@ def fetch_production(zone_key='IN-KA', session=None, target_datetime=None, logge
         'storage': {
             'hydro': 0.0
         },
-        'source': 'kptclsldc.com',
+        'source': 'kptclsldc.in',
     }
 
     return data

--- a/parsers/test/test_IN_KA.py
+++ b/parsers/test/test_IN_KA.py
@@ -15,13 +15,13 @@ class Test_IN_KA(unittest.TestCase):
 
     def test_fetch_consumption(self):
         response_text = resource_string("parsers.test.mocks", "IN_KA_Default.html")
-        self.adapter.register_uri("GET", "http://kptclsldc.com/Default.aspx", content=response_text)
+        self.adapter.register_uri("GET", "http://kptclsldc.in/Default.aspx", content=response_text)
 
         try:
             data = IN_KA.fetch_consumption('IN-KA', self.session)
             self.assertIsNotNone(data)
             self.assertEqual(data['zoneKey'], 'IN-KA')
-            self.assertEqual(data['source'], 'kptclsldc.com')
+            self.assertEqual(data['source'], 'kptclsldc.in')
             self.assertIsNotNone(data['datetime'])
             self.assertIsNotNone(data['consumption'])
             self.assertEqual(data['consumption'], 7430.0)
@@ -30,15 +30,15 @@ class Test_IN_KA(unittest.TestCase):
 
     def test_fetch_production(self):
         response_text = resource_string("parsers.test.mocks", "IN_KA_StateGen.html")
-        self.adapter.register_uri("GET", "http://kptclsldc.com/StateGen.aspx", content=response_text)
+        self.adapter.register_uri("GET", "http://kptclsldc.in/StateGen.aspx", content=response_text)
         response_text = resource_string("parsers.test.mocks", "IN_KA_StateNCEP.html")
-        self.adapter.register_uri("GET", "http://kptclsldc.com/StateNCEP.aspx", content=response_text)
+        self.adapter.register_uri("GET", "http://kptclsldc.in/StateNCEP.aspx", content=response_text)
 
         try:
             data = IN_KA.fetch_production('IN-KA', self.session)
             self.assertIsNotNone(data)
             self.assertEqual(data['zoneKey'], 'IN-KA')
-            self.assertEqual(data['source'], 'kptclsldc.com')
+            self.assertEqual(data['source'], 'kptclsldc.in')
             self.assertIsNotNone(data['datetime'])
             self.assertIsNotNone(data['production'])
             self.assertEqual(data['production']['hydro'], 1108.0)


### PR DESCRIPTION
The website TLD has been changed to a .in from the previous .com 
Checked the basics, seems like the rest of the website is still the same, so the parser should work with no problems. 