### PR TITLE
Uses original US geo json for backend (coordinate lookup)

### DIFF
--- a/web/generate-geometries.js
+++ b/web/generate-geometries.js
@@ -925,10 +925,9 @@ function getZoneFeatures(zoneDefinitions, geos) {
 }
 
 const webGeos = countryGeos.concat(stateGeos, thirdpartyGeos, USSimplifiedGeos);
-const backendGeos = countryGeos.concat(stateGeos, thirdpartyGeos, USSimplifiedGeos); //should be changed back to USOriginalGeos
+const backendGeos = countryGeos.concat(stateGeos, thirdpartyGeos, USOriginalGeos);
 
 const webZones = getZones(zoneDefinitions, webGeos);
-const backendZones = getZones(zoneDefinitions, backendGeos);
 
 const zonesMoreDetails = getZonesMoreDetails(zoneDefinitions, webGeos, webZones);
 const zoneFeatures = getZoneFeatures(zoneDefinitions, backendGeos)
@@ -944,7 +943,7 @@ fs.writeFileSync(`${zonegeometriesFolder}/zonegeometries.json`, zoneFeatures.map
 // Convert to TopoJSON
 const topojson = require('topojson');
 let topo = topojson.topology(webZones);
-
+let topoMoreDetails = null;
 // merge contiguous Florida counties in US-FL and US-SEC so that we only see the
 // outer region boundary line(s), not the interior county boundary lines.
 // Example: https://bl.ocks.org/mbostock/5416405


### PR DESCRIPTION
Currently we use the simplified shapes for both frontend (map) and backend (API). This means coordinate lookup might fail.

Half of Monterey (CA in US) is "missing" as an example.

This PR fixes that for the API and the CO2Signal API :)

This reverts the changes here: https://github.com/tmrowco/electricitymap-contrib/commit/59847f160965de1b468e5eeb66bd2b3ad91ebff3#diff-f75ea9da5b88e825cc22142a4c851aee29336bcacf833c50cd7ad5c4a115ff11 and I have increased memory limits to allow for this.