### PR TITLE
Added electricity prices for New Zealand

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -93,6 +93,7 @@ Real-time electricity data is obtained using [parsers](https://github.com/tmrowc
 - New Zealand:
   - [Transpower](https://www.transpower.co.nz/power-system-live-data)
   - [Siesa](https://www.southlanddc.govt.nz/my-southland/siesa-2/what-sieasa-does/)
+  - [Energy Market Services](https://em6live.co.nz)
 - Nicaragua: [CNDC](http://www.cndc.org.ni/)
 - Northern Ireland: [SONI](http://www.soni.ltd.uk/InformationCentre/)
 - Norway: [ENTSOE](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html)

--- a/config/zones.json
+++ b/config/zones.json
@@ -4369,11 +4369,13 @@
     ],
     "contributors": [
       "https://github.com/BobGrun",
-      "https://github.com/corradio"
+      "https://github.com/corradio",
+      "https://github.com/davidcole1340"
     ],
     "flag_file_name": "nz.png",
     "parsers": {
-      "production": "NZ.fetch_production"
+      "production": "NZ.fetch_production",
+      "price": "NZ.fetch_price"
     },
     "timezone": "Pacific/Auckland"
   },
@@ -4390,11 +4392,13 @@
     ],
     "contributors": [
       "https://github.com/BobGrun",
-      "https://github.com/corradio"
+      "https://github.com/corradio",
+      "https://github.com/davidcole1340"
     ],
     "flag_file_name": "nz.png",
     "parsers": {
-      "production": "NZ.fetch_production"
+      "production": "NZ.fetch_production",
+      "price": "NZ.fetch_price"
     },
     "timezone": "Pacific/Auckland"
   },


### PR DESCRIPTION
Added ability to pull electricity prices for New Zealand. Data comes from [Energy Market Services](https://em6live.co.nz) which is the [commercial entity](https://www.transpower.co.nz/news/ems-launches-new-em6-website-enhanced-services) of Transpower, the New Zealand transmission company.

EMS provides price data for each region of NZ however ElectricityMap only breaks the power usage down into each island, so for the price I have averaged all the regions in each island for the price.