### PR TITLE
Fix Kuwait (KW) production parser

### DIFF
--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -76,7 +76,7 @@ class CyprusParser:
             data.append(datum)
         return data
 
-    def fetch_production(self, target_datetime: datetime.datetime) -> list:
+    def fetch_production(self, session=None, target_datetime: datetime.datetime = None, logger=None) -> list:
         if target_datetime is None:
             url = 'https://tsoc.org.cy/electrical-system/total-daily-system-generation-on-the-transmission-system/'
         else:

--- a/parsers/CY.py
+++ b/parsers/CY.py
@@ -76,7 +76,7 @@ class CyprusParser:
             data.append(datum)
         return data
 
-    def fetch_production(self, session=None, target_datetime: datetime.datetime = None, logger=None) -> list:
+    def fetch_production(self, target_datetime: datetime.datetime) -> list:
         if target_datetime is None:
             url = 'https://tsoc.org.cy/electrical-system/total-daily-system-generation-on-the-transmission-system/'
         else:

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -18,8 +18,11 @@ def fetch_production(zone_key='KW', target_datetime=None, session=None, logger=N
 
     # Kuwait very rarely imports power, so we assume that production is equal to consumption
     # "Kuwait imports power in an emergency and only for a few hours at a time"
-    # See https://github.com/tmrowco/electricitymap-contrib/pull/2457#pullrequestreview-408781556 
-    consumption = fetch_consumption(zone_key=zone_key, session=session, logger=logger)
+    # See https://github.com/tmrowco/electricitymap-contrib/pull/2457#pullrequestreview-408781556
+    consumption_dict = fetch_consumption(
+        zone_key=zone_key, session=session, logger=logger
+    )
+    consumption = consumption_dict["consumption"]
 
     datapoint = {
         'zoneKey': zone_key,

--- a/parsers/KW.py
+++ b/parsers/KW.py
@@ -12,7 +12,7 @@ import arrow
 import requests
 import re
 
-def fetch_production(zone_key='KW', target_datetime=None, session=None, logger=None):
+def fetch_production(zone_key='KW', session=None, target_datetime=None, logger=None):
     if target_datetime:
         raise NotImplementedError('This parser is not yet able to parse past dates')
 


### PR DESCRIPTION
There are currently two issues with KW:
- the signature of `fetch_production` is wrong (I checked that no other parsers have this issue)
- the consumption dict should be parsed before forwarding it

### Preview

```
2021-08-25 13:14:08,042 DEBUG    urllib3.connectionpool         Starting new HTTPS connection (1): www.mew.gov.kw:443
2021-08-25 13:14:08,685 DEBUG    urllib3.connectionpool         https://www.mew.gov.kw:443 "GET /en HTTP/1.1" 200 None
Parser result:
{'datetime': datetime.datetime(2021, 8, 25, 14, 14, 8, 700892, tzinfo=tzfile('/usr/share/zoneinfo/Asia/Kuwait')),
 'production': {'unknown': 14080},
 'source': 'mew.gov.kw',
 'zoneKey': 'KW'}
---------------------
took 1.01s
min returned datetime: 2021-08-25T11:14:08.700892+00:00 UTC
max returned datetime: 2021-08-25T11:14:08.700892+00:00 UTC  -- OK, <2h from now :) (now=2021-08-25T11:14:08.701181+00:00 UTC)
```