### PR TITLE
Modified canonical and alternate URLs in web

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -158,7 +158,10 @@ app.use('/', (req, res) => {
       res.setLocale(lr[0]);
     }
     const { locale } = res;
-    const fullUrl = `https://www.electricitymap.org${req.baseUrl + req.path}`;
+    let canonicalUrl = `https://www.electricitymap.org${req.baseUrl + req.path}`;
+    if(req.query.lang) {
+      canonicalUrl += `?lang=${req.query.lang}`;
+    }
 
     // basic auth for premium access
     if (process.env.BASIC_AUTH_CREDENTIALS) {
@@ -182,7 +185,10 @@ app.use('/', (req, res) => {
     }
     res.render('pages/index', {
       alternateUrls: locales.map((l) => {
-        return `${fullUrl}?lang=${l}`;
+        if (canonicalUrl.indexOf('lang') !== -1) {
+          return canonical.replace(`lang=${req.query.lang}`, `lang=${l}`);
+        }
+        return `${canonicalUrl}?lang=${l}`;
       }),
       bundleHash: getHash('bundle', 'js', manifest),
       vendorHash: getHash('vendor', 'js', manifest),
@@ -200,7 +206,7 @@ app.use('/', (req, res) => {
           // Note we here point to static hosting in order to make
           // sure we can serve older bundle versions
           `https://static.electricitymap.org/public_web/${relativePath}`,
-      fullUrl,
+      canonicalUrl,
       locale,
       locales: { en: localeConfigs.en, [locale]: localeConfigs[locale] },
       supportedLocales: locales,

--- a/web/server.js
+++ b/web/server.js
@@ -158,7 +158,7 @@ app.use('/', (req, res) => {
       res.setLocale(lr[0]);
     }
     const { locale } = res;
-    const fullUrl = `https://www.electricitymap.org${req.originalUrl}`;
+    const fullUrl = `https://www.electricitymap.org${req.baseUrl + req.path}`;
 
     // basic auth for premium access
     if (process.env.BASIC_AUTH_CREDENTIALS) {
@@ -182,13 +182,7 @@ app.use('/', (req, res) => {
     }
     res.render('pages/index', {
       alternateUrls: locales.map((l) => {
-        if (fullUrl.indexOf('lang') !== -1) {
-          return fullUrl.replace(`lang=${req.query.lang}`, `lang=${l}`);
-        }
-        if (Object.keys(req.query).length) {
-          return `${fullUrl}&lang=${l}`;
-        }
-        return `${fullUrl.replace('?', '')}?lang=${l}`;
+        return `${fullUrl}?lang=${l}`;
       }),
       bundleHash: getHash('bundle', 'js', manifest),
       vendorHash: getHash('vendor', 'js', manifest),

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -62,9 +62,9 @@
         <% for(var i=0; i<alternateUrls.length; i++) {%>
         <link rel="alternate" href="<%- alternateUrls[i] %>" hreflang="<%= supportedLocales[i] %>" />
         <% } %>
-        <% if (typeof fullUrl != 'undefined') { %>
-        <link rel="alternate" href="<%- fullUrl %>" hreflang="x-default" />
-        <link rel="canonical" href="<%- fullUrl %>" />
+        <% if (typeof canonicalUrl != 'undefined') { %>
+        <link rel="alternate" href="<%- canonicalUrl.replace(/[?|&]lang=[^&]*/, '') %>" hreflang="x-default" />
+        <link rel="canonical" href="<%- canonicalUrl %>" />
         <% } %>
 
         <!-- Set Global Variables -->

--- a/web/views/pages/index.ejs
+++ b/web/views/pages/index.ejs
@@ -63,7 +63,7 @@
         <link rel="alternate" href="<%- alternateUrls[i] %>" hreflang="<%= supportedLocales[i] %>" />
         <% } %>
         <% if (typeof fullUrl != 'undefined') { %>
-        <link rel="alternate" href="<%- fullUrl.replace(/[?|&]lang=[^&]*/, '') %>" hreflang="x-default" />
+        <link rel="alternate" href="<%- fullUrl %>" hreflang="x-default" />
         <link rel="canonical" href="<%- fullUrl %>" />
         <% } %>
 


### PR DESCRIPTION
Solving issue  #3363 

Canonical URL and alternate URLs should not contain query params, otherwise search engines will see duplicate pages.

In the index template _baseUrl_ and _path_ are fetched from the request instead of _originalUrl_ to create the canonical URL, as they do not contain the query string.


For alternate URLs, we just need to loop through locales and add the language as a query param to the canonical URL.

