### PR TITLE
Enable serving live map on app.electricitymap.org

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -137,13 +137,14 @@ app.use('/', (req, res) => {
   const isTmrowCo = req.get('host').indexOf('electricitymap.tmrow') !== -1;
   const isNonWWW = req.get('host').includes('electricitymap.org')
     || req.get('host') !== 'www.electricitymap.org';
-  const isExcludedFromRedirect = req.get('host') === 'app.electricitymap.org'; // Temporary
   const isStaging = req.get('host').includes('staging');
+  const isExcludedFromRedirect = isStaging
+    || req.get('host') === 'app.electricitymap.org'; // Temporary
   const isHTTPS = req.secure;
   const isLocalhost = req.hostname === 'localhost'; // hostname is without port
 
   // Redirect all non-facebook, non-staging, non-(www.* or *.tmrow.co)
-  if (!isStaging && (isNonWWW || isTmrowCo) && (req.headers['user-agent'] || '').indexOf('facebookexternalhit') == -1) {
+  if (!isExcludedFromRedirect && (isNonWWW || isTmrowCo) && (req.headers['user-agent'] || '').indexOf('facebookexternalhit') == -1) {
     res.redirect(301, `https://www.electricitymap.org${req.originalUrl}`);
   // Redirect all non-HTTPS and non localhost
   // Warning: this can't happen here because Cloudfare is the HTTPS proxy.

--- a/web/server.js
+++ b/web/server.js
@@ -135,8 +135,9 @@ app.use('/', (req, res) => {
   // redirect everyone except the Facebook crawler,
   // else, we will lose all likes
   const isTmrowCo = req.get('host').indexOf('electricitymap.tmrow') !== -1;
-  const isNonWWW = req.get('host') === 'electricitymap.org'
-    || req.get('host') === 'live.electricitymap.org';
+  const isNonWWW = req.get('host').includes('electricitymap.org')
+    || req.get('host') !== 'www.electricitymap.org';
+  const isExcludedFromRedirect = req.get('host') === 'app.electricitymap.org'; // Temporary
   const isStaging = req.get('host').includes('staging');
   const isHTTPS = req.secure;
   const isLocalhost = req.hostname === 'localhost'; // hostname is without port


### PR DESCRIPTION
This PR disables the redirect to www from app.electricitymap.org so we can test serving it on both domains.
@skovhus I think it would be good to add some redirect tests here. Do you have any idea of how we could go about this? (also feel free to add the scaffolding directly to the PR)