### PR TITLE
Number formatting for exchange flow

### DIFF
--- a/web/src/components/tooltips/mapexchangetooltip.js
+++ b/web/src/components/tooltips/mapexchangetooltip.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { __ } from '../../helpers/translation';
+import { formatPower } from '../../helpers/formatting';
 import Tooltip from '../tooltip';
 
 import { CarbonIntensity, ZoneName } from './common';
@@ -17,7 +18,7 @@ const MapExchangeTooltip = ({ exchangeData, position, onClose }) => {
     <Tooltip id="exchange-tooltip" position={position} onClose={onClose}>
       {__('tooltips.crossborderexport')}:
       <br />
-      <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{netFlow}</b> MW
+      <ZoneName zone={zoneFrom} /> → <ZoneName zone={zoneTo} />: <b>{formatPower(netFlow)}</b>
       <br />
       <br />
       {__('tooltips.carbonintensityexport')}:


### PR DESCRIPTION
Updates the exchange tooltip to use formatting depending on the magnitude of the flow. It uses the same formatting as the production tooltip.

A simpler approach to #3273 as suggested by @madsnedergaard 