### PR TITLE
Update UK nuclear capacity

### DIFF
--- a/DATA_SOURCES.md
+++ b/DATA_SOURCES.md
@@ -239,7 +239,9 @@ For many European countries, data is available from [ENTSO-E](https://transparen
   - Geothermal and Unknown: [Bundesnetzagentur](https://www.bundesnetzagentur.de/DE/Sachgebiete/ElektrizitaetundGas/Unternehmen_Institutionen/Versorgungssicherheit/Erzeugungskapazitaeten/Kraftwerksliste/kraftwerksliste-node.html)
   - Other: [Frauenhofer ISE](https://energy-charts.info/charts/installed_power/chart.htm)
 - Georgia: [GSE](http://www.gse.com.ge/for-customers/data-from-the-power-system)
-- Great Britain: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
+- Great Britain:
+  - Nuclear: [EDF](https://www.edfenergy.com/energy/power-station/daily-statuses)
+  - Other: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Greece: [ENTSO-E](https://transparency.entsoe.eu/generation/r2/installedGenerationCapacityAggregation/show)
 - Guatemala: [AMM](http://www.amm.org.gt/pdfs2/2017/Capacidad_Instalada_2017.xls)
 - Honduras: [ENEE](http://www.enee.hn/planificacion/2018/boletines/Boletin%20Estadistico%20Mes%20de%20Septiembre%202018%20PDF.pdf)

--- a/config/zones.json
+++ b/config/zones.json
@@ -2144,7 +2144,7 @@
       "geothermal": 0,
       "hydro": 1919,
       "hydro storage": 4309,
-      "nuclear": 8256,
+      "nuclear": 7888,
       "oil": 0,
       "solar": 13378,
       "unknown": 4708,


### PR DESCRIPTION
Some of the power plants have been down-rated and Dungeness B is being [decommissioned](https://www.edfenergy.com/media-centre/news-releases/edf-decides-move-dungeness-b-defuelling-phase).

From the EDF [website](https://www.edfenergy.com/energy/power-station/daily-statuses):

| Power plant | Total supply to the national grid (MW) |
| --- | --- |
| Torness | 1190 |
| Sizewell B | 1198 |
| Hunterston B | 965 |
| Hinkley Point B | 965 |
| Heysham 2 | 1230 |
| Heysham 1 | 1155 |
| Hartlepool | 1185 |
| *Total* | *7888* |