### PR TITLE
Change backend for the live map

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 services:
   mockserver:
     build: mockserver
-    ports: ['9000:8000']
+    ports: ['8001:8000']
     volumes:
       - './mockserver/public:/home/public'
       - './mockserver/server.py:/home/server.py'

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -18,7 +18,7 @@ function isUsingLocalEndpoint() {
 }
 
 export function getEndpoint() {
-  return isUsingLocalEndpoint() ? 'http://localhost:9000' : 'https://api.electricitymap.org';
+  return isUsingLocalEndpoint() ? 'http://localhost:8001' : 'https://app-backend.electricitymap.org';
 }
 
 export function protectedJsonRequest(path) {


### PR DESCRIPTION
https://github.com/tmrowco/electricitymap/issues/1353

The live map now has a new dedicated backend. Locally this now runs on port 8001 instead of 9000.