### PR TITLE
add mobile responsive view for language translation selector

### DIFF
--- a/web/src/components/languageselect.js
+++ b/web/src/components/languageselect.js
@@ -35,6 +35,14 @@ const LanguageSelect = () => {
       />
       {languagesVisible && (
         <div id="language-select-container">
+          <div id="close-language-select-container">
+            <ButtonToggle
+              onChange={toggleLanguagesVisible}
+              tooltip={__('tooltips.selectLanguage')}
+              ariaLabel={__('tooltips.selectLanguage')}
+              icon="language_select"
+            />
+          </div>
           {map(languageNames, (language, key) => (
             <li key={key} onClick={() => handleLanguageSelect(key)}>
               {language}

--- a/web/src/scss/content/map/_controls.scss
+++ b/web/src/scss/content/map/_controls.scss
@@ -110,6 +110,25 @@
     transform: translateX(0px);
     transition: opacity 0.4s, visibility 0.4s, transform 0.4s;
 
+    #close-language-select-container {
+      display: none;
+    }
+
+    @media (max-width: 700px) {
+      position: fixed;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      top: 0;
+      z-index: 100;
+      text-align: center;
+
+      #close-language-select-container {
+        display: block;
+        position: fixed;
+      }
+    }
+
     &.hidden {
         visibility: hidden;
         opacity: 0;


### PR DESCRIPTION
See comment thread here: https://github.com/tmrowco/electricitymap-contrib/issues/1841#issuecomment-935235883

I've added a few SCSS changes to the button container with an additional button toggle similar to what activates the language selector. 

The icon can be altered for a different one that may be more fitting. At this time, I could not make material-icons work properly. I may have been referencing them incorrectly. I was trying to use the `Close` icon: https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Aclose%3A

Happy to take feedback and make adjustments. 