### PR TITLE
Adds zone_key to a bunch of logger.warning calls

### DIFF
--- a/parsers/CR.py
+++ b/parsers/CR.py
@@ -162,9 +162,12 @@ def df_to_data(zone_key, day, df, logger):
         results.append(data)
 
     for plant in unknown_plants:
-        logger.warning(u'{} is not mapped to generation type'.format(plant),
-                       extra={'key': zone_key})
-
+        logger.warning(
+            {
+                "message": f"{format(plant)}is not mapped to generation type",
+                "zone_key": zone_key,
+            }
+        )
     return results
 
 

--- a/parsers/ENTSOE.py
+++ b/parsers/ENTSOE.py
@@ -812,7 +812,11 @@ def fetch_consumption(zone_key, session=None, target_datetime=None,
                 i = datetimes.index(dt)
             except ValueError:
                 logger.warning(
-                    f'No corresponding consumption value found for self-consumption at {dt}')
+                    {
+                        'message':f'No corresponding consumption value found for self-consumption at {dt}',
+                        'zone_key': zone_key
+                    }
+                )
                 continue
             quantities[i] += value
 
@@ -830,7 +834,12 @@ def fetch_consumption(zone_key, session=None, target_datetime=None,
         # data is available for a given TZ a few minutes before production data is.
         dt, quantity = datetimes[-1].datetime, quantities[-1]
         if dt not in self_consumption:
-            logger.warning(f'Self-consumption data not yet available for {zone_key} at {dt}')
+            logger.warning(
+                {
+                    'message': f'Self-consumption data not yet available for {zone_key} at {dt}',
+                    'zone_key': zone_key
+                }
+            )
         data = {
             'zoneKey': zone_key,
             'datetime': dt,
@@ -895,8 +904,12 @@ def fetch_production(zone_key, session=None, target_datetime=None,
                 if v is None: continue
                 if v < 0 and v > -50:
                     # Set small negative values to 0
-                    logger.warning('Setting small value of %s (%s) to 0.' % (k, v),
-                                   extra={'key': zone_key})
+                    logger.warning(
+                        {
+                            'message': f'Setting small value of {k} ({v}) to 0.',
+                            'zone_key': zone_key
+                        }
+                    )
                     d['production'][k] = 0
 
     return list(filter(lambda x: validate_production(x, logger), data))
@@ -974,7 +987,12 @@ def fetch_production_per_units(zone_key, session=None, target_datetime=None,
                 v['datetime'] = v['datetime'].datetime
                 v['source'] = 'entsoe.eu'
                 if not v['unitName'] in ENTSOE_UNITS_TO_ZONE:
-                    logger.warning('Unknown unit %s with id %s' % (v['unitName'], v['unitKey']))
+                    logger.warning(
+                        {
+                            'message': 'Unknown unit %s with id %s' % (v['unitName'], v['unitKey']),
+                            'zone_key': zone_key
+                        }
+                    )
                 else:
                     v['zoneKey'] = ENTSOE_UNITS_TO_ZONE[v['unitName']]
                     if v['zoneKey'] == zone_key:

--- a/parsers/IN_HP.py
+++ b/parsers/IN_HP.py
@@ -108,7 +108,10 @@ def get_state_gen(soup, logger: logging.Logger):
             gen[gen_type.value] += float(cols[1].text)
         except (AttributeError, KeyError, IndexError, ValueError):
             logger.error(
-                f'Error importing data from row: {row}', extra={"key": ZONE_KEY}
+                {
+                    "message": f"Error importing data from row: {row}",
+                    "zone_key": ZONE_KEY,
+                }
             )
     return gen
 

--- a/parsers/KR.py
+++ b/parsers/KR.py
@@ -66,11 +66,21 @@ def check_hydro_capacity(plant_name, value, logger) -> Union[bool, ValueError]:
         max_value = HYDRO_CAPACITIES[plant_name]
     except KeyError:
         if value != 0.0:
-            logger.warning('New hydro plant seen - {} - {}MW'.format(plant_name, value), extra={'key': 'KR'})
+            logger.warning(
+                {
+                    'message': 'New hydro plant seen - {plant_name} - {value}MW',
+                    'zone_key': 'KR',
+                }
+            )
         return True
 
     if value > max_value:
-        logger.warning('{} reports {}MW generation with capacity of {}MW - discarding'.format(plant_name, value, max_value), extra={'key': 'KR'})
+        logger.warning(
+            {
+                'messsage': '{} reports {}MW generation with capacity of {}MW - discarding'.format(plant_name, value, max_value),
+                'zone_key': 'KR',
+            }
+        )
         raise ValueError
     else:
         return True

--- a/parsers/OPENNEM.py
+++ b/parsers/OPENNEM.py
@@ -215,8 +215,12 @@ def fetch_production(zone_key=None, session=None, target_datetime=None, logger=l
                 continue
             if v < 0 and v > -50:
                 # Set small negative values to 0
-                logger.warning(f'Setting small value of {k} ({v}) to 0.',
-                               extra={'key': zone_key})
+                logger.warning(
+                    {
+                        "message": f"Setting small value of {k} ({v}) to 0.",
+                        "zone_key": zone_key,
+                    }
+                )
                 obj['production'][k] = 0
 
     return objs

--- a/parsers/PA.py
+++ b/parsers/PA.py
@@ -153,7 +153,12 @@ def fetch_production(zone_key='PA', session=None, target_datetime=None, logger: 
           data['production'][unit_fuel_type] += unit_generation
           data['production']['unknown'] -= unit_generation
       else:
-        logger.warning(u'{} is not mapped to generation type'.format(unit_name), extra={'key': zone_key})
+        logger.warning(
+            {
+                "message": f"{format(unit_name)}is not mapped to generation type",
+                "zone_key": zone_key,
+            }
+        )
 
     #Thermal total from the graph and the total one would get from summing output of all generators deviates a bit,
     #presumably because they aren't updated at the exact same moment.

--- a/parsers/TR.py
+++ b/parsers/TR.py
@@ -127,8 +127,12 @@ def fetch_production(zone_key='TR', session=None, target_datetime=None, logger=N
                     if prod_type in MAP_GENERATION.keys():
                         data['production'][MAP_GENERATION[prod_type]] += prod_val
                     elif prod_type not in ['total', 'uluslarasi', 'saat']:
-                        logger.warning('Warning: %s (%d) is missing in mapping!' % (prod_type, prod_val))
-
+                        logger.warning(
+                            {
+                                'message': f'Warning: {prod_type} ({prod_val}) is missing in mapping!',
+                                'zone_key': zone_key,
+                            }
+                        )
                 try:
                     data['datetime'] = tr_datetime.replace(hour=int(datapoint['saat'])).datetime
                 except ValueError:

--- a/parsers/US_CA.py
+++ b/parsers/US_CA.py
@@ -57,7 +57,12 @@ def fetch_production(zone_key='US-CA', session=None, target_datetime=None,
             production = float(csv[ca_gen_type][i])
             
             if production < 0 and (mapped_gen_type == 'solar' or mapped_gen_type == 'nuclear'):
-                logger.warn(ca_gen_type + ' production for US_CA was reported as less than 0 and was clamped')
+                logger.warning(
+                    {
+                        'message': f'{ca_gen_type} production for US_CA was reported as less than 0 and was clamped',
+                        'zone_key': zone_key,
+                    }
+                )
                 production = 0.0
             
             # if another mean of production created a value, sum them up

--- a/parsers/lib/validation.py
+++ b/parsers/lib/validation.py
@@ -14,10 +14,10 @@ def has_value_for_key(datapoint, key, logger):
     value = datapoint["production"].get(key, None)
     if value is None or math.isnan(value):
         logger.warning(
-            "Required generation type {} is missing from {}".format(
-                key, datapoint["zoneKey"]
-            ),
-            extra={"key": datapoint["zoneKey"]},
+            {
+                "message": f"Required generation type {key} is missing from {datapoint['zoneKey']}",
+                "zone_key": datapoint["zoneKey"],
+            }
         )
         return None
     return True


### PR DESCRIPTION
By adding a `zone_key` field to the log entires, we can more easily filter these messages by zone instead of lumping them all together.

Some of the error log entries that should now have a zone key attached:
```
- Warning: toplam (30136) is missing in mapping!
- Sparkle Power 5 is not mapped to generation type
- Error importing data from row:
- No corresponding consumption value found for self-consumption at ...
- Self-consumption data not yet available for X at ...
- Required generation type coal is missing from *
```