### PR TITLE
EIA: log relevant warning if mixes are an empty list

### DIFF
--- a/parsers/EIA.py
+++ b/parsers/EIA.py
@@ -403,6 +403,10 @@ def fetch_production_mix(zone_key, session=None, target_datetime=None, logger=No
             point = validate(point, logger=logger, remove_negative=True)
         mixes.append(mix)
 
+    if not mixes:
+        logger.warning(f'No production mix data found for {zone_key}')
+        return []
+
     # Some of the returned mixes could be for older timeframes.
     # Fx the latest oil data could be 6 months old.
     # In this case we want to discard the old data as we won't be able to merge it


### PR DESCRIPTION
Currently all EIA parsers are failing, but the error in the log is a bit cryptic. This PR should fix that.

Related: https://github.com/tmrowco/electricitymap-contrib/issues/3492

### Preview

#### Before

```
    return callback(*args, **kwargs)
  File "/Users/kenneth/git/electricitymap/contrib/test_parser.py", line 68, in test_parser
    *args, target_datetime=target_datetime, logger=logging.getLogger(__name__)
  File "/Users/kenneth/git/electricitymap/contrib/parsers/EIA.py", line 427, in fetch_production_mix
    latest_timeframe = max(timeframes, key=lambda x: x[-1])
ValueError: max() arg is an empty sequence
```

#### After
```
2021-11-12 10:25:34,689 WARNING  test_parser                    No production mix data found for US-TEN-TVA
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/kenneth/git/electricitymap/contrib/.venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/kenneth/git/electricitymap/contrib/.venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/kenneth/git/electricitymap/contrib/.venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/kenneth/git/electricitymap/contrib/.venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/kenneth/git/electricitymap/contrib/test_parser.py", line 72, in test_parser
    raise ValueError('Error: parser returned nothing ({})'.format(res))
ValueError: Error: parser returned nothing ([])
```