### PR TITLE
Fix Bolivia parser that now includes solar production

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -769,7 +769,8 @@
     },
     "contributors": [
       "https://github.com/igorarduin",
-      "https://github.com/corradio"
+      "https://github.com/corradio",
+      "https://github.com/skovhus"
     ],
     "parsers": {
       "generationForecast": "BO.fetch_generation_forecast",

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -96,7 +96,8 @@ def fetch_production(
         session=session, target_datetime=target_datetime, logger=logger
     ):
         # NOTE: thermo includes gas + oil mixed, so we set these as unknown for now
-        modes_extracted = [row.hydro, row.solar, row.wind]
+        # The modes here should match the ones we extract in the production payload
+        modes_extracted = [row.hydro, row.solar, row.wind, row.bagasse]
 
         if row.total is None or None in modes_extracted:
             continue
@@ -106,6 +107,7 @@ def fetch_production(
                 "zoneKey": zone_key,
                 "datetime": row.datetime,
                 "production": {
+                    "biomass": row.bagasse,
                     "hydro": row.hydro,
                     "solar": row.solar,
                     "unknown": row.total - sum(modes_extracted),

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -83,10 +83,10 @@ def fetch_production(
 def fetch_generation_forecast(
     zone_key="BO", session=None, target_datetime=None, logger=None
 ):
-    if target_datetime:
-        raise NotImplementedError("This parser is not yet able to parse past dates")
-
-    now = arrow.now(tz=tz_bo)
+    if target_datetime is not None:
+        now = arrow.get(target_datetime)
+    else:
+        now = arrow.now(tz=tz_bo)
 
     r = session or requests.session()
 

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -33,14 +33,15 @@ def fetch_data(
     session=None, target_datetime=None, logger=None
 ) -> List[HourlyProduction]:
     if target_datetime is not None:
-        now = arrow.get(target_datetime)
+        dt = arrow.get(target_datetime, tz_bo)
     else:
-        now = arrow.now(tz=tz_bo)
+        dt = arrow.now(tz=tz_bo)
+        print("current dt", dt)
 
     r = session or requests.session()
 
     # Define actual and previous day (for midnight data).
-    formatted_date = now.format("YYYY-MM-DD")
+    formatted_dt = dt.format("YYYY-MM-DD")
 
     # initial path for url to request
     url_init = "https://www.cndc.bo/gene/dat/gene.php?fechag={0}"
@@ -48,7 +49,7 @@ def fetch_data(
     # XSRF token for the initial request
     xsrf_token = extract_xsrf_token(r.get("https://www.cndc.bo/gene/index.php").text)
 
-    resp = r.get(url_init.format(formatted_date), headers={"x-csrf-token": xsrf_token})
+    resp = r.get(url_init.format(formatted_dt), headers={"x-csrf-token": xsrf_token})
 
     hour_rows = json.loads(resp.text.replace("ï»¿", ""))["data"]
 
@@ -57,18 +58,15 @@ def fetch_data(
     for hour_row in hour_rows:
         [hour, forecast, total, thermo, hydro, wind, solar, bagasse] = hour_row
 
-        if target_datetime is None and hour > now.hour:
-            continue
+        # isn't this Bolivia time and not UTC?
 
-        if hour == 24:
-            timestamp = now.shift(days=1)
-        else:
-            timestamp = now
-
-        if target_datetime is not None and hour < 24:
-            timestamp = timestamp.replace(
-                hour=hour - 1, minute=0, second=0, microsecond=0
-            )
+        timestamp = dt.replace(
+            # "hour" is one-indexed
+            hour=hour - 1,
+            minute=0,
+            second=0,
+            microsecond=0,
+        )
 
         result.append(
             HourlyProduction(

--- a/parsers/BO.py
+++ b/parsers/BO.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
 # The arrow library is used to handle datetimes
-import arrow
 import json
-# The request library is used to fetch content through HTTP
-import requests
 import re
 
-tz_bo = 'America/La_Paz'
+import arrow
+import requests
+
+tz_bo = "America/La_Paz"
 
 
 def extract_xsrf_token(html):
-  """Extracts XSRF token from the source code of the generation graph page."""
-  return re.search(r'var ttoken = "([a-f0-9]+)";', html).group(1)
+    """Extracts XSRF token from the source code of the generation graph page."""
+    return re.search(r'var ttoken = "([a-f0-9]+)";', html).group(1)
 
 
 def template_response(zone_key, datetime, source):
@@ -21,12 +21,13 @@ def template_response(zone_key, datetime, source):
         "datetime": datetime,
         "production": {
             "hydro": 0.0,
-            "unknown": 0, # Gas + Oil are mixed, so unknown for now
-            "wind": 0
+            "unknown": 0,  # Gas + Oil are mixed, so unknown for now
+            "wind": 0,
         },
         "storage": {},
         "source": source,
     }
+
 
 def template_forecast_response(zone_key, datetime, source):
     return {
@@ -37,7 +38,9 @@ def template_forecast_response(zone_key, datetime, source):
     }
 
 
-def fetch_production(zone_key='BO', session=None, target_datetime=None, logger=None) -> dict:
+def fetch_production(
+    zone_key="BO", session=None, target_datetime=None, logger=None
+) -> dict:
     """Requests the last known production mix (in MW) of a given country."""
     if target_datetime is not None:
         now = arrow.get(target_datetime)
@@ -47,19 +50,17 @@ def fetch_production(zone_key='BO', session=None, target_datetime=None, logger=N
     r = session or requests.session()
 
     # Define actual and previous day (for midnight data).
-    formatted_date = now.format('YYYY-MM-DD')
+    formatted_date = now.format("YYYY-MM-DD")
 
     # initial path for url to request
-    url_init = 'https://www.cndc.bo/gene/dat/gene.php?fechag={0}'
+    url_init = "https://www.cndc.bo/gene/dat/gene.php?fechag={0}"
 
     # XSRF token for the initial request
     xsrf_token = extract_xsrf_token(r.get("https://www.cndc.bo/gene/index.php").text)
 
-    resp = r.get(url_init.format(formatted_date), headers={
-        "x-csrf-token": xsrf_token
-    })
+    resp = r.get(url_init.format(formatted_date), headers={"x-csrf-token": xsrf_token})
 
-    hour_rows = json.loads(resp.text.replace('ï»¿', ''))["data"]
+    hour_rows = json.loads(resp.text.replace("ï»¿", ""))["data"]
     payload = []
 
     for hour_row in hour_rows:
@@ -74,8 +75,7 @@ def fetch_production(zone_key='BO', session=None, target_datetime=None, logger=N
             timestamp = now
 
         if target_datetime is not None and hour < 24:
-            timestamp = timestamp.replace(hour=hour-1)
-
+            timestamp = timestamp.replace(hour=hour - 1)
 
         hour_resp = template_response(zone_key, timestamp.datetime, "cndc.bo")
         hour_resp["production"]["unknown"] = thermo
@@ -87,28 +87,28 @@ def fetch_production(zone_key='BO', session=None, target_datetime=None, logger=N
     return payload
 
 
-def fetch_generation_forecast(zone_key='BO', session=None, target_datetime=None, logger=None):
+def fetch_generation_forecast(
+    zone_key="BO", session=None, target_datetime=None, logger=None
+):
     if target_datetime:
-        raise NotImplementedError('This parser is not yet able to parse past dates')
+        raise NotImplementedError("This parser is not yet able to parse past dates")
 
     now = arrow.now(tz=tz_bo)
 
     r = session or requests.session()
 
     # Define actual and previous day (for midnight data).
-    formatted_date = now.format('YYYY-MM-DD')
+    formatted_date = now.format("YYYY-MM-DD")
 
     # initial path for url to request
-    url_init = 'https://www.cndc.bo/gene/dat/gene.php?fechag={0}'
+    url_init = "https://www.cndc.bo/gene/dat/gene.php?fechag={0}"
 
     # XSRF token for the initial request
     xsrf_token = extract_xsrf_token(r.get("https://www.cndc.bo/gene/index.php").text)
 
-    resp = r.get(url_init.format(formatted_date), headers={
-        "x-csrf-token": xsrf_token
-    })
+    resp = r.get(url_init.format(formatted_date), headers={"x-csrf-token": xsrf_token})
 
-    hour_rows = json.loads(resp.text.replace('ï»¿', ''))["data"]
+    hour_rows = json.loads(resp.text.replace("ï»¿", ""))["data"]
     payload = []
 
     for hour_row in hour_rows:
@@ -119,7 +119,7 @@ def fetch_generation_forecast(zone_key='BO', session=None, target_datetime=None,
         else:
             timestamp = now
 
-        zeroed = timestamp.replace(hour=hour-1, minute=0, second=0, microsecond=0)
+        zeroed = timestamp.replace(hour=hour - 1, minute=0, second=0, microsecond=0)
 
         hour_resp = template_forecast_response(zone_key, zeroed.datetime, "cndc.bo")
         hour_resp["value"] = forecast
@@ -128,10 +128,11 @@ def fetch_generation_forecast(zone_key='BO', session=None, target_datetime=None,
 
     return payload
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     """Main method, never used by the Electricity Map backend, but handy for testing."""
-    print('fetch_production() ->')
+    print("fetch_production() ->")
     print(fetch_production())
 
-    print('fetch_generation_forecast() ->')
+    print("fetch_generation_forecast() ->")
     print(fetch_generation_forecast())


### PR DESCRIPTION
#3463 

As seen here https://storage.googleapis.com/electricitymap-parser-logs/BO.html, the parser fails while trying to unpack the following list: `[hour, forecast, _total, _thermo, _hydro, _wind, _unknown] = hour_row `

It turns out that https://www.cndc.bo/gene/index.php now includes solar! 🌞 

While fixing this issue I discovered that the old parser was setting `unknown = thermo`... But I believe this should have been `unknown = total - (the_production_modes_we_extract)`. This seems to be a regression that was introduced in https://github.com/tmrowco/electricitymap-contrib/pull/2969

I recommend reviewing commit by commit.