### PR TITLE
Portugal no longer uses coal for electricity production

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -5040,7 +5040,7 @@
     ],
     "capacity": {
       "biomass": 729,
-      "coal": 628,
+      "coal": 0,
       "gas": 4585,
       "geothermal": 29,
       "hydro": 4372,


### PR DESCRIPTION
The last coal power plant in Portugal was scheduled to shut down on 30 November, 2021. However, the plant ran out of coal on the morning of Friday, 19 November.
Therefore, Portugal no longer uses coal to produce electricity. 
News Source: https://www.rtp.pt/noticias/economia/fecho-central-do-pego-portugal-deixa-de-ter-producao-de-eletricidade-a-partir-do-carvao_v1364794