### PR TITLE
Update Portugal Coal Capacity

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -5040,7 +5040,7 @@
     ],
     "capacity": {
       "biomass": 729,
-      "coal": 628,
+      "coal": 0,
       "gas": 4585,
       "geothermal": 29,
       "hydro": 4372,
@@ -5051,6 +5051,7 @@
       "wind": 5233
     },
     "contributors": [
+      "https://github.com/brandongalbraith",
       "https://github.com/corradio",
       "https://github.com/nessie2013",
       "https://github.com/Falconet8"


### PR DESCRIPTION
https://web.archive.org/web/20211122155025/https://apnews.com/article/business-environment-and-nature-europe-portugal-european-union-b09d32a0ee8c661f6932d79bda9d2d19

"The Pego plant located 150 kilometers (90 miles) northeast of the Portuguese capital Lisbon stopped generating over the weekend, as Portugal became the fourth European Union country to stop burning coal to produce electricity."