### PR TITLE
Changes links to electricitymap.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ The electricityMap doesn't use scheduled generation data or make assumptions abo
 Yes, providing there is a valid GeoJSON geometry (or another format that can be converted) for the area. As an example, we already split several countries into states and grid regions.
 
 **How can I get access to historical data or the live API?**
-All this and more can be found **[here](https://api.electricitymap.org/)**.
+All this and more can be found **[here](https://electricitymap.org/)**.

--- a/web/locales/cs.json
+++ b/web/locales/cs.json
@@ -96,8 +96,8 @@
         "oops": "Ach jo! Máme problém v komunikaci se serverem. Zkusíme to znovu za pár vteřin.",
         "newversion": "Nová verze je dostupná! <a onClick=\"location.reload(true);\">Klikněte zde</a> pro aktualizaci.",
         "retrynow": "Zkusit znovu",
-        "database-ad": "Hledáte historická data? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Zkontrolujte naši databázi!</a>",
-        "api-ad": "Chcete mít aktuální data ve své aplikaci nebo na svém zařízení? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Vyzkoušejte naše API!</a>]",
+        "database-ad": "Hledáte historická data? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Zkontrolujte naši databázi!</a>",
+        "api-ad": "Chcete mít aktuální data ve své aplikaci nebo na svém zařízení? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Vyzkoušejte naše API!</a>]",
         "legend": "Legenda",
         "faq": "Často kladené otázky"
     },
@@ -144,7 +144,7 @@
         "divideExistingArea-question": "Můžete rozdělit mou oblast na menší?",
         "divideExistingArea-answer": "Určitě, když existují separátní zdroje dat pro každou část dané oblasti. Můžete <a href=\"#contribute\" class=\"entry-link\">nám pomoci přidáním nových datových zdrojů</a>.",
         "seeHistoricalData-question": "Můžu zobrazit historii oblasti starší než 24 hodin?",
-        "seeHistoricalData-answer": "Můžete si zakoupíte přístup do <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databáze historických dat</a>."
+        "seeHistoricalData-answer": "Můžete si zakoupíte přístup do <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databáze historických dat</a>."
     },
     "methodology": {
         "groupName": "Metogologie",
@@ -172,9 +172,9 @@
         "dataOrigins-question": "Jak získáváte vaše data?",
         "dataOrigins-answer": "Všechna naše data zpracováváme z veřejně přístupných zdrojů publikovaných operátory elektrických rozvodných sítí, oficiálních agentur atd. Kliknutím na konkrétní oblast se zobrazí detailnější informace o původu dat.",
         "dataDownload-question": "Můžu si stáhnout vaše data?",
-        "dataDownload-answer": "Můžete si zakoupit přístup ke všem našim datům v naší <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databázi</a>.",
+        "dataDownload-answer": "Můžete si zakoupit přístup ke všem našim datům v naší <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databázi</a>.",
         "dataIntegration-question": "Můžu integrovat vaše data do mé aplikace nebo zařízení?",
-        "dataIntegration-answer": "Ano! Prodáváme přístup do <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, které zahrnuje budoucí předpovědi."
+        "dataIntegration-answer": "Ano! Prodáváme přístup do <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, které zahrnuje budoucí předpovědi."
     },
     "aboutUs": {
         "groupName": "O nás",

--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -105,8 +105,8 @@
         "oops": "Ups! Wir haben Probleme den Server zu erreichen. Wir versuchen es in wenigen Sekunden noch einmal.",
         "newversion": "Eine neuere Version ist verfügbar! Klick <a onClick=\"location.reload(true);\">hier</a>, um sie zu laden.",
         "retrynow": "Erneut versuchen",
-        "database-ad": "Auf der Suche nach historischen Daten? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Sieh dir unsere Datenbank an!</a>",
-        "api-ad": "Benötigst du Live-Daten für deine Apps oder Geräte? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Probiere unsere API!</a>",
+        "database-ad": "Auf der Suche nach historischen Daten? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Sieh dir unsere Datenbank an!</a>",
+        "api-ad": "Benötigst du Live-Daten für deine Apps oder Geräte? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Probiere unsere API!</a>",
         "legend": "Legende",
         "faq": "Häufig gestellte Fragen",
         "webgl-not-supported": "Diese Karte kann nicht angezeigt werden, weil dieser Webbrowser kein WebGL unterstützt."
@@ -154,7 +154,7 @@
         "divideExistingArea-question": "Können Sie meinen Bereich in kleinere Teile aufteilen?",
         "divideExistingArea-answer": "Das ist möglich, sofern es für diese Region eigene Datenquellen gibt. Du kannst <a href=\"#contribute\" class=\"entry-link\">uns helfen, neue Datenquellen hinzuzufügen</a>.",
         "seeHistoricalData-question": "Kann ich die Zeitreihe eines Bereiches sehen, die weiter als 24 Stunden zurückliegt?",
-        "seeHistoricalData-answer": "Sie können Zugriff auf alle unsere historischen Daten über unsere <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Datenbank</a> erwerben."
+        "seeHistoricalData-answer": "Sie können Zugriff auf alle unsere historischen Daten über unsere <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Datenbank</a> erwerben."
     },
     "methodology": {
         "groupName": "Unsere Methoden",
@@ -182,9 +182,9 @@
         "dataOrigins-question": "Wie erhalten Sie Ihre Daten?",
         "dataOrigins-answer": "Wir berechnen alle unsere Daten aus öffentlich zugänglichen Datenquellen, die von Stromnetzbetreibern, Behörden und anderen Institutionen veröffentlicht werden. Sie können auf eine Region klicken, um mehr über die Herkunft der Daten zu erfahren.",
         "dataDownload-question": "Kann ich Ihre Daten herunterladen?",
-        "dataDownload-answer": "Sie können einen Zugang zu allen unseren Daten über unsere <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Datenbank</a> erwerben.",
+        "dataDownload-answer": "Sie können einen Zugang zu allen unseren Daten über unsere <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Datenbank</a> erwerben.",
         "dataIntegration-question": "Kann ich Ihre Daten in Echtzeit in meine Anwendung oder mein Gerät integrieren?",
-        "dataIntegration-answer": "Ja! Wir bieten den Zugang zu einer kostenpflichtigen <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Echtzeit API</a> an, die auch Zukunftsprognosen beinhaltet."
+        "dataIntegration-answer": "Ja! Wir bieten den Zugang zu einer kostenpflichtigen <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Echtzeit API</a> an, die auch Zukunftsprognosen beinhaltet."
     },
     "aboutUs": {
         "groupName": "Über uns",

--- a/web/locales/el.json
+++ b/web/locales/el.json
@@ -101,8 +101,8 @@
         "newversion": "Μια νέα έκδοση είναι διαθέσιμη! Πατήστε <a onClick=\"location.reload(true);\">εδώ</a> για επαναφόρτωση.",
         "webgl-not-supported": "Ο χάρτης δεν μπορεί να παρουσιαστεί καθώς αυτό το πρόγραμμα περιήγησης δεν υποστηρίζει WebGL.",
         "retrynow": "Επαναδοκιμή τώρα",
-        "database-ad": "Ψάχνετε για ιστορικά δεδομένα; <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Δείτε τη βάση δεδομένων μας!</a>",
-        "api-ad": "Θέλετε ζωντανά δεδομένα στην εφαρμογή ή στη συσκευή σας; <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Δοκιμάστε το API μας!</a>",
+        "database-ad": "Ψάχνετε για ιστορικά δεδομένα; <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Δείτε τη βάση δεδομένων μας!</a>",
+        "api-ad": "Θέλετε ζωντανά δεδομένα στην εφαρμογή ή στη συσκευή σας; <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Δοκιμάστε το API μας!</a>",
         "legend": "Yπόμνημα",
         "faq": "Συχνές Ερωτήσεις"
     },
@@ -149,7 +149,7 @@
         "divideExistingArea-question": "Can you divide my area into smaller parts?",
         "divideExistingArea-answer": "Sure, if there exists separate data sources for each part of the area. You can <a href=\"#contribute\" class=\"entry-link\">help us with adding new data sources</a>",
         "seeHistoricalData-question": "Can I see the history for an area further back in time than 24 hours?",
-        "seeHistoricalData-answer": "You can purchase access to all of our historical data through our <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
+        "seeHistoricalData-answer": "You can purchase access to all of our historical data through our <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
     },
     "methodology": {
         "groupName": "Our methods",
@@ -177,9 +177,9 @@
         "dataOrigins-question": "How do you get your data?",
         "dataOrigins-answer": "We compute all of our data from publically available data, published by electricity grid operators, official agencies, and others. You can click on an area to see more specifics on the origins of its data.",
         "dataDownload-question": "Can I download your data?",
-        "dataDownload-answer": "You can purchase access to all of our data in our <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
+        "dataDownload-answer": "You can purchase access to all of our data in our <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
         "dataIntegration-question": "Can I integrate your data real-time into my application or device?",
-        "dataIntegration-answer": "Yes! We sell access to a <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, which includes future forecasts."
+        "dataIntegration-answer": "Yes! We sell access to a <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, which includes future forecasts."
     },
     "aboutUs": {
         "groupName": "Σχετικά με εμάς",

--- a/web/locales/en.json
+++ b/web/locales/en.json
@@ -105,8 +105,8 @@
         "newversion": "A new version is available! Press <a onClick=\"location.reload(true);\">here</a> to reload.",
         "webgl-not-supported": "The map can't be rendered because this browser does not support WebGL.",
         "retrynow": "Retry now",
-        "database-ad": "Looking for historical data? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Check out our Database!</a>",
-        "api-ad": "Want live data in your app or on your device? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Try our API!</a>",
+        "database-ad": "Looking for historical data? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Check out our Database!</a>",
+        "api-ad": "Want live data in your app or on your device? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Try our API!</a>",
         "legend": "Legend",
         "faq": "Frequently Asked Questions"
     },
@@ -155,7 +155,7 @@
         "divideExistingArea-question": "Can you divide my area into smaller parts?",
         "divideExistingArea-answer": "Sure, if there exists separate data sources for each part of the area. You can <a href=\"#contribute\" class=\"entry-link\">help us with adding new data sources</a>",
         "seeHistoricalData-question": "Can I see the history for an area further back in time than 24 hours?",
-        "seeHistoricalData-answer": "You can purchase access to all of our historical data through our <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
+        "seeHistoricalData-answer": "You can purchase access to all of our historical data through our <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
     },
     "methodology": {
         "groupName": "Our methods",
@@ -183,9 +183,9 @@
         "dataOrigins-question": "How do you get your data?",
         "dataOrigins-answer": "We compute all of our data from publically available data, published by electricity grid operators, official agencies, and others. You can click on an area to see more specifics on the origins of its data.",
         "dataDownload-question": "Can I download your data?",
-        "dataDownload-answer": "You can purchase access to all of our data in our <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
+        "dataDownload-answer": "You can purchase access to all of our data in our <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
         "dataIntegration-question": "Can I integrate your data real-time into my application or device?",
-        "dataIntegration-answer": "Yes! We sell access to a <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, which includes future forecasts."
+        "dataIntegration-answer": "Yes! We sell access to a <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, which includes future forecasts."
     },
     "aboutUs": {
         "groupName": "About us",

--- a/web/locales/es.json
+++ b/web/locales/es.json
@@ -99,8 +99,8 @@
         "newversion": "¡Hay disponible una nueva versión! Pulsa <a onClick=\"location.reload(true);\">aquí</a> para recargar.",
         "webgl-not-supported": "No se puede mostrar el mapa porque este navegador no es compatible con WebGL.",
         "retrynow": "Vuelve a intentarlo",
-        "database-ad": "¿Buscas datos históricos? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Echa un vistazo a nuestra Base de Datos!</a>",
-        "api-ad": "¿Quieres datos en tiempo real en tu app o dispositivo? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Prueba nuestra API!</a>",
+        "database-ad": "¿Buscas datos históricos? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Echa un vistazo a nuestra Base de Datos!</a>",
+        "api-ad": "¿Quieres datos en tiempo real en tu app o dispositivo? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Prueba nuestra API!</a>",
         "legend": "Leyenda",
         "faq": "Preguntas frecuentes"
     },
@@ -147,7 +147,7 @@
         "divideExistingArea-question": "¿Se puede dividir mi zona en partes más pequeñas?",
         "divideExistingArea-answer": "Sí, pero necesitamos datos para cada subdivisión de la zona. Puedes <a href=\"#contribute\" class=\"entry-link\">echarnos una mano añadiendo nuevas fuentes de datos</a>",
         "seeHistoricalData-question": "¿Puedo ver los datos históricos de una zona más allá de las 24 horas que se muestran?",
-        "seeHistoricalData-answer": "Puedes adquirir el acceso a todos los datos históricos que tenemos en nuestra <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de datos</a>."
+        "seeHistoricalData-answer": "Puedes adquirir el acceso a todos los datos históricos que tenemos en nuestra <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de datos</a>."
     },
     "methodology": {
         "groupName": "Nuestros métodos",
@@ -175,9 +175,9 @@
         "dataOrigins-question": "¿De dónde obtenéis los datos?",
         "dataOrigins-answer": "Calculamos la intensidad de carbono con los datos que hacen públicos los operadores de red eléctrica, agencias oficiales y otros. Puedes hacer clic en una zona para ver información específica sobre las fuentes de los datos.",
         "dataDownload-question": "¿Puedo descargarme vuestros datos?",
-        "dataDownload-answer": "Puedes acceder previo pago a todos los datos de nuestra <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de datos</a>.",
+        "dataDownload-answer": "Puedes acceder previo pago a todos los datos de nuestra <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de datos</a>.",
         "dataIntegration-question": "¿Puedo integrar vuestros datos en tiempo real en mi aplicación o dispositivo?",
-        "dataIntegration-answer": "¡Claro! Puedes adquirir los datos en <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">nuestra API en tiempo real</a>, que incluye pronósticos a veinticuatro horas vista."
+        "dataIntegration-answer": "¡Claro! Puedes adquirir los datos en <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">nuestra API en tiempo real</a>, que incluye pronósticos a veinticuatro horas vista."
     },
     "aboutUs": {
         "groupName": "Sobre nosotros",

--- a/web/locales/et.json
+++ b/web/locales/et.json
@@ -103,8 +103,8 @@
         "newversion": "Saadaval on uus versioon! Vajutage ümberlaadimiseks <a onClick=\"location.reload(true);\">siia</a>.",
         "webgl-not-supported": "Kaarti ei saa renderdada, kuna see brauser ei toeta WebGL-i.",
         "retrynow": "Proovi kohe uuesti",
-        "database-ad": "Otsite ajaloo andmeid? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Vaadake meie andmebaasi!</a>",
-        "api-ad": "Tahate reaalajas andmeid enda rakendusse või seadmesse? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Proovige meie API-t!</a>",
+        "database-ad": "Otsite ajaloo andmeid? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Vaadake meie andmebaasi!</a>",
+        "api-ad": "Tahate reaalajas andmeid enda rakendusse või seadmesse? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Proovige meie API-t!</a>",
         "legend": "Legend",
         "faq": "Korduma kippuvad küsimused"
     },
@@ -151,7 +151,7 @@
         "divideExistingArea-question": "Kas saate jaotada minu piirkonda väiksemateks osadeks?",
         "divideExistingArea-answer": "Muidugi, kui iga piirkonna osa kohta on olemas eraldi andmeallikad. Teil on võimalik <a href=\"#contribute\" class=\"entry-link\">meid aidata, lisades uued andmeallikaid</a>",
         "seeHistoricalData-question": "Kas ma saan vaadata piirkonna ajalugu kaugemale kui 24 tundi tagasi?",
-        "seeHistoricalData-answer": "Saate osta juurdepääsu kõigile meie ajaloo andmetele läbi meie <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">andmebaasi</a>."
+        "seeHistoricalData-answer": "Saate osta juurdepääsu kõigile meie ajaloo andmetele läbi meie <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">andmebaasi</a>."
     },
     "methodology": {
         "groupName": "Meie meetodid",
@@ -179,9 +179,9 @@
         "dataOrigins-question": "Kuidas te oma andmed saate?",
         "dataOrigins-answer": "Me arvutame kõik oma andmed avalikult kättesaadavate andmete põhjal, mille on avaldanud elektrivõrguettevõtted, ametlikud asutused ja teised. Võite klõpsata piirkonnal, et näha andmete päritolu kohta täpsemat teavet.",
         "dataDownload-question": "Kas ma saan teie andmeid alla laadida?",
-        "dataDownload-answer": "Saate osta juurdepääsu kõigile meie andmetele läbi meie <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">andmebaasi</a>.",
+        "dataDownload-answer": "Saate osta juurdepääsu kõigile meie andmetele läbi meie <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">andmebaasi</a>.",
         "dataIntegration-question": "Kas ma saan teie andmeid reaalajas enda rakendusse või seadmesse integreerida?",
-        "dataIntegration-answer": "Jah! Me müüme juurdepääsu <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">reaalajas API-le</a>, mis sisaldab ka tulevikuprognoose."
+        "dataIntegration-answer": "Jah! Me müüme juurdepääsu <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">reaalajas API-le</a>, mis sisaldab ka tulevikuprognoose."
     },
     "aboutUs": {
         "groupName": "Meist",

--- a/web/locales/fi.json
+++ b/web/locales/fi.json
@@ -98,8 +98,8 @@
         "oops": "Meillä on vaikeuksia palvelimen saavuttamisessa. Yritämme uudelleen muutamassa sekunnissa.",
         "newversion": "Uusi versio saatavilla! Päivitä <a onClick=\"location.reload(true);\">tästä</a>.",
         "retrynow": "Yritä uudelleen nyt",
-        "database-ad": "Etsitkö historiallista tietoa? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Tutustu tietokantaamme!</a>",
-        "api-ad": "Haluatko live-tietoja sovelluksessasi tai laitteessasi? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Kokeile meidän API:ta!</a>",
+        "database-ad": "Etsitkö historiallista tietoa? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Tutustu tietokantaamme!</a>",
+        "api-ad": "Haluatko live-tietoja sovelluksessasi tai laitteessasi? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Kokeile meidän API:ta!</a>",
         "legend": "Selite",
         "faq": "Usein Kysytyt Kysymykset"
     },
@@ -146,7 +146,7 @@
         "divideExistingArea-question": "Voitko jakaa alueeni pienempiin osiin?",
         "divideExistingArea-answer": "Toki, jos alueen jokaiselle osalle on olemassa erilliset tietolähteet. Voit <a href=\"#contribute\" class=\"entry-link\">auttaa meitä lisäämällä uusia tietolähteitä</a>",
         "seeHistoricalData-question": "Voinko nähdä alueen historian, joka on vanhempi kuin 24 tuntia?",
-        "seeHistoricalData-answer": "Voit ostaa pääsyn kaikkiin historiallisiin tietoihimme <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">tietokantamme</a> kautta."
+        "seeHistoricalData-answer": "Voit ostaa pääsyn kaikkiin historiallisiin tietoihimme <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">tietokantamme</a> kautta."
     },
     "methodology": {
         "groupName": "Menetelmämme",
@@ -174,9 +174,9 @@
         "dataOrigins-question": "Kuinka saatte datanne?",
         "dataOrigins-answer": "Laskemme kaikki tietomme julkisesti saatavilla olevista tiedoista, jotka sähköverkko-operaattorit, viralliset virastot ja muut ovat julkaisseet. Voit klikata aluetta nähdäksesi tarkempia tietoja sen alkuperästä.",
         "dataDownload-question": "Voinko ladata datasi?",
-        "dataDownload-answer": "Voit ostaa pääsyn kaikkiin tietoihimme <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">tietokannassamme</a>.",
+        "dataDownload-answer": "Voit ostaa pääsyn kaikkiin tietoihimme <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">tietokannassamme</a>.",
         "dataIntegration-question": "Voinko integroida tietosi reaaliaikaisesti sovellukseeni tai laitteeseeni?",
-        "dataIntegration-answer": "Kyllä! Myymme pääsyä <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">reaaliaikaiseen API:hin</a>, joka sisältää ennusteita."
+        "dataIntegration-answer": "Kyllä! Myymme pääsyä <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">reaaliaikaiseen API:hin</a>, joka sisältää ennusteita."
     },
     "aboutUs": {
         "groupName": "Tietoa meistä",

--- a/web/locales/fr.json
+++ b/web/locales/fr.json
@@ -102,8 +102,8 @@
         "retrynow": "Réessayez maintenant",
         "legend": "Légende",
         "faq": "Foire Aux Questions",
-        "database-ad": "Vous recherchez des données historiques ? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Jetez un œil à notre base de données.</a>",
-        "api-ad": "Vous voulez des données en temps réel pour votre application ou votre appareil ? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Explorez notre API !</a>",
+        "database-ad": "Vous recherchez des données historiques ? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Jetez un œil à notre base de données.</a>",
+        "api-ad": "Vous voulez des données en temps réel pour votre application ou votre appareil ? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Explorez notre API !</a>",
         "webgl-not-supported": "La carte ne peut pas être rendue car ce navigateur ne supporte pas WebGL."
     },
     "wind": "éolien",
@@ -149,7 +149,7 @@
         "divideExistingArea-question": "Pouvez-vous diviser ma zone en petites parties ?",
         "divideExistingArea-answer": "Bien sûr, s’il existe des sources de données distinctes pour chaque partie de la zone. Vous pouvez <a href=\"#contribute\" class=\"entry-link\">nous aider à ajouter de nouvelles sources de données</a>.",
         "seeHistoricalData-question": "Puis-je voir l’historique de plus de 24 heures d’une région ?",
-        "seeHistoricalData-answer": "Vous pouvez acheter un accès à toutes nos données historiques via notre <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de données</a>."
+        "seeHistoricalData-answer": "Vous pouvez acheter un accès à toutes nos données historiques via notre <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de données</a>."
     },
     "methodology": {
         "groupName": "Nos méthodes",
@@ -177,9 +177,9 @@
         "dataOrigins-question": "Comment obtenez-vous vos données ?",
         "dataOrigins-answer": "Nous calculons toutes nos données à partir de données accessibles au public, publiées par les opérateurs de réseaux électriques, les agences officielles et autres. Vous pouvez cliquer sur une zone pour voir plus de détails sur les origines de ces données.",
         "dataDownload-question": "Puis-je télécharger vos données ?",
-        "dataDownload-answer": "Vous pouvez acheter un accès à toutes nos données dans notre <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de données</a>.",
+        "dataDownload-answer": "Vous pouvez acheter un accès à toutes nos données dans notre <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">base de données</a>.",
         "dataIntegration-question": "Puis-je intégrer vos données en temps réel dans mon application ou mon appareil?",
-        "dataIntegration-answer": "Oui ! Nous vendons l’accès à l’API <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">en temps réel</a>, qui inclut les prévisions pour l’avenir."
+        "dataIntegration-answer": "Oui ! Nous vendons l’accès à l’API <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">en temps réel</a>, qui inclut les prévisions pour l’avenir."
     },
     "aboutUs": {
         "groupName": "À propos de nous",

--- a/web/locales/hr.json
+++ b/web/locales/hr.json
@@ -96,8 +96,8 @@
         "oops": "Ups! Došlo je do problema kod kontaktiranja servera. Pokušat ćemo opet za nekoliko sekundi.",
         "newversion": "Nova verzija je dostupna! Klikni <a onClick=\"location.reload(true);\">ovdje</a> za ponovno učitavanje.",
         "retrynow": "Pokušaj opet",
-        "database-ad": "Tražiš povijesne podatke? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Pogledaj u našu bazu podataka!</a>",
-        "api-ad": "Želiš podatke uživo za svoju aplikaciju ili uređaj? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Isprobaj naš API!</a>",
+        "database-ad": "Tražiš povijesne podatke? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Pogledaj u našu bazu podataka!</a>",
+        "api-ad": "Želiš podatke uživo za svoju aplikaciju ili uređaj? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Isprobaj naš API!</a>",
         "legend": "Legenda",
         "faq": "Često postavljana pitanja"
     },
@@ -144,7 +144,7 @@
         "divideExistingArea-question": "Možete li podijeliti moje područje na manje dijelove?",
         "divideExistingArea-answer": "Naravno, ako postoje nezavisni izvori podataka za svaki dio područja. Pomozi nam u <a href=\"#contribute\" class=\"entry-link\">dodavanju novih izvora podataka</a>.",
         "seeHistoricalData-question": "Mogu li vidjeti povijest za područje više od 24 sata unazad?",
-        "seeHistoricalData-answer": "Možeš nabaviti pristup svim našim povijesnim podacima preko naše <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">baze podataka</a>."
+        "seeHistoricalData-answer": "Možeš nabaviti pristup svim našim povijesnim podacima preko naše <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">baze podataka</a>."
     },
     "methodology": {
         "groupName": "Naše metode",
@@ -166,9 +166,9 @@
         "dataOrigins-question": "Otkud dobivate podatke?",
         "dataOrigins-answer": "Svi izračuni su dobiveni iz javno dostpnih podaka, objavljenih od rukovodioca elektičnih mreža, službenih agencija i drugih. Možeš kliknuti na pojedina područja za više informacija o izvoru pojedinih podataka.",
         "dataDownload-question": "Mogu li skinuti vaše podatke?",
-        "dataDownload-answer": "Možeš nabaviti pristup svim podacima u našoj <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">bazi podataka</a>.",
+        "dataDownload-answer": "Možeš nabaviti pristup svim podacima u našoj <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">bazi podataka</a>.",
         "dataIntegration-question": "Mogu li integrirati vaše podake uživo u svoju aplikaciju ili uređaj?",
-        "dataIntegration-answer": "Da! Prodajemo pristup <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">našem API-u</a>, koji uključuje i predviđanja za budućnost."
+        "dataIntegration-answer": "Da! Prodajemo pristup <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">našem API-u</a>, koji uključuje i predviđanja za budućnost."
     },
     "aboutUs": {
         "groupName": "O nama",

--- a/web/locales/id.json
+++ b/web/locales/id.json
@@ -96,8 +96,8 @@
         "oops": "Oops! Kami mengalami masalah menghubungkan ke dalam server. Kami akan coba beberapa detik lagi.",
         "newversion": "Versi baru tersedia! Klik <a onClick=\"location.reload(true);\">di sini</a> untuk memuat ulang.",
         "retrynow": "Ulangi sekarang",
-        "database-ad": "Mencari data historikal? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Periksa di database Kami!</a>",
-        "api-ad": "Ingin mendapatkan data langsung di aplikasi atau perangkat Anda? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Coba API kami!</a>",
+        "database-ad": "Mencari data historikal? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Periksa di database Kami!</a>",
+        "api-ad": "Ingin mendapatkan data langsung di aplikasi atau perangkat Anda? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Coba API kami!</a>",
         "legend": "Legenda",
         "faq": "Pertanyaan yang Sering Diajukan"
     },
@@ -144,7 +144,7 @@
         "divideExistingArea-question": "Bisakah Anda membagi area di wilayah Saya menjadi bagian lebih kecil lagi?",
         "divideExistingArea-answer": "Tentu, jika ada data terpisah yang lebih lengkap di setiap wilayah tersebut. Kamu bisa <a href=\"#contribute\" class=\"entry-link\">membantu Kami dengan menambahkan data di wilayah tersebut</a>",
         "seeHistoricalData-question": "Dapatkah saya melihat sejarah untuk suatu daerah lebih jauh ke belakang dalam waktu 24 jam?",
-        "seeHistoricalData-answer": "Anda bisa membeli untuk mengakses seluruh data historikal kami melalui <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
+        "seeHistoricalData-answer": "Anda bisa membeli untuk mengakses seluruh data historikal kami melalui <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
     },
     "methodology": {
         "groupName": "Metode Kami",
@@ -172,9 +172,9 @@
         "dataOrigins-question": "Bagaimana Anda mendapatkan data Anda?",
         "dataOrigins-answer": "Kami menghitung semua data kami dari data yang tersedia untuk umum, diterbitkan oleh operator jaringan listrik, agen resmi, dan lainnya. Anda dapat mengklik area untuk melihat lebih spesifik tentang asal-usul datanya.",
         "dataDownload-question": "Bisakah Saya mengunduh data Anda?",
-        "dataDownload-answer": "Anda dapat membeli akses ke semua data di <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
+        "dataDownload-answer": "Anda dapat membeli akses ke semua data di <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
         "dataIntegration-question": "Dapatkah saya mengintegrasikan data Anda secara langsung ke aplikasi atau perangkat saya?",
-        "dataIntegration-answer": "Ya! Kami menjual akses ke dalam <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, yang mencakup prakiraan cuaca."
+        "dataIntegration-answer": "Ya! Kami menjual akses ke dalam <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, yang mencakup prakiraan cuaca."
     },
     "aboutUs": {
         "groupName": "Tentang Kami",

--- a/web/locales/it.json
+++ b/web/locales/it.json
@@ -105,8 +105,8 @@
         "newversion": "È disponibile una nuova versione! Clicca <a onClick=\"location.reload(true);\">qua</a> per ricaricare.",
         "webgl-not-supported": "La mappa non può essere mostrata perché questo browser non supporta WebGL.",
         "retrynow": "Riprova ora",
-        "database-ad": "Stai cercando lo storico dei dati? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Controlla nel nostro Database!</a>",
-        "api-ad": "Vuoi i dati in tempo reale sulla tua app o sul tuo dispositivo? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Prova la nostra API!</a>",
+        "database-ad": "Stai cercando lo storico dei dati? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Controlla nel nostro Database!</a>",
+        "api-ad": "Vuoi i dati in tempo reale sulla tua app o sul tuo dispositivo? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Prova la nostra API!</a>",
         "legend": "Legenda",
         "faq": "Domande poste frequentemente"
     },
@@ -155,7 +155,7 @@
         "divideExistingArea-question": "Potete dividere la mia area in parti più piccole?",
         "divideExistingArea-answer": "Certamente, se esitono fonti separate per ogni parte di quest'area. Puoi <a href=\"#contribute\" class=\"entry-link\">aiutare aggiungendo nuove fonti di dati</a>",
         "seeHistoricalData-question": "Posso vedere la cronologia di un area per un periodo più lungo di 24 ore?",
-        "seeHistoricalData-answer": "Puoi comprare l'accesso a tutto lo storico dei nostri dati sul nostro <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
+        "seeHistoricalData-answer": "Puoi comprare l'accesso a tutto lo storico dei nostri dati sul nostro <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
     },
     "methodology": {
         "groupName": "I nostri metodi",
@@ -183,9 +183,9 @@
         "dataOrigins-question": "Dove prendete i dati?",
         "dataOrigins-answer": "Prendiamo tutti i dati da dati liberamente accessibili, pubblicati dagli operatori di linea, dalle agenzie ufficiali, ed altri. Puoi cliccare su un'area per vedere più specifiche sulle origini dei dati.",
         "dataDownload-question": "Posso scaricare i vostri dati?",
-        "dataDownload-answer": "Puoi comprare l'accesso a tutti i nostri dati sul nostro <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
+        "dataDownload-answer": "Puoi comprare l'accesso a tutti i nostri dati sul nostro <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
         "dataIntegration-question": "Possono integrare i vostri dati in tempo reale nella mia applicazione o nel mio dispositivo?",
-        "dataIntegration-answer": "Sì! Vendiamo l'accesso alle nostre <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">API in tempo reale</a>, che includono le previsioni future."
+        "dataIntegration-answer": "Sì! Vendiamo l'accesso alle nostre <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">API in tempo reale</a>, che includono le previsioni future."
     },
     "aboutUs": {
         "groupName": "Informazioni su di noi",

--- a/web/locales/ja.json
+++ b/web/locales/ja.json
@@ -101,8 +101,8 @@
         "newversion": "新しいバージョンが使える、リロードするには<a onClick=\"location.reload(true);\">こちら</a>にタップしてください",
         "webgl-not-supported": "ブラウザがWebGLをサポートしていないため、マップを表示できません。",
         "retrynow": "今すぐリトライ",
-        "database-ad": "過去のデータをお探しですか? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">データベースをチェックしてください!</a>",
-        "api-ad": "あなたのアプリやデバイスにデータを取り込みたいですか? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">私たちのAPIをお試しください!</a>",
+        "database-ad": "過去のデータをお探しですか? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">データベースをチェックしてください!</a>",
+        "api-ad": "あなたのアプリやデバイスにデータを取り込みたいですか? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">私たちのAPIをお試しください!</a>",
         "legend": "Legend",
         "faq": "よくある質問"
     },
@@ -149,7 +149,7 @@
         "divideExistingArea-question": "私が住む地域をより小さい単位に分割できますか?",
         "divideExistingArea-answer": "それぞれの地域を分割できるような情報源がある場合はもちろんできます。<a href=\"#contribute\" class=\"entry-link\">新しい情報源を追加</a>することができます。",
         "seeHistoricalData-question": "24時間を超える過去のデータ履歴を見ることができますか?",
-        "seeHistoricalData-answer": "<a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">データベース</a>を通して全ての過去データへのアクセス権を購入できます。"
+        "seeHistoricalData-answer": "<a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">データベース</a>を通して全ての過去データへのアクセス権を購入できます。"
     },
     "methodology": {
         "groupName": "手法",
@@ -177,9 +177,9 @@
         "dataOrigins-question": "データはどのように取得しているのですか?",
         "dataOrigins-answer": "私たちは全てのデータを送電事業者、官公庁、その他の機関から公開されているデータを処理して利用しています。地域をクリックすることで情報源についてより詳細な情報が得られます。",
         "dataDownload-question": "データをダウンロードできますか?",
-        "dataDownload-answer": "<a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">データベース</a>から全てのデータのアクセス権を購入できます。",
+        "dataDownload-answer": "<a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">データベース</a>から全てのデータのアクセス権を購入できます。",
         "dataIntegration-question": "データをリアルタイムに私のアプリケーションやデバイスに統合できますか?",
-        "dataIntegration-answer": "できます! <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">リアルタイムAPI</a>へのアクセス権を販売しており、これには未来予測も含まれています。"
+        "dataIntegration-answer": "できます! <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">リアルタイムAPI</a>へのアクセス権を販売しており、これには未来予測も含まれています。"
     },
     "aboutUs": {
         "groupName": "私たちについて",

--- a/web/locales/ko.json
+++ b/web/locales/ko.json
@@ -96,8 +96,8 @@
         "oops": "이런! 서버 접속에 문제가 있네요. 잠시 후 다시 시도해보겠습니다.",
         "newversion": "새 버전이 출시되었습니다! 누르세요 <a onClick=\"location.reload(true);\">here</a> to reload.",
         "retrynow": "지금 다시 눌러보세요",
-        "database-ad": "역사학적 데이터를 찾으시나요? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">데이터 베이스를 확인해보세요!</a>",
-        "api-ad": "당신의 앱이나 기기에 라이브 데이터가 필요한가요? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">저희 API를 체험해보세요!</a>",
+        "database-ad": "역사학적 데이터를 찾으시나요? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">데이터 베이스를 확인해보세요!</a>",
+        "api-ad": "당신의 앱이나 기기에 라이브 데이터가 필요한가요? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">저희 API를 체험해보세요!</a>",
         "legend": "범주",
         "faq": "자주 묻는 질문"
     },
@@ -144,7 +144,7 @@
         "divideExistingArea-question": "나의 지역도 더 작은 부분으로 나눌 수 있습니까?",
         "divideExistingArea-answer": "물론입니다. 해당 영역의 각 부분에 대해 별도의 데이터 소스가 있는 경우. <a href=\"#contribute\" class=\"entry-link\">사용자는 새로운 데이터를 우리에게 제공함으로써 우리를 도울 수 있습니다.</a>",
         "seeHistoricalData-question": "지역의 더 많은 역사를 24시간 안에 받아 볼 수 있습니까?",
-        "seeHistoricalData-answer": "당신은 우리의 <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">데이터베이스를</a> 통해 모든 우리의 역사적 데이터를 구매할 수 있습니다."
+        "seeHistoricalData-answer": "당신은 우리의 <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">데이터베이스를</a> 통해 모든 우리의 역사적 데이터를 구매할 수 있습니다."
     },
     "methodology": {
         "groupName": "접근 방법/연구 방법",
@@ -172,9 +172,9 @@
         "dataOrigins-question": "어떻게 데이터를 얻나요?",
         "dataOrigins-answer": "저희는 전력망이나, 공식 에이전시 등을 통해 공개적으로 접근 가능한 모든 데이터를 다룹니다. 각 섹션을 클릭하시면 데이터의 출처를 더 자세히 알 수 있습니다.",
         "dataDownload-question": "데이터를 다운로드 받을 수 있나요?",
-        "dataDownload-answer": "<a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">데이터베이스</a>에서 구입하시면 모든 데이터에 접근 가능합니다.",
+        "dataDownload-answer": "<a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">데이터베이스</a>에서 구입하시면 모든 데이터에 접근 가능합니다.",
         "dataIntegration-question": "여기 데이터를 실시간으로 내 어플리케이션이나 장치에 실시간으로 업데이트 할 수 있나요?",
-        "dataIntegration-answer": "네!! 구입하시면 <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">실시간 API</a>, 에 접근할 수 있습니다. 향후 예측도 포함되어 있습니다."
+        "dataIntegration-answer": "네!! 구입하시면 <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">실시간 API</a>, 에 접근할 수 있습니다. 향후 예측도 포함되어 있습니다."
     },
     "aboutUs": {
         "groupName": "About us",

--- a/web/locales/nl.json
+++ b/web/locales/nl.json
@@ -75,8 +75,8 @@
         "oops": "Oeps! Er zijn moeilijkheden om de server te bereiken. We proberen opnieuw over een paar seconden.",
         "newversion": "Een nieuwe versie is beschikbaar! Klik <a onClick=\"location.reload(true);\">hier</a> om opnieuw te laden.",
         "retrynow": "Probeer opnieuw",
-        "database-ad": "Looking for historical data? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Check out our Database!</a>",
-        "api-ad": "Want live data in your app or on your device? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Try our API!</a>",
+        "database-ad": "Looking for historical data? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Check out our Database!</a>",
+        "api-ad": "Want live data in your app or on your device? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Try our API!</a>",
         "legend": "Legenda",
         "faq": "Veelgestelde vragen"
     },

--- a/web/locales/pl.json
+++ b/web/locales/pl.json
@@ -100,8 +100,8 @@
         "oops": "Ups! Mamy problemy z komunikacją z serwerem. Spróbujemy ponownie za kilka sekund.",
         "newversion": "Jest dostępna nowa wersja! <a onClick=\"location.reload(true);\">Załaduj ją</a>.",
         "retrynow": "Spróbuj teraz",
-        "database-ad": "Szukasz danych historycznych? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Sprawdź Electricity Map Database!</a>",
-        "api-ad": "Chcesz mieć aktualne dane w twojej aplikacji lub na urządzeniu? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Spróbuj Electricity Map API!</a>",
+        "database-ad": "Szukasz danych historycznych? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Sprawdź Electricity Map Database!</a>",
+        "api-ad": "Chcesz mieć aktualne dane w twojej aplikacji lub na urządzeniu? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Spróbuj Electricity Map API!</a>",
         "legend": "Legenda",
         "faq": "Najczęściej Zadawane Pytania",
         "webgl-not-supported": "Nie można wyrenderować mapy, ponieważ wykorzystywana przeglądarka nie obsługuje WebGL."
@@ -128,7 +128,7 @@
         "divideExistingArea-question": "Czy możecie podzielić mój obszar na mniejsze części?",
         "divideExistingArea-answer": "Oczywiście, jeżeli istnieją oddzielne źródła danych dla każdej części obszaru. Możesz <a href=\"#contribute\" class=\"entry-link\">nam pomóc dodając nowe źródła danych</a>",
         "seeHistoricalData-question": "Czy mogę zobaczyć historię obszaru cofniętą w czasie o więcej niż 24 godziny?",
-        "seeHistoricalData-answer": "Możesz zakupić dostęp do naszych wszystkich danych historycznych za pośrednictwem <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">naszej bazy danych</a>."
+        "seeHistoricalData-answer": "Możesz zakupić dostęp do naszych wszystkich danych historycznych za pośrednictwem <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">naszej bazy danych</a>."
     },
     "methodology": {
         "groupName": "Nasze metody",
@@ -154,9 +154,9 @@
         "dataOrigins-question": "Skąd bierzecie swoje dane?",
         "dataOrigins-answer": "Wszystkie nasze dane obliczamy na podstawie publicznie dostępnych danych, publikowanych przez operatorów sieci elektroenergetycznych, oficjale agencje i innych. Możesz kliknąć na obszar aby zobaczyć więcej szczegółów na temat pochodzenia jego danych.",
         "dataDownload-question": "Czy mogę pobrać wasze dane?",
-        "dataDownload-answer": "Możesz wykupić dostęp do naszych wszystkich danych w naszej <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">bazie danych</a>.",
+        "dataDownload-answer": "Możesz wykupić dostęp do naszych wszystkich danych w naszej <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">bazie danych</a>.",
         "dataIntegration-question": "Czy mogę zintegrować wasze dane w czasie rzeczywistym z moją aplikacją lub urządzeniem?",
-        "dataIntegration-answer": "Tak! Sprzdajemy dostęp do <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">API w czasie rzeczywistym</a>, które zawiera prognozy na przyszłość."
+        "dataIntegration-answer": "Tak! Sprzdajemy dostęp do <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">API w czasie rzeczywistym</a>, które zawiera prognozy na przyszłość."
     },
     "aboutUs": {
         "groupName": "O nas",

--- a/web/locales/pt-br.json
+++ b/web/locales/pt-br.json
@@ -105,8 +105,8 @@
         "newversion": "Uma nova versão está disponível! Clique <a onClick=\"location.reload(true);\">aqui</a> para recarregar.",
         "webgl-not-supported": "O mapa não pode ser renderizado porque este navegador não oferece suporte a WebGL.",
         "retrynow": "Tentar novamente",
-        "database-ad": "Procurando por dados históricos? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Olhe nosso banco de dados!</a>",
-        "api-ad": "Gostaria de dados em tempo real no seu app ou no seu dispositivo? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Tente nossa API!</a>",
+        "database-ad": "Procurando por dados históricos? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Olhe nosso banco de dados!</a>",
+        "api-ad": "Gostaria de dados em tempo real no seu app ou no seu dispositivo? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Tente nossa API!</a>",
         "legend": "Legenda",
         "faq": "Questões frequentes"
     },
@@ -153,7 +153,7 @@
         "divideExistingArea-question": "Você pode dividir minha área em partes menores?",
         "divideExistingArea-answer": "Claro, se houver fontes de dados separadas para cada parte da área. Você pode <a href=\"#contribute\" class=\"entry-link\"> nos ajudar a adicionar novas fontes de dados </a>",
         "seeHistoricalData-question": "Posso ver o histórico de uma área mais atrasada do que 24 horas?",
-        "seeHistoricalData-answer": "Você pode adquirir acesso a todos os nossos dados históricos através de nosso <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\"> banco de dados </ a >."
+        "seeHistoricalData-answer": "Você pode adquirir acesso a todos os nossos dados históricos através de nosso <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\"> banco de dados </ a >."
     },
     "methodology": {
         "groupName": "Nossos métodos",
@@ -184,9 +184,9 @@
         "dataOrigins-question": "Como você obtém seus dados?",
         "dataOrigins-answer": "Computamos todos os nossos dados a partir de dados publicamente disponíveis, publicados por operadores de rede elétrica, agências oficiais e outros. Você pode clicar em uma área para ver mais detalhes sobre a origem de seus dados.",
         "dataDownload-question": "Posso baixar seus dados?",
-        "dataDownload-answer": "Você pode adquirir acesso a todos os nossos dados em nosso <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">banco de dados </a>.",
+        "dataDownload-answer": "Você pode adquirir acesso a todos os nossos dados em nosso <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">banco de dados </a>.",
         "dataIntegration-question": "Posso integrar seus dados em tempo real ao meu aplicativo ou dispositivo?",
-        "dataIntegration-answer": "Sim! Nós vendemos acesso a nossa API <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\"> em tempo real</a>, que inclui previsões futuras."
+        "dataIntegration-answer": "Sim! Nós vendemos acesso a nossa API <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\"> em tempo real</a>, que inclui previsões futuras."
     },
     "aboutUs": {
         "groupName": "Sobre nós",

--- a/web/locales/ro.json
+++ b/web/locales/ro.json
@@ -105,8 +105,8 @@
         "newversion": "O nouă versiune e disponibilă! Apăsați <a onClick=\"location.reload(true);\">here</a> pentru a reîncărca.",
         "webgl-not-supported": "Harta nu poate fi afișată pentru că acest browser nu este compatibil cu WebGL.",
         "retrynow": "Reîncercați acum",
-        "database-ad": "Căutați date din trecut? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Verificați în baza noastră de date!</a>",
-        "api-ad": "Doriți date în timp real în aplicația sau dispozitivul dumneavoastră? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Încercați API-ul nostru!</a>",
+        "database-ad": "Căutați date din trecut? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Verificați în baza noastră de date!</a>",
+        "api-ad": "Doriți date în timp real în aplicația sau dispozitivul dumneavoastră? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Încercați API-ul nostru!</a>",
         "legend": "Legendă",
         "faq": "Întrebări frecvente"
     },
@@ -155,7 +155,7 @@
         "divideExistingArea-question": "Puteți diviza o zonă în părți mai mici?",
         "divideExistingArea-answer": "Desigur, dacă există surse de date pentru fiecare parte. Ne puteți ajuta cu <a href=\"#contribute\" class=\"entry-link\">noi surse de date</a>",
         "seeHistoricalData-question": "Pot să văd istoricul unei zone mai mult de 24 de ore în trecut?",
-        "seeHistoricalData-answer": "Puteți cumpăra access la întreaga <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">colecție de date</a>."
+        "seeHistoricalData-answer": "Puteți cumpăra access la întreaga <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">colecție de date</a>."
     },
     "methodology": {
         "groupName": "Metodele noastre",
@@ -183,9 +183,9 @@
         "dataOrigins-question": "De unde obțineți datele?",
         "dataOrigins-answer": "Folosim date făcute publice, publicate de operatori de rețele electrice, agenții oficiale și altele. Dați click pe o zonă pentru a afla mai multe detalii despre originea datelor.",
         "dataDownload-question": "Pot să downloadez datele?",
-        "dataDownload-answer": "Puteți cumpăra acces la toată <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">colecția noastră de date</a>.",
+        "dataDownload-answer": "Puteți cumpăra acces la toată <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">colecția noastră de date</a>.",
         "dataIntegration-question": "Pot integra datele voastre în timp real în aplicația / dispozitivul meu?",
-        "dataIntegration-answer": "Da! Vindem acces la <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">API-ul în timp real</a>, care include predicții pe viitor."
+        "dataIntegration-answer": "Da! Vindem acces la <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">API-ul în timp real</a>, care include predicții pe viitor."
     },
     "aboutUs": {
         "groupName": "Despre noi",

--- a/web/locales/ru.json
+++ b/web/locales/ru.json
@@ -83,8 +83,8 @@
         "oops": "Ой! У нас возникли проблемы с доступом к серверу. Подождите несколько секунд.",
         "newversion": "Доступна новая версия! Нажмите <a onClick=\"location.reload(true);\">здесь</a> чтобы обновить сайт.",
         "retrynow": "Повторить попытку",
-        "database-ad": "Ищите исторические данные? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Посетите нашу базу данных!</a>",
-        "api-ad": "Хотите получить данные в прямом эфире для приложения или электронного устройства? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Посетите наш API!</a>",
+        "database-ad": "Ищите исторические данные? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Посетите нашу базу данных!</a>",
+        "api-ad": "Хотите получить данные в прямом эфире для приложения или электронного устройства? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Посетите наш API!</a>",
         "legend": "Легенда",
         "faq": "Часто Задаваемые Вопросы"
     },
@@ -1418,7 +1418,7 @@
         "divideExistingArea-question": "Можете ли вы разделить мою зону на меньшие части?",
         "divideExistingArea-answer": "Конечно, если мы сможем получить данные разделенные для каждого участка этой зоны. Вы можете <a href=\"#contribute\" class=\"entry-link\">помочь добавив новые источники данных</a>",
         "seeHistoricalData-question": "Могу ли я просмотреть историю определенного региона дальше чем 24 часа?",
-        "seeHistoricalData-answer": "Вы можете купить доступ ко всей нашей <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">исторической базе</a>."
+        "seeHistoricalData-answer": "Вы можете купить доступ ко всей нашей <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">исторической базе</a>."
     },
     "methodology": {
         "groupName": "Наши методы",
@@ -1430,7 +1430,7 @@
         "dataOrigins-question": "Как вы получаете данные?",
         "dataDownload-question": "Могу ли я скачать эти данные?",
         "dataIntegration-question": "Могу ли я интегрировать ваши данные в реальном времени в свое приложение или устройство?",
-        "dataIntegration-answer": "Да! Вы можете купить доступ <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">к нашему API</a>, которое так же предоставляет ближайшие прогнозы."
+        "dataIntegration-answer": "Да! Вы можете купить доступ <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">к нашему API</a>, которое так же предоставляет ближайшие прогнозы."
     },
     "aboutUs": {
         "groupName": "О нас",

--- a/web/locales/sk.json
+++ b/web/locales/sk.json
@@ -92,8 +92,8 @@
         "oops": "Achjaj! Máme problém v komunikácii so serverom. Skúsime to opäť o pár sekúnd.",
         "newversion": "Nová verzia je dostupná! Klikni <a onClick=\"location.reload(true);\">tu</a> pre znovunačítanie.",
         "retrynow": "Zopakuj teraz",
-        "database-ad": "Hladáte historické dáta? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Skontrolujte našu databázu!</a>",
-        "api-ad": "Chcete mať živé dáta vo svojej aplikácii alebo na svojom zariadení? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Vyskúšajte naše API!</a>]",
+        "database-ad": "Hladáte historické dáta? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Skontrolujte našu databázu!</a>",
+        "api-ad": "Chcete mať živé dáta vo svojej aplikácii alebo na svojom zariadení? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Vyskúšajte naše API!</a>]",
         "legend": "Legenda",
         "faq": "Často kladené otázky"
     },
@@ -140,7 +140,7 @@
         "divideExistingArea-question": "Môžete rozdeliť moju oblasť na menšie?",
         "divideExistingArea-answer": "Určite, ak existujú separátne zdroje dát pre každú časť danej oblasti. Môžete <a href=\"#contribute\" class=\"entry-link\">nám pomôcť pridaním nových dátovych zdrojov</a>.",
         "seeHistoricalData-question": "Môžem zobraziť históriu oblasti staršiu ako 24 hodín?",
-        "seeHistoricalData-answer": "Môžete, ak si zakúpite prístup k všetkým historickým dátam prostredníctvom <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databázy</a>"
+        "seeHistoricalData-answer": "Môžete, ak si zakúpite prístup k všetkým historickým dátam prostredníctvom <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databázy</a>"
     },
     "methodology": {
         "groupName": "Naše metódy",
@@ -168,9 +168,9 @@
         "dataOrigins-question": "Ako získavate vaše dáta?",
         "dataOrigins-answer": "Všetky naše dáta spracúvame z verejne prístupných zdrojov publikovaných operátormi elektrických rozvodných sietí, oficiálnych agentúr atď. Kliknutím na konkrétnu oblasť sa zobrazia detailnejšie informácie o pôvode dát.",
         "dataDownload-question": "Môžem si stiahnuť vaše dáta?",
-        "dataDownload-answer": "Môžete si zakúpiť prístup k všetkým naším dátam v našej <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databáze</a>.",
+        "dataDownload-answer": "Môžete si zakúpiť prístup k všetkým naším dátam v našej <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databáze</a>.",
         "dataIntegration-question": "Môžem integrovať vaše dáta do mojej aplikácie alebo zariadenia?",
-        "dataIntegration-answer": "Áno! Predávame prístup do <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, ktoré zahrňuje budúce predpovede."
+        "dataIntegration-answer": "Áno! Predávame prístup do <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, ktoré zahrňuje budúce predpovede."
     },
     "aboutUs": {
         "groupName": "O nás",

--- a/web/locales/sv.json
+++ b/web/locales/sv.json
@@ -103,8 +103,8 @@
         "newversion": "En ny version är tillgänglig! Tryck <a onClick=\"location.reload(true);\">här</a> för att ladda om.",
         "webgl-not-supported": "Kartan kan inte renderas då denna webbläsare inte stöder WebGL.",
         "retrynow": "Försök igen",
-        "database-ad": "Letar du efter historisk data? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Kolla in vår databas!</a>",
-        "api-ad": "Vill ha uppdaterad data i din app eller på din enhet? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Prova vårt API!</a>",
+        "database-ad": "Letar du efter historisk data? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Kolla in vår databas!</a>",
+        "api-ad": "Vill ha uppdaterad data i din app eller på din enhet? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Prova vårt API!</a>",
         "legend": "Förklaring",
         "faq": "Vanliga frågor"
     },
@@ -151,7 +151,7 @@
         "divideExistingArea-question": "Kan ni dela in min region i mindre delar?",
         "divideExistingArea-answer": "Självklart, om det finns separata datakällor för varje del av regionen. Du kan <a href=\"#contribute\" class=\"entry-link\">hjälpa oss genom att lägga till datakällor</a>",
         "seeHistoricalData-question": "Kan jag se historik för en region längre tillbaka än 24 timmar?",
-        "seeHistoricalData-answer": "Du kan köpa åtkomst till all vår historiska data från vår <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databas</a>."
+        "seeHistoricalData-answer": "Du kan köpa åtkomst till all vår historiska data från vår <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databas</a>."
     },
     "methodology": {
         "groupName": "Våra metoder",
@@ -180,9 +180,9 @@
         "dataOrigins-question": "Hur får ni er data?",
         "dataOrigins-answer": "Vi beräknar all vi data från publik tillgänglig data publicerad av elnätsoperatörer, officiella myndigheter eller andra. Du kan klicka på en region för att se mer detaljer om ursprunget för dess data.",
         "dataDownload-question": "Kan jag ladda ned er data?",
-        "dataDownload-answer": "Du kan köpa åtkomst till all vår data i vår <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databas</a>.",
+        "dataDownload-answer": "Du kan köpa åtkomst till all vår data i vår <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">databas</a>.",
         "dataIntegration-question": "Kan jag integrera er live-data i min applikation eller utrustning?",
-        "dataIntegration-answer": "Ja! Vi säljer åtkomst till ett <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">realtids-API</a>, som inkluderar framtida prognoser."
+        "dataIntegration-answer": "Ja! Vi säljer åtkomst till ett <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">realtids-API</a>, som inkluderar framtida prognoser."
     },
     "aboutUs": {
         "groupName": "Om oss",

--- a/web/locales/vi.json
+++ b/web/locales/vi.json
@@ -96,8 +96,8 @@
         "oops": "Oops! We are having trouble reaching the server. We will try again in a few seconds.",
         "newversion": "A new version is available! Press <a onClick=\"location.reload(true);\">here</a> to reload.",
         "retrynow": "Retry now",
-        "database-ad": "Looking for historical data? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Check out our Database!</a>",
-        "api-ad": "Want live data in your app or on your device? <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Try our API!</a>",
+        "database-ad": "Looking for historical data? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Check out our Database!</a>",
+        "api-ad": "Want live data in your app or on your device? <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">Try our API!</a>",
         "legend": "Legend",
         "faq": "Frequently Asked Questions"
     },
@@ -144,7 +144,7 @@
         "divideExistingArea-question": "Can you divide my area into smaller parts?",
         "divideExistingArea-answer": "Sure, if there exists separate data sources for each part of the area. You can <a href=\"#contribute\" class=\"entry-link\">help us with adding new data sources</a>",
         "seeHistoricalData-question": "Can I see the history for an area further back in time than 24 hours?",
-        "seeHistoricalData-answer": "You can purchase access to all of our historical data through our <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
+        "seeHistoricalData-answer": "You can purchase access to all of our historical data through our <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>."
     },
     "methodology": {
         "groupName": "Phương pháp của chúng tôi",
@@ -172,9 +172,9 @@
         "dataOrigins-question": "How do you get your data?",
         "dataOrigins-answer": "We compute all of our data from publically available data, published by electricity grid operators, official agencies, and others. You can click on an area to see more specifics on the origins of its data.",
         "dataDownload-question": "Can I download your data?",
-        "dataDownload-answer": "You can purchase access to all of our data in our <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
+        "dataDownload-answer": "You can purchase access to all of our data in our <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">database</a>.",
         "dataIntegration-question": "Can I integrate your data real-time into my application or device?",
-        "dataIntegration-answer": "Yes! We sell access to a <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, which includes future forecasts."
+        "dataIntegration-answer": "Yes! We sell access to a <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">real-time API</a>, which includes future forecasts."
     },
     "aboutUs": {
         "groupName": "About us",

--- a/web/locales/zh-cn.json
+++ b/web/locales/zh-cn.json
@@ -72,8 +72,8 @@
         "oops": "哎呀！ 我们无法连线到服务器。 我们会在几秒钟后再试一次。",
         "newversion": "有新版本可用！按<a onClick=\"location.reload(true);\">这里</a>重新载入。",
         "webgl-not-supported": "由于该浏览器不支持WebGL，无法渲染地图。",
-        "database-ad": "寻找历史数据？<a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">看看我们的数据库！</a>",
-        "api-ad": "想要在您的应用程序或设备上获得实时数据？ <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">试试我们的API!</a>",
+        "database-ad": "寻找历史数据？<a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">看看我们的数据库！</a>",
+        "api-ad": "想要在您的应用程序或设备上获得实时数据？ <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">试试我们的API!</a>",
         "legend": "图例",
         "faq": "常见问题"
     },
@@ -119,7 +119,7 @@
         "divideExistingArea-question": "可以将我所在的地区划分为更小的部分吗",
         "divideExistingArea-answer": "当然可以，如果该区域的每个部分区域都存在单独的数据源。 您可以 <a href=\"#contribute\" class=\"entry-link\">帮我们添加新的数据源</a>",
         "seeHistoricalData-question": "我可以查看某个地区比24小时更早的历史记录吗？",
-        "seeHistoricalData-answer": "您可以通过我们的网站上的 <a href=\"https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">数据库</a>购买对我们所有历史数据的访问权限。"
+        "seeHistoricalData-answer": "您可以通过我们的网站上的 <a href=\"https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral\" target=\"_blank\">数据库</a>购买对我们所有历史数据的访问权限。"
     },
     "zoneShortName": {
         "AL": {

--- a/web/src/layout/header.js
+++ b/web/src/layout/header.js
@@ -12,15 +12,15 @@ const headerLinks = [
   },
   {
     label: 'Open Source',
-    href: 'https://api.electricitymap.org/open-source?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org/open-source?utm_source=app.electricitymap.org&utm_medium=referral',
   },
   {
     label: 'Blog',
-    href: 'https://api.electricitymap.org/blog?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org/blog?utm_source=app.electricitymap.org&utm_medium=referral',
   },
   {
     label: 'Get our data',
-    href: 'https://api.electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral',
+    href: 'https://electricitymap.org?utm_source=app.electricitymap.org&utm_medium=referral',
   },
 ];
 

--- a/web/src/layout/leftpanel/countrypanel.js
+++ b/web/src/layout/leftpanel/countrypanel.js
@@ -302,7 +302,7 @@ const CountryPanel = ({
               </CountryHistoryTitle>
               <br />
               <IconContainer>
-                <i className="material-icons" aria-hidden="true">file_download</i> <a href="https://api.electricitymap.org/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel" target="_blank">{__('country-history.Getdata')}</a>
+                <i className="material-icons" aria-hidden="true">file_download</i> <a href="https://electricitymap.org/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel" target="_blank">{__('country-history.Getdata')}</a>
                 <span className="pro"><i className="material-icons" aria-hidden="true">lock</i> pro</span>
               </IconContainer>
               {/* TODO: Make the loader part of AreaGraph component with inferred height */}
@@ -318,7 +318,7 @@ const CountryPanel = ({
               </CountryHistoryTitle>
               <br />
               <IconContainer>
-                <i className="material-icons" aria-hidden="true">file_download</i> <a href="https://api.electricitymap.org/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel" target="_blank">{__('country-history.Getdata')}</a>
+                <i className="material-icons" aria-hidden="true">file_download</i> <a href="https://electricitymap.org/?utm_source=app.electricitymap.org&utm_medium=referral&utm_campaign=country_panel" target="_blank">{__('country-history.Getdata')}</a>
                 <span className="pro"><i className="material-icons" aria-hidden="true">lock</i> pro</span>
               </IconContainer>
               {/* TODO: Make the loader part of AreaGraph component with inferred height */}


### PR DESCRIPTION
**Tomorrow is going all-in on electricityMap!**

That also means making our commercial side and the API behind the map more prominent. We're doing this to get more companies, organisations and researchers around the world to use our data to power the transition towards a truly decarbonised electricity system ⚡

Therefore https://electricitymap.org now shows our commercial website, with clear links to https://app.electricitymap.org where the map now lives.

This PR  change all links on the map from `api.electricitymap.org` to `electricitymap.org`.