### PR TITLE
Updated czech word for oil from 'olej' (which means oil for cooking) …

### DIFF
--- a/web/locales/cs.json
+++ b/web/locales/cs.json
@@ -111,7 +111,7 @@
     "geothermal": "geotermální",
     "gas": "plyn",
     "coal": "uhlí",
-    "oil": "olej",
+    "oil": "ropa",
     "unknown": "neznámé",
     "electricityComesFrom": "<b>%1$s %%</b> elektřiny dostupné v <img id=\"country-flag\"></img> <b>%2$s</b> pochází z %3$s",
     "emissionsComeFrom": "<b>%1$s %%</b> emisí z elektřiny dostupné v <img id=\"country-flag\"></img> <b>%2$s</b> pochází z %3$s",


### PR DESCRIPTION
…to 'ropa' (which means oil, as in crude oil/petroleum)